### PR TITLE
New Feature: ultra scan modules for v2b electronics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,22 @@
+# Ignore everything
 *
-!setup.sh
-!Makefile
-!apps.common.mk
-!README.md
-!./src/*.cpp
-!./include/*.h
-!./doc
-!./lib
+
+# Don't ignore git settings
 !.gitignore
 !.github
-!./conf/conf.txt
+
+# Don't Ignore special files
+!apps.common.mk
+!README.md
+!Makefile
+!setup.sh
+
+# Don't ignore subdirectories
+!*/
+
+# Don't ignore source files
+!*.cpp
+!*.h
+
+# Don't ignore configuration
+!/conf/conf.txt

--- a/include/optohybrid.h
+++ b/include/optohybrid.h
@@ -503,19 +503,24 @@ void stopCalPulse2AllChannelsLocal(localArgs *la, uint32_t ohN, uint32_t mask, u
     if (fw_maj == 1){
         uint32_t trimVal=0;
         for(int vfat=0; vfat<24; ++vfat){
+            if ((mask >> vfatN) & 0x1) continue; //skip masked VFATs
             for(uint32_t chan=ch_min; chan<ch_max; ++chan){
                 trimVal = (0x3f & readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%d.GEB.VFATS.VFAT%d.VFATChannels.ChanReg%d",ohN,vfat,chan)));
                 writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%d.GEB.VFATS.VFAT%d.VFATChannels.ChanReg%d",ohN,vfat,chan),trimVal, la->response);
                 if(chan>127){
                     LOGGER->log_message(LogManager::ERROR, stdsprintf("OH %d: Chan %d greater than possible chan_max %d",ohN,chan,ch_max));
-                    //break; //Why is this necessary?
                 }
             }
         }
     }
     else if (fw_maj == 3){
-        //Placeholder
-        LOGGER->log_message(LogManager::INFO, stdsprintf("stopCalPulse2AllChannelsLocal(): No functionality for v3 electronics yet"));
+        for(int vfatN = 0; vfatN < 24; vfatN++){
+            if ((mask >> vfatN) & 0x1) continue; //skip masked VFATs
+            for(uint32_t chan=ch_min; chan<ch_max; ++chan){
+                sprintf(regBuf,"GEM_AMC.OH.OH%d.GEB.VFAT%d.VFAT_CHANNELS.CHANNEL%d.CALPULSE_ENABLE", ohN, vfatN, ch);
+                writeReg(la->rtxn, la->dbi, regBuf, 0x0, la->response);
+            }
+        }
     }
     else {
         LOGGER->log_message(LogManager::ERROR, stdsprintf("Unexpected value for system release major: %i",fw_maj));

--- a/include/optohybrid.h
+++ b/include/optohybrid.h
@@ -465,10 +465,12 @@ void getUltraScanResultsLocal(localArgs *la, uint32_t *outData, uint32_t ohN, ui
     LOGGER->log_message(LogManager::DEBUG, stdsprintf("\tUltra scan status (0x%08x)\n",readReg(la->rtxn, la->dbi, scanBase + ".MONITOR")));
     LOGGER->log_message(LogManager::DEBUG, stdsprintf("\tUltra scan results available (0x%06x)",readReg(la->rtxn, la->dbi, scanBase + ".MONITOR.READY")));
 
-    /*for(int vfatN = 0; vfatN < 24; ++vfatN){
-        int idx = vfatN*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
-        outData[idx] = readRawAddress(daqMonAddr[vfatN], la->response);
-    }*/
+    for(uint32_t dacVal = dacMin; dacVal <= dacMax; dacVal += dacStep){
+        for(int vfatN = 0; vfatN < 24; ++vfatN){
+            int idx = vfatN*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
+            outData[idx] = readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.ScanController.ULTRA.RESULTS.VFAT%i",ohN,vfatN));
+        }
+    }
 
     return;
 } //End getUltraScanResultsLocal(...)

--- a/include/optohybrid.h
+++ b/include/optohybrid.h
@@ -4,7 +4,7 @@
 
 void broadcastWriteLocal(lmdb::txn & rtxn, lmdb::dbi & dbi, std::string oh_number, std::string reg_to_write, uint32_t val_to_write, RPCMsg * response, uint32_t mask = 0xFF000000) {
   uint32_t fw_maj = readReg(rtxn, dbi, "GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR");
-  if (fw_maj == 2) {
+  if (fw_maj == 1) {
     std::string reg_basename = "GEM_AMC.OH.OH";
     reg_basename += oh_number;
     reg_basename += ".GEB.Broadcast";
@@ -60,7 +60,7 @@ void broadcastReadLocal(lmdb::txn & rtxn, lmdb::dbi & dbi, std::string oh_number
   uint32_t fw_maj = readReg(rtxn, dbi, "GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR");
   std::string reg_basename = "GEM_AMC.OH.OH";
   reg_basename += oh_number;
-  if (fw_maj == 2) {
+  if (fw_maj == 1) {
     reg_basename += ".GEB.VFATS.VFAT";
   } else if (fw_maj == 3) {
     reg_basename += ".GEB.VFAT";

--- a/include/optohybrid.h
+++ b/include/optohybrid.h
@@ -469,6 +469,7 @@ void getUltraScanResultsLocal(localArgs *la, uint32_t *outData, uint32_t ohN, ui
         for(int vfatN = 0; vfatN < 24; ++vfatN){
             int idx = vfatN*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
             outData[idx] = readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.ScanController.ULTRA.RESULTS.VFAT%i",ohN,vfatN));
+            LOGGER->log_message(LogManager::DEBUG, stdsprintf("\tUltra scan results: outData[%i] = (%i, %i)",idx,(outData[idx]&0xff000000)>>24,(outData[idx]&0xffffff)));
         }
     }
 
@@ -502,11 +503,11 @@ void stopCalPulse2AllChannelsLocal(localArgs *la, uint32_t ohN, uint32_t mask, u
 
     if (fw_maj == 1){
         uint32_t trimVal=0;
-        for(int vfat=0; vfat<24; ++vfat){
+        for(int vfatN=0; vfatN<24; ++vfatN){
             if ((mask >> vfatN) & 0x1) continue; //skip masked VFATs
             for(uint32_t chan=ch_min; chan<ch_max; ++chan){
-                trimVal = (0x3f & readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%d.GEB.VFATS.VFAT%d.VFATChannels.ChanReg%d",ohN,vfat,chan)));
-                writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%d.GEB.VFATS.VFAT%d.VFATChannels.ChanReg%d",ohN,vfat,chan),trimVal, la->response);
+                trimVal = (0x3f & readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%d.GEB.VFATS.VFAT%d.VFATChannels.ChanReg%d",ohN,vfatN,chan)));
+                writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%d.GEB.VFATS.VFAT%d.VFATChannels.ChanReg%d",ohN,vfatN,chan),trimVal, la->response);
                 if(chan>127){
                     LOGGER->log_message(LogManager::ERROR, stdsprintf("OH %d: Chan %d greater than possible chan_max %d",ohN,chan,ch_max));
                 }
@@ -517,8 +518,7 @@ void stopCalPulse2AllChannelsLocal(localArgs *la, uint32_t ohN, uint32_t mask, u
         for(int vfatN = 0; vfatN < 24; vfatN++){
             if ((mask >> vfatN) & 0x1) continue; //skip masked VFATs
             for(uint32_t chan=ch_min; chan<ch_max; ++chan){
-                sprintf(regBuf,"GEM_AMC.OH.OH%d.GEB.VFAT%d.VFAT_CHANNELS.CHANNEL%d.CALPULSE_ENABLE", ohN, vfatN, ch);
-                writeReg(la->rtxn, la->dbi, regBuf, 0x0, la->response);
+                writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%d.GEB.VFAT%d.VFAT_CHANNELS.CHANNEL%d.CALPULSE_ENABLE", ohN, vfatN, chan), 0x0, la->response);
             }
         }
     }

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -45,7 +45,6 @@ void ttcGenConf(const RPCMsg *request, RPCMsg *response)
     ttcGenConfLocal(&la, L1Ainterval, pulseDelay);
 
     return;
-
 }
 
 void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask, uint32_t ch, uint32_t enCal, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg, bool useUltra){
@@ -121,7 +120,6 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                 int idx = vfatN*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
                 outData[idx] = readRawAddress(daqMonAddr[vfatN], la->response);
             }
-
         }
 
         for(int vfatN = 0; vfatN < 24; vfatN++) if((notmask >> vfatN) & 0x1)
@@ -182,8 +180,10 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
         startScanModuleLocal(la, ohN, useUltra);
 
         //Get scan results
-
+        getUltraScanResultsLocal(la, outData, ohN, nevts, dacMin, dacMax, dacStep);
     } //End v2b electronics behavior
+
+    return;
 } //End genScanLocal(...)
 
 void genScan(const RPCMsg *request, RPCMsg *response)

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -12,9 +12,9 @@ void dacMonConfLocal(localArgs * la, uint32_t ohN, uint32_t ch){
         writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.ENABLE", 0x0, la->response);
         writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.RESET", 0x1, la->response);
         writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.OH_SELECT", ohN, la->response);
-        if(ch==128)
+        if(ch>127)
         {
-            writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.VFAT_CHANNEL_SELECT", 0, la->response);
+            //writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.VFAT_CHANNEL_SELECT", 0, la->response);
             writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.VFAT_CHANNEL_GLOBAL_OR", 0x1, la->response);
         }
         else
@@ -296,6 +296,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
             {
                 //writeRawAddress(scanDacAddr[vfatN], dacVal, la->response);
                 writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str()), dacVal, la->response);
+                //std::this_thread::sleep_for(std::chrono::microseconds(50)); //Seen some evidence that
             }
 
             //Reset and enable the VFAT_DAQ_MONITOR

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -300,7 +300,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                             currentEvtNum = readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.VFAT%i.GOOD_EVENTS_COUNT",vfatN));
                             running = (currentEvtNum <= nevts);
                             if( currentEvtNum % 100 ){
-                                LOGGER->log_message(LogManager::INFO, stdsprintf("OH%d: dacVal: %d; Trigger Recieved, L1A Num: %d",ohN, dacVal, readReg(la->rtxn, la->dbi, "GEM_AMC.TTC.CMD_COUNTERS.L1A")));
+                                LOGGER->log_message(LogManager::DEBUG, stdsprintf("OH%d: dacVal: %d; Trigger Recieved, L1A Num: %d",ohN, dacVal, readReg(la->rtxn, la->dbi, "GEM_AMC.TTC.CMD_COUNTERS.L1A")));
                             }
                         }
                         break;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -308,20 +308,21 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                 }
             } //End TTC Commands from Backplane
 
-            for(int vfatN = 0; vfatN < 24; vfatN++)
-            {
+            for(int vfatN = 0; vfatN < 24; vfatN++){
                 int idx = vfatN*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
                 outData[idx] = readRawAddress(daqMonAddr[vfatN], la->response);
 
-                LOGGER->log_message(LogManager::CRITICAL, stdsprintf("%s Value: %i; Readback Val: %i; Nhits: %i; Nev: %i; CFG_THR_ARM: %i",
-                             scanReg.c_str(),
-                             dacVal,
-                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str())),
-                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.VFAT%i.CHANNEL_FIRE_COUNT",vfatN)),
-                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.VFAT%i.GOOD_EVENTS_COUNT",vfatN)),
-                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_THR_ARM_DAC",ohN,vfatN,scanReg.c_str()))
-                    )
-                );
+                if((notmask >> vfatN) & 0x1){
+                    LOGGER->log_message(LogManager::CRITICAL, stdsprintf("%s Value: %i; Readback Val: %i; Nhits: %i; Nev: %i; CFG_THR_ARM: %i",
+                                 scanReg.c_str(),
+                                 dacVal,
+                                 readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str())),
+                                 readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.VFAT%i.CHANNEL_FIRE_COUNT",vfatN)),
+                                 readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.VFAT%i.GOOD_EVENTS_COUNT",vfatN)),
+                                 readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_THR_ARM_DAC",ohN,vfatN,scanReg.c_str()))
+                        )
+                    );
+                }
             }
 
         } //End Loop from dacMin to dacMax

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -25,7 +25,7 @@ void ttcGenToggleLocal(localArgs * la, uint32_t ohN, bool bRun){
     //Get firmware version
     int iFWVersion = readReg(la->rtxn, la->dbi, "GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR");
 
-    if (iFWVersion > 2){ //v3 electronics behavior
+    if (iFWVersion == 3){ //v3 electronics behavior
         if (bRun){
             writeReg(la->rtxn, la->dbi, "GEM_AMC.TTC.GENERATOR.ENABLE", 0x1, la->response);
         }
@@ -33,7 +33,7 @@ void ttcGenToggleLocal(localArgs * la, uint32_t ohN, bool bRun){
             writeReg(la->rtxn, la->dbi, "GEM_AMC.TTC.GENERATOR.ENABLE", 0x0, la->response);
         }
     } //End v3 electronics behavior
-    else { //v2b electronics behavior
+    else if (iFWVersion == 1) { //v2b electronics behavior
         //base reg
         std::stringstream sstream;
         sstream<<ohN;
@@ -50,6 +50,9 @@ void ttcGenToggleLocal(localArgs * la, uint32_t ohN, bool bRun){
             }
         }
     } //End v2b electronics behavior
+    else {
+        LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major!");
+    }
 
     return;
 } //End ttcGenToggleLocal(...)
@@ -74,13 +77,13 @@ void ttcGenConfLocal(localArgs * la, uint32_t ohN, uint32_t mode, uint32_t type,
     //Get firmware version
     int iFWVersion = readReg(la->rtxn, la->dbi, "GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR");
 
-    if (iFWVersion > 2){ //v3 electronics behavior
+    if (iFWVersion == 3){ //v3 electronics behavior
         writeReg(la->rtxn, la->dbi, "GEM_AMC.TTC.GENERATOR.RESET", 0x1, la->response);
         //ttcGenToggleLocal(la, ohN, bRun);
         writeReg(la->rtxn, la->dbi, "GEM_AMC.TTC.GENERATOR.CYCLIC_L1A_GAP", L1Ainterval, la->response);
         writeReg(la->rtxn, la->dbi, "GEM_AMC.TTC.GENERATOR.CYCLIC_CALPULSE_TO_L1A_GAP", pulseDelay, la->response);
     } //End v3 electronics behavior
-    else { //v2b electronics behavior
+    else if (iFWVersion == 1){ //v2b electronics behavior
         /*
          * Configure the T1 controller
          * mode: 0 (Single T1 signal),
@@ -146,6 +149,9 @@ void ttcGenConfLocal(localArgs * la, uint32_t ohN, uint32_t mode, uint32_t type,
 
         //ttcGenToggleLocal(la, ohN, bRun);
     } //End v2b electronics behavior
+    else {
+        LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major!");
+    }
 
     //start or stop
     ttcGenToggleLocal(la, ohN, bRun);
@@ -182,7 +188,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
     //Get firmware version
     int iFWVersion = readReg(la->rtxn, la->dbi, "GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR");
 
-    if (iFWVersion > 2){ //v3 electronics behavior
+    if (iFWVersion == 3){ //v3 electronics behavior
         writeReg(la->rtxn, la->dbi, "GEM_AMC.TTC.GENERATOR.CYCLIC_L1A_COUNT", nevts, la->response);
         writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_SYSTEM.VFAT3.VFAT3_RUN_MODE", 0x1, la->response);
         writeReg(la->rtxn, la->dbi, "GEM_AMC.TTC.GENERATOR.SINGLE_RESYNC", 0x1, la->response);
@@ -255,7 +261,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
             if(ch < 128) writeReg(la->rtxn, la->dbi, regBuf, 0x1, la->response);
         }
     } //End v3 electronics behavior
-    else { //v2b electronics behavior
+    else if (iFWVersion == 1){ //v2b electronics behavior
         //Determine scanmode
         std::map<int, std::string> map_strKnownRegs; //Key -> scanmode; val -> register
 
@@ -307,6 +313,9 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
         //Get scan results
         getUltraScanResultsLocal(la, outData, ohN, nevts, dacMin, dacMax, dacStep);
     } //End v2b electronics behavior
+    else {
+        LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major!");
+    }
 
     return;
 } //End genScanLocal(...)

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -283,7 +283,8 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
         {
             for(int vfatN = 0; vfatN < 24; vfatN++) if((notmask >> vfatN) & 0x1)
             {
-                writeRawAddress(scanDacAddr[vfatN], dacVal, la->response);
+                //writeRawAddress(scanDacAddr[vfatN], dacVal, la->response);
+                writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str()), dacVal, la->response);
             }
             writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.RESET", 0x1, la->response);
             writeReg(la->rtxn, la->dbi, "GEM_AMC.TTC.GENERATOR.CYCLIC_START", 0x1, la->response);
@@ -311,7 +312,18 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
             {
                 int idx = vfatN*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
                 outData[idx] = readRawAddress(daqMonAddr[vfatN], la->response);
+
+                LOGGER->log_message(LogManager::CRITICAL, stdsprintf("%s Value: %i; Readback Val: %i; Nhits: %i; Nev: %i; CFG_THR_ARM: %i",
+                             scanReg.c_str(),
+                             dacVal,
+                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str())),
+                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.VFAT%i.CHANNEL_FIRE_COUNT",vfatN)),
+                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.VFAT%i.GOOD_EVENTS_COUNT",vfatN)),
+                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_THR_ARM_DAC",ohN,vfatN,scanReg.c_str()))
+                    )
+                );
             }
+
         } //End Loop from dacMin to dacMax
 
         //If the calpulse for channel ch was turned on, turn it off

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -313,7 +313,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                 outData[idx] = readRawAddress(daqMonAddr[vfatN], la->response);
 
                 if((notmask >> vfatN) & 0x1){
-                    LOGGER->log_message(LogManager::CRITICAL, stdsprintf("%s Value: %i; Readback Val: %i; Nhits: %i; Nev: %i; CFG_THR_ARM: %i",
+                    LOGGER->log_message(LogManager::DEBUG, stdsprintf("%s Value: %i; Readback Val: %i; Nhits: %i; Nev: %i; CFG_THR_ARM: %i",
                                  scanReg.c_str(),
                                  dacVal,
                                  readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str())),

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -254,6 +254,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                     if((notmask >> vfatN) & 0x1){
                         sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.CALPULSE_ENABLE", ohN, vfatN, ch);
                         writeReg(la->rtxn, la->dbi, regBuf, 0x1, la->response);
+                        writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_CAL_MODE", ohN, vfatN), 0x1, la->response);
                     }
                 }
             }
@@ -348,7 +349,10 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
             for(int vfatN = 0; vfatN < 24; vfatN++) if((notmask >> vfatN) & 0x1)
             {
                 sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.CALPULSE_ENABLE", ohN, vfatN, ch);
-                if(ch < 128) writeReg(la->rtxn, la->dbi, regBuf, 0x0, la->response);
+                if(ch < 128){
+                    writeReg(la->rtxn, la->dbi, regBuf, 0x0, la->response);
+                    writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_CAL_MODE", ohN, vfatN), 0x0, la->response);
+                }
             }
         }
     } //End v3 electronics behavior

--- a/src/optohybrid.cpp
+++ b/src/optohybrid.cpp
@@ -9,10 +9,14 @@ extern "C" {
 			LOGGER->log_message(LogManager::ERROR, "Unable to load module");
 			return; // Do not register our functions, we depend on memsvc.
 		}
-		modmgr->register_method("optohybrid", "broadcastWrite", broadcastWrite);
 		modmgr->register_method("optohybrid", "broadcastRead", broadcastRead);
-		modmgr->register_method("optohybrid", "loadVT1", loadVT1);
-		modmgr->register_method("optohybrid", "loadTRIMDAC", loadTRIMDAC);
+		modmgr->register_method("optohybrid", "broadcastWrite", broadcastWrite);
+		modmgr->register_method("optohybrid", "configureScanModule", configureScanModule);
 		modmgr->register_method("optohybrid", "configureVFATs", configureVFATs);
+		modmgr->register_method("optohybrid", "getUltraScanResults", getUltraScanResults);
+        modmgr->register_method("optohybrid", "loadTRIMDAC", loadTRIMDAC);
+		modmgr->register_method("optohybrid", "loadVT1", loadVT1);
+		modmgr->register_method("optohybrid", "printScanConfiguration", printScanConfiguration);
+		modmgr->register_method("optohybrid", "startScanModule", startScanModule);
 	}
 }

--- a/src/optohybrid.cpp
+++ b/src/optohybrid.cpp
@@ -1,22 +1,23 @@
 #include "optohybrid.h"
 
 extern "C" {
-	const char *module_version_key = "optohybrid v1.0.1";
-	int module_activity_color = 4;
-	void module_init(ModuleManager *modmgr) {
-		if (memsvc_open(&memsvc) != 0) {
-			LOGGER->log_message(LogManager::ERROR, stdsprintf("Unable to connect to memory service: %s", memsvc_get_last_error(memsvc)));
-			LOGGER->log_message(LogManager::ERROR, "Unable to load module");
-			return; // Do not register our functions, we depend on memsvc.
-		}
-		modmgr->register_method("optohybrid", "broadcastRead", broadcastRead);
-		modmgr->register_method("optohybrid", "broadcastWrite", broadcastWrite);
-		modmgr->register_method("optohybrid", "configureScanModule", configureScanModule);
-		modmgr->register_method("optohybrid", "configureVFATs", configureVFATs);
-		modmgr->register_method("optohybrid", "getUltraScanResults", getUltraScanResults);
+    const char *module_version_key = "optohybrid v1.0.1";
+    int module_activity_color = 4;
+    void module_init(ModuleManager *modmgr) {
+        if (memsvc_open(&memsvc) != 0) {
+            LOGGER->log_message(LogManager::ERROR, stdsprintf("Unable to connect to memory service: %s", memsvc_get_last_error(memsvc)));
+            LOGGER->log_message(LogManager::ERROR, "Unable to load module");
+            return; // Do not register our functions, we depend on memsvc.
+        }
+        modmgr->register_method("optohybrid", "broadcastRead", broadcastRead);
+        modmgr->register_method("optohybrid", "broadcastWrite", broadcastWrite);
+        modmgr->register_method("optohybrid", "configureScanModule", configureScanModule);
+        modmgr->register_method("optohybrid", "configureVFATs", configureVFATs);
+        modmgr->register_method("optohybrid", "getUltraScanResults", getUltraScanResults);
         modmgr->register_method("optohybrid", "loadTRIMDAC", loadTRIMDAC);
-		modmgr->register_method("optohybrid", "loadVT1", loadVT1);
-		modmgr->register_method("optohybrid", "printScanConfiguration", printScanConfiguration);
-		modmgr->register_method("optohybrid", "startScanModule", startScanModule);
-	}
+        modmgr->register_method("optohybrid", "loadVT1", loadVT1);
+        modmgr->register_method("optohybrid", "printScanConfiguration", printScanConfiguration);
+        modmgr->register_method("optohybrid", "startScanModule", startScanModule);
+        modmgr->register_method("optohybrid", "stopCalPulse2AllChannels", stopCalPulse2AllChannels);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have expanded the scan tools for v3 electronics to also work with v2b electronics.  The modules identify at runtime what behavior should be executed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
If we are moving toward RPC/XHAL framework for CTP7 we should have the tools for both v2b and v3 electronics rather than having to move back and forth between libraries.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A complete working example is shown here:
http://cmsonline.cern.ch/cms-elog/1020178

For the v2b electronics I took a per channel threshold scan using the ipbus/uhal framework and then compared the results obtained when taking data with the rpc/xhal tools shown here.  As can be seen the behavior is identical.

Additionally as shown the tools also work on v3 electronics.

### Screenshots (if appropriate):
See attached plots in above elog

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->