### PR TITLE
New Feature: SBIT Rate Scan vs. Arbitrary Scan Register

### DIFF
--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -556,7 +556,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
         writeRawAddress(scanDacAddr, dacVal, la->response);
         std::this_thread::sleep_for(std::chrono::milliseconds(1050));
 
-        int idx = (dacMax-dacMin+1)/dacStep;
+        int idx = (dacVal-dacMin)/dacStep;
         outDataDacVal[idx] = dacVal;
         outDataTrigRate[idx] = readRawAddress(ohTrigRateAddr, la->response);
     } //End Loop from dacMin to dacMax

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -559,8 +559,8 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     } //End Case: Measuring Rate for 1 channel
 
     //Get the scanAddress
-    sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str());
-    uint32_t scanDacAddr = getAddress(la->rtxn, la->dbi, regBuf, la->response);
+    //sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str());
+    //uint32_t scanDacAddr = getAddress(la->rtxn, la->dbi, regBuf, la->response);
 
     //Get the OH Rate Monitor Address
     sprintf(regBuf,"GEM_AMC.TRIGGER.OH%i.TRIGGER_RATE",ohN);
@@ -582,7 +582,9 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
 
     //Loop from dacMin to dacMax in steps of dacStep
     for(uint32_t dacVal = dacMin; dacVal <= dacMax; dacVal += dacStep){
-        writeRawAddress(scanDacAddr, dacVal, la->response);
+        //writeRawAddress(scanDacAddr, dacVal, la->response);
+        sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str());
+        writeReg(la->rtxn, la->dbi, regBuf, dacVal, la->response);
         std::this_thread::sleep_for(std::chrono::milliseconds(waitTime));
 
         int idx = (dacVal-dacMin)/dacStep;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -613,7 +613,6 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response){
 
     uint32_t ohN = request->get_word("ohN");
     uint32_t maskOh = request->get_word("maskOh");
-    uint32_t vfatN = request->get_word("vfatN");
     uint32_t ch = request->get_word("ch");
     uint32_t dacMin = request->get_word("dacMin");
     uint32_t dacMax = request->get_word("dacMax");
@@ -624,7 +623,7 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response){
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     uint32_t outDataDacVal[(dacMax-dacMin+1)/dacStep];
     uint32_t outDataTrigRate[(dacMax-dacMin+1)/dacStep];
-    sbitRateScanLocal(&la, outDataDacVal, outDataTrigRate, ohN, maskOh, vfatN, ch, dacMin, dacMax, dacStep, scanReg, waitTime);
+    sbitRateScanLocal(&la, outDataDacVal, outDataTrigRate, ohN, maskOh, ch, dacMin, dacMax, dacStep, scanReg, waitTime);
 
     response->set_word_array("data_dacVal", outDataDacVal, (dacMax-dacMin+1)/dacStep);
     response->set_word_array("data_trigRate", outDataTrigRate, (dacMax-dacMin+1)/dacStep);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -522,7 +522,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
 
     //Determine vfatN based on input maskOh
     auto vfatNptr = map_maskOh2vfatN.find(maskOh);
-    if( vfatNptr != map_maskOh2vfatN.end() ){
+    if( vfatNptr == map_maskOh2vfatN.end() ){
         sprintf(regBuf,"Input maskOh: %x not recgonized. Please make sure all but one VFAT is unmasked and then try again", maskOh);
         la->response->set_string("error",regBuf);
         return;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -311,7 +311,8 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                 uint32_t l1aCnt = 0;
                 while(l1aCnt < nevts){
                     l1aCnt = readRawAddress(l1CntAddr, la->response);
-                    std::this_thread::sleep_for(std::chrono::microseconds(50));
+                    //std::this_thread::sleep_for(std::chrono::microseconds(50));
+                    std::this_thread::sleep_for(std::chrono::microseconds(200));
                 }
 
                 writeReg(la->rtxn, la->dbi, "GEM_AMC.TTC.CTRL.L1A_ENABLE", 0x0, la->response);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -481,7 +481,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     //Will scan from dacMin to dacMax in steps of dacStep
     //The x-values (e.g. scanReg values) will be stored in outDataDacVal
     //The y-valued (e.g. rate) will be stored in outDataTrigRate
-    //Each measured point will take 3 seconds
+    //Each measured point will take 1.05 seconds
     //The measurement is performed for all channels (ch=128) or a specific channel (0 <= ch <= 127)
 
     char regBuf[200];
@@ -494,7 +494,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
 
     uint32_t goodVFATs = vfatSyncCheckLocal(la, ohN);
     uint32_t notmask = ~maskOh & 0xFFFFFF;
-    if(!((notmask >> maskOh) & 0x1)){
+    if( (notmask & goodVFATs) != notmask){
         sprintf(regBuf,"The requested VFAT is not synced; goodVFATs: %x\t requested VFAT: %x", goodVFATs, maskOh);
         la->response->set_string("error",regBuf);
         return;
@@ -554,7 +554,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     //Loop from dacMin to dacMax in steps of dacStep
     for(uint32_t dacVal = dacMin; dacVal <= dacMax; dacVal += dacStep){
         writeRawAddress(scanDacAddr, dacVal, la->response);
-        std::this_thread::sleep_for(std::chrono::seconds(3));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1050));
 
         int idx = (dacMax-dacMin+1)/dacStep;
         outDataDacVal[idx] = dacVal;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -494,7 +494,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     }
 
     //Hard code possible maskOh values and how they map to vfatN
-    std::map<uint32_t,uint32_t> map_maskOh2vfatN;
+    std::unordered_map<uint32_t,uint32_t> map_maskOh2vfatN;
     map_maskOh2vfatN[0xfffffe] = 0;
     map_maskOh2vfatN[0xfffffd] = 1;
     map_maskOh2vfatN[0xfffffb] = 2;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -529,8 +529,8 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     }
 
     uint32_t goodVFATs = vfatSyncCheckLocal(la, ohN);
-    if( !( (goodVFATs >> (*vfatNptr) ) & 0x1 ) ){
-        sprintf(regBuf,"The requested VFAT is not synced; goodVFATs: %x\t requested VFAT: %i; maskOh: %x", goodVFATs, (*vfatNptr), maskOh);
+    if( !( (goodVFATs >> (*vfatNptr).second ) & 0x1 ) ){
+        sprintf(regBuf,"The requested VFAT is not synced; goodVFATs: %x\t requested VFAT: %i; maskOh: %x", goodVFATs, (*vfatNptr).second, maskOh);
         la->response->set_string("error",regBuf);
         return;
     }
@@ -547,7 +547,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
             }
 
             //store the original channel mask
-            sprintf(regBuf, "GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.MASK",ohN,(*vfatNptr),chan);
+            sprintf(regBuf, "GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.MASK",ohN,(*vfatNptr).second,chan);
             chanMaskAddr[chan]=getAddress(la->rtxn, la->dbi, regBuf, la->response);
             map_chanOrigMask[chanMaskAddr[chan]]=readReg(la->rtxn, la->dbi, regBuf);   //We'll write this by address later
 
@@ -557,7 +557,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     } //End Case: Measuring Rate for 1 channel
 
     //Get the scanAddress
-    sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,(*vfatNptr),scanReg.c_str());
+    sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,(*vfatNptr).second,scanReg.c_str());
     uint32_t scanDacAddr = getAddress(la->rtxn, la->dbi, regBuf, la->response);
 
     //Get the OH Rate Monitor Address
@@ -565,7 +565,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     uint32_t ohTrigRateAddr = getAddress(la->rtxn, la->dbi, regBuf, la->response);
 
     //Store the original OH  VFAT Mask, and then reset it
-    sprintf(regBuf,"GEM_AMC.OH.OH%i.TRIG.CTRL.VFAT_MASK"%(ohN))
+    sprintf(regBuf,"GEM_AMC.OH.OH%i.TRIG.CTRL.VFAT_MASK",ohN);
     uint32_t ohVFATMaskAddr = getAddress(la->rtxn, la->dbi, regBuf, la->response);
     uint32_t maskOhOrig = readRawAddress(ohVFATMaskAddr, la->response);   //We'll write this later
     writeRawAddress(ohVFATMaskAddr, maskOh, la->response);
@@ -574,7 +574,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_SYSTEM.VFAT3.VFAT3_RUN_MODE", 0x1, la->response);
 
     //Place chip in run mode
-    //sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_RUN",ohN,(*vfatNptr));
+    //sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_RUN",ohN,(*vfatNptr).second);
     //uint32_t runAddr = getAddress(la->rtxn, la->dbi, regBuf, la->response);
     //writeRawAddress(runAddr, 0x1, la->response);
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -633,7 +633,7 @@ extern "C" {
             return; // Do not register our functions, we depend on memsvc.
         }
         modmgr->register_method("calibration_routines", "genScan", genScan);
-        modmgr->register_method("calibration_routines", "genChannelScan", genScan);
+        modmgr->register_method("calibration_routines", "genChannelScan", genChannelScan);
         modmgr->register_method("calibration_routines", "sbitRateScan", sbitRateScan);
         modmgr->register_method("calibration_routines", "ttcGenConf", ttcGenConf);
         modmgr->register_method("calibration_routines", "ttcGenToggle", ttcGenToggle);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -593,6 +593,11 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response){
     uint32_t outDataDacVal[(dacMax-dacMin+1)/dacStep];
     uint32_t outDataTrigRate[(dacMax-dacMin+1)/dacStep];
     sbitRateScanLocal(&la, outDataDacVal, outDataTrigRate, ohN, maskOh, ch, dacMin, dacMax, dacStep, scanReg);
+
+    response->set_word_array("data_dacVal", outDataDacVal, (dacMax-dacMin+1)/dacStep);
+    response->set_word_array("data_trigRate", outDataTrigRate, (dacMax-dacMin+1)/dacStep);
+
+    return;
 } //End sbitRateScan(...)
 
 void genChannelScan(const RPCMsg *request, RPCMsg *response)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The sbit rate scan code that was originally written by Evaldas was done purely in python and could only be reliably executed from the CTP7 itself.  This PR includes an RPC module that provides functionality for performing an SBIT rate scan.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Allows an SBIT rate scan against an arbitrary scan register, the following table describes the input arguments:

| Argument | Type | Description |
| ---------- | ---- | ------------|
| `la` | `localArgs` | Struct containing the `rtxn`, `dbi` and RPC `response` objects. |
| `outDataDacVal` | `uint32_t *` | Pointer to an array that will hold the DAC values of each scan point of `scanReg`.  Note the size of the array is assumed to be `(dacMax - daxMin + 1) / dacStep`.  The `idx` position of this array represents the same scan point as the `outDataTrigRate` argument. |
| `outDataTrigRate` | `uint32_t *` | As `outDataDacVal` but for the y-values of the array. |
| `ohN` | `uint32_t` | Link on CTP7 to be scanned. | 
| `maskOh` | `uint32_t` | This is a 24 bit number that is used as the mask for  `GEM_AMC.OH.OHX.TRIG.CTRL.VFAT_MASK`.  The VFAT to be scanned `vfatN` is determined from this mask and it is assumed to be the only unmasked VFAT. |
| `ch` | `uint32_t` | Channel of `vfatN` to be used, all other channels will be masked.  The original mask settings will be returned after the scan has completed.  Expected to be in the range [0,127].  Note if `ch=128` then the channel mask settings will not be altered and the rate measurement will use the `OR` of all channels. |
| `dacMin` | `uint32_t` | Starting value of `scanReg`.|
| `dacMax` | `uint32_t` | Final value of `scanReg`.|
| `dacStep` | `uint32_t` | Step size used to move from `dacMin` to `dacMax` of `scanReg`.|
| `scanReg` | `std::string` | Register to be scanned, the leading `CFG_` of the register name is omitted when passing to this argument. |
| `waitTime` | `uint32_t` | The time the scan will spend measuring the rate at each scan point. |

Right now the code will only perform a scan using one VFAT of one link.  However discussing with @andrewpeck and @evka85 on how this could be parallelized at least inside of one link (e.g. 24 VFATs simultaneously).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I made measurements using [sbitThreshScanSeries.py](https://github.com/bdorney/vfatqc-python-scripts/blob/qualify-v3-el/sbitThreshScanSeries.py)

### Screenshots (if appropriate):
![ratesummary](https://user-images.githubusercontent.com/6432141/34981575-3569a340-faa8-11e7-9dad-dad87c0aa38d.png)

Please note in the above scan only VFATs: 0-2, 7-10, 16-18 were unmasked.  The remaining VFATs were masked.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
