### PR TITLE
"Bug Fix" New VFAT3 Slow Control Only Mode Behavior

### DIFF
--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -285,9 +285,6 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
         //Configure VFAT_DAQ_MONITOR
         dacMonConfLocal(la, ohN, ch);
 
-        //Place VFATs out of slow control only mode
-        writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_SYSTEM.VFAT3.VFAT3_RUN_MODE", 0x1, la->response);
-
         //Scan over DAC values
         for(uint32_t dacVal = dacMin; dacVal <= dacMax; dacVal += dacStep)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
@evka renamed the register for placing the VFAT3s into slow control only mode and inverted it's meaning in CTP7 FW version v3.3.6 and beyond.  This PR ensures this new behavior is propagated to the SW.

For complete discussion see: http://cmsonline.cern.ch/cms-elog/1026503

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Presently if using CTP7 FW v3.3.6 or higher `genScanLocal(...)` will either:

1. throw a reg not found error, or
2. place VFAT3s into slow control only mode (no data taking possible).

This PR addresses this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See above e-log.  Change was trivial, but tested anyway.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
