### PR TITLE
New Feature: Parallel SBIT Rate Scan vs. Arbitrary Register

### DIFF
--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -294,9 +294,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
             //Write the scan reg value
             for(int vfatN = 0; vfatN < 24; vfatN++) if((notmask >> vfatN) & 0x1)
             {
-                //writeRawAddress(scanDacAddr[vfatN], dacVal, la->response);
                 writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str()), dacVal, la->response);
-                //std::this_thread::sleep_for(std::chrono::microseconds(50)); //Seen some evidence that
             }
 
             //Reset and enable the VFAT_DAQ_MONITOR
@@ -311,7 +309,6 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                 uint32_t l1aCnt = 0;
                 while(l1aCnt < nevts){
                     l1aCnt = readRawAddress(l1CntAddr, la->response);
-                    //std::this_thread::sleep_for(std::chrono::microseconds(50));
                     std::this_thread::sleep_for(std::chrono::microseconds(200));
                 }
 
@@ -329,21 +326,21 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
 
 
             for(int vfatN = 0; vfatN < 24; vfatN++){
+                if ( !( (notmask >> vfat) & 0x1)) continue;
+
                 int idx = vfatN*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
                 outData[idx] = readRawAddress(daqMonAddr[vfatN], la->response);
 
-                if((notmask >> vfatN) & 0x1){
-                    LOGGER->log_message(LogManager::DEBUG, stdsprintf("%s Value: %i; Readback Val: %i; Nhits: %i; Nev: %i; CFG_THR_ARM: %i",
-                                 scanReg.c_str(),
-                                 dacVal,
-                                 readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str())),
-                                 readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.VFAT%i.CHANNEL_FIRE_COUNT",vfatN)),
-                                 readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.VFAT%i.GOOD_EVENTS_COUNT",vfatN)),
-                                 readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_THR_ARM_DAC",ohN,vfatN,scanReg.c_str()))
-                        )
-                    );
-                }
-            }
+                LOGGER->log_message(LogManager::DEBUG, stdsprintf("%s Value: %i; Readback Val: %i; Nhits: %i; Nev: %i; CFG_THR_ARM: %i",
+                             scanReg.c_str(),
+                             dacVal,
+                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str())),
+                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.VFAT%i.CHANNEL_FIRE_COUNT",vfatN)),
+                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.VFAT%i.GOOD_EVENTS_COUNT",vfatN)),
+                             readReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_THR_ARM_DAC",ohN,vfatN,scanReg.c_str()))
+                    )
+                );
+            } //End Loop over vfats
         } //End Loop from dacMin to dacMax
 
         //If the calpulse for channel ch was turned on, turn it off
@@ -539,9 +536,9 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
 
     //If ch!=128 store the original channel mask settings
     //Then mask all other channels except for channel ch
-    std::map<uint32_t, uint32_t> map_chanOrigMask; //key -> reg addr; val -> reg value
+    std::unordered_map<uint32_t, uint32_t> map_chanOrigMask; //key -> reg addr; val -> reg value
     if( ch != 128){
-        uint32_t chanMaskAddr[128];
+        uint32_t chanMaskAddr;
         for(unsigned int chan=0; chan<128; ++chan){ //Loop Over All Channels
             uint32_t chMask = 1;
             if ( ch == chan){ //Do not mask the channel of interest
@@ -550,35 +547,26 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
 
             //store the original channel mask
             sprintf(regBuf, "GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.MASK",ohN,vfatN,chan);
-            chanMaskAddr[chan]=getAddress(la->rtxn, la->dbi, regBuf, la->response);
-            map_chanOrigMask[chanMaskAddr[chan]]=readReg(la->rtxn, la->dbi, regBuf);   //We'll write this by address later
+            chanMaskAddr=getAddress(la->rtxn, la->dbi, regBuf, la->response);
+            map_chanOrigMask[chanMaskAddr]=readReg(la->rtxn, la->dbi, regBuf);   //We'll write this by address later
 
             //write the new channel mask
-            writeRawAddress(chanMaskAddr[chan], chMask, la->response);
+            writeRawAddress(chanMaskAddr, chMask, la->response);
         } //End Loop Over all Channels
     } //End Case: Measuring Rate for 1 channel
-
-    //Get the scanAddress
-    //sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str());
-    //uint32_t scanDacAddr = getAddress(la->rtxn, la->dbi, regBuf, la->response);
 
     //Get the OH Rate Monitor Address
     sprintf(regBuf,"GEM_AMC.TRIGGER.OH%i.TRIGGER_RATE",ohN);
     uint32_t ohTrigRateAddr = getAddress(la->rtxn, la->dbi, regBuf, la->response);
 
-    //Store the original OH  VFAT Mask, and then reset it
+    //Store the original OH VFAT Mask, and then reset it
     sprintf(regBuf,"GEM_AMC.OH.OH%i.TRIG.CTRL.VFAT_MASK",ohN);
     uint32_t ohVFATMaskAddr = getAddress(la->rtxn, la->dbi, regBuf, la->response);
     uint32_t maskOhOrig = readRawAddress(ohVFATMaskAddr, la->response);   //We'll write this later
     writeRawAddress(ohVFATMaskAddr, maskOh, la->response);
 
     //Take the VFATs out of slow control only mode
-    writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_SYSTEM.VFAT3.VFAT3_RUN_MODE", 0x1, la->response);
-
-    //Place chip in run mode
-    //sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_RUN",ohN,vfatN);
-    //uint32_t runAddr = getAddress(la->rtxn, la->dbi, regBuf, la->response);
-    //writeRawAddress(runAddr, 0x1, la->response);
+    writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_SYSTEM.VFAT3.SC_ONLY_MODE", 0x0, la->response);
 
     //Loop from dacMin to dacMax in steps of dacStep
     for(uint32_t dacVal = dacMin; dacVal <= dacMax; dacVal += dacStep){
@@ -592,9 +580,6 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
         outDataTrigRate[idx] = readRawAddress(ohTrigRateAddr, la->response);
     } //End Loop from dacMin to dacMax
 
-    //Take chip out of run mode
-    //writeRawAddress(runAddr, 0x0, la->response);
-
     //Restore the original channel masks if specific channel was requested
     if( ch != 128){
         for(auto chanPtr = map_chanOrigMask.begin(); chanPtr != map_chanOrigMask.end(); ++chanPtr){
@@ -607,6 +592,113 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
 
     return;
 } //End sbitRateScanLocal(...)
+
+void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t outDataTrigRateOverall, uint32_t ohN, uint32_t vfatmask, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg){
+    //Measures the SBIT rate seen by OHv3 ohN for the non-masked VFATs defined in vfatmask as a function of scanReg
+    //Will scan from dacMin to dacMax in steps of dacStep
+    //The x-values (e.g. scanReg values) will be stored in outDataDacVal
+    //For each VFAT the y-valued (e.g. rate) will be stored in outDataTrigRatePerVFAT
+    //For the overall y-value (e.g. rate) will be stored in outDataTrigRateOverall
+    //Each measured point will take one second
+    //The measurement is performed for all channels (ch=128) or a specific channel (0 <= ch <= 127)
+
+    char regBuf[200];
+
+    //Are we using v3 electronics?
+    int iFWVersion = readReg(la->rtxn, la->dbi, "GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR");
+    if (iFWVersion < 3){ //v2b electronics behavior
+        sprintf(regBuf,"SBIT Rate Scan is Presently only supported in V3 Electronics");
+        la->response->set_string("error",regBuf);
+        return;
+    }
+
+    //Check if vfats are sync'd
+    uint32_t notmask = ~mask & 0xFFFFFF;
+    uint32_t goodVFATs = vfatSyncCheckLocal(la, ohN);
+    if( (notmask & goodVFATs) != notmask){
+        sprintf(regBuf,"One of the unmasked VFATs is not Synced. goodVFATs: %x\tnotmask: %x",goodVFATs,notmask);
+        la->response->set_string("error",regBuf);
+        return;
+    }
+
+    //If ch!=128 store the original channel mask settings
+    //Then mask all other channels except for channel ch
+    std::unordered_map<uint32_t, uint32_t> map_chanOrigMask; //key -> reg addr; val -> reg value
+    if( ch != 128){
+        uint32_t chanMaskAddr;
+        for(int vfat=0; vfat<24; ++vfat){
+            //Skip this vfat if it's masked
+            if ( !( (notmask >> vfat) & 0x1)) continue;
+
+            for(unsigned int chan=0; chan<128; ++chan){ //Loop Over All Channels
+                uint32_t chMask = 1;
+                if ( ch == chan){ //Do not mask the channel of interest
+                    chMask = 0;
+                }
+
+                //store the original channel mask
+                sprintf(regBuf, "GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.MASK",ohN,vfatN,chan);
+                chanMaskAddr=getAddress(la->rtxn, la->dbi, regBuf, la->response);
+                map_chanOrigMask[chanMaskAddr]=readReg(la->rtxn, la->dbi, regBuf);   //We'll write this by address later
+
+                //write the new channel mask
+                writeRawAddress(chanMaskAddr, chMask, la->response);
+            } //End Loop Over all Channels
+        } //End loop over all vfats
+    } //End Case: Measuring Rate for 1 channel
+
+    //Get the SBIT Rate Monitor Address
+    uint32_t ohTrigRateAddr[25]; //idx 0->23 VFAT counters; idx 24 overall rate
+    sprintf(regBuf,"GEM_AMC.TRIGGER.OH%i.TRIGGER_RATE",ohN);
+    ohTrigRateAddr[24] = getAddress(la->rtxn, la->dbi, regBuf, la->response);
+    for(int vfat=0; vfat<24; ++vfat){
+        sprintf(regBuf,"GEM_AMC.OH.OH%i.TRIG.CNT.VFAT%i_SBITS",ohN,vfat);
+        ohTrigRateAddr[vfat] = getAddress(la->rtxn, la->dbi, regBuf, la->response);
+    } //End Loop over all VFATs
+
+    //Take the VFATs out of slow control only mode
+    writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_SYSTEM.VFAT3.SC_ONLY_MODE", 0x0, la->response);
+
+    //Prep the SBIT counters
+    writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.TRIG.CNT.SBIT_CNT_PERSIST",ohN), 0x0, la->response); //reset all counters after SBIT_CNT_TIME_MAX
+    writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.TRIG.CNT.SBIT_CNT_TIME_MAX",ohN), 0x02638e98, la->response); //count for 1 second
+
+    //Loop from dacMin to dacMax in steps of dacStep
+    for(uint32_t dacVal = dacMin; dacVal <= dacMax; dacVal += dacStep){
+        //Set the scan register value
+        for(int vfat=0; vfat<24; ++vfat){
+            if ( !( (notmask >> vfat) & 0x1)) continue;
+            sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfat,scanReg.c_str());
+            writeReg(la->rtxn, la->dbi, regBuf, dacVal, la->response);
+        } //End Loop Over all VFATs
+
+        //Reset the counters
+        writeReg(la->rtxn, la->dbi, stdsprintf("GEM_AMC.OH.OH%i.TRIG.CNT.RESET",ohN), 0x1, la->response);
+
+        //Wait just over 1 second
+        std::this_thread::sleep_for(std::chrono::milliseconds(1005));
+
+        //Read the counters
+        int idx = (dacVal-dacMin)/dacStep;
+        outDataDacVal[idx] = dacVal;
+        outDataTrigRateOverall[idx] = readRawAddress(ohTrigRateAddr[24], la->response);
+        for(int vfat=0; vfat<24; ++vfat){
+            if ( !( (notmask >> vfat) & 0x1)) continue;
+
+            idx = vfat*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
+            outDataTrigRatePerVFAT[idx] = readRawAddress(ohTrigRateAddr[vfat], la->response);
+        }
+    } //End Loop from dacMin to dacMax
+
+    //Restore the original channel masks if specific channel was requested
+    if( ch != 128){
+        for(auto chanPtr = map_chanOrigMask.begin(); chanPtr != map_chanOrigMask.end(); ++chanPtr){
+            writeRawAddress( (*chanPtr).first, (*chanPtr).second, la->response);
+        }
+    } //End restore original channel masks if specific channel was requested
+
+    return;
+} //End sbitRateScanParallel(...)
 
 void sbitRateScan(const RPCMsg *request, RPCMsg *response){
     auto env = lmdb::env::create();
@@ -624,11 +716,20 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response){
     uint32_t dacStep = request->get_word("dacStep");
     std::string scanReg = request->get_string("scanReg");
     uint32_t waitTime = request->get_word("waitTime");
+    bool isParallel = request->get_word("isParallel");
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     uint32_t outDataDacVal[(dacMax-dacMin+1)/dacStep];
     uint32_t outDataTrigRate[(dacMax-dacMin+1)/dacStep];
-    sbitRateScanLocal(&la, outDataDacVal, outDataTrigRate, ohN, maskOh, invertVFATPos, ch, dacMin, dacMax, dacStep, scanReg, waitTime);
+    if(isParallel){
+        uint32_t outDataTrigRatePerVFAT[24*(dacMax-dacMin+1)/dacStep];
+        sbitRateScanParallelLocal(&la, outDataDacVal, outDataTrigRatePerVFAT, outDataTrigRate, ohN, maskOh, ch, dacMin, dacMax, dacStep, scanReg);
+
+        response->set_word_array("data_trigRatePerVFAT", outDataTrigRatePerVFAT, 24*(dacMax-dacMin+1)/dacStep);
+    }
+    else{
+        sbitRateScanLocal(&la, outDataDacVal, outDataTrigRate, ohN, maskOh, invertVFATPos, ch, dacMin, dacMax, dacStep, scanReg, waitTime);
+    }
 
     response->set_word_array("data_dacVal", outDataDacVal, (dacMax-dacMin+1)/dacStep);
     response->set_word_array("data_trigRate", outDataTrigRate, (dacMax-dacMin+1)/dacStep);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -326,7 +326,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
 
 
             for(int vfatN = 0; vfatN < 24; vfatN++){
-                if ( !( (notmask >> vfat) & 0x1)) continue;
+                if ( !( (notmask >> vfatN) & 0x1)) continue;
 
                 int idx = vfatN*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
                 outData[idx] = readRawAddress(daqMonAddr[vfatN], la->response);
@@ -593,7 +593,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     return;
 } //End sbitRateScanLocal(...)
 
-void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t outDataTrigRateOverall, uint32_t ohN, uint32_t vfatmask, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg){
+void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ohN, uint32_t vfatmask, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg){
     //Measures the SBIT rate seen by OHv3 ohN for the non-masked VFATs defined in vfatmask as a function of scanReg
     //Will scan from dacMin to dacMax in steps of dacStep
     //The x-values (e.g. scanReg values) will be stored in outDataDacVal
@@ -613,7 +613,7 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
     }
 
     //Check if vfats are sync'd
-    uint32_t notmask = ~mask & 0xFFFFFF;
+    uint32_t notmask = ~vfatmask & 0xFFFFFF;
     uint32_t goodVFATs = vfatSyncCheckLocal(la, ohN);
     if( (notmask & goodVFATs) != notmask){
         sprintf(regBuf,"One of the unmasked VFATs is not Synced. goodVFATs: %x\tnotmask: %x",goodVFATs,notmask);
@@ -637,7 +637,7 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
                 }
 
                 //store the original channel mask
-                sprintf(regBuf, "GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.MASK",ohN,vfatN,chan);
+                sprintf(regBuf, "GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.MASK",ohN,vfat,chan);
                 chanMaskAddr=getAddress(la->rtxn, la->dbi, regBuf, la->response);
                 map_chanOrigMask[chanMaskAddr]=readReg(la->rtxn, la->dbi, regBuf);   //We'll write this by address later
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In Optohybrid v3 FW version [3.0.7.A](https://github.com/cms-gem-daq-project/OptoHybridv3/releases/tag/3.0.7.A) a set of new counters was added which measure the rate of sbits being sent from each VFAT individually.  I have added a new SBIT rate scan module `sbitRateScanParallelLocal(...)` which takes advantage of this new FW functionality.

However, due to the issues with Optohybrid FW versions v3.0.7.A (trigger link underflow error) and v3.0.8.A (VFATs kept in hard reset) it has not yet been possible to test yet.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
In the previous sbit rate scan `sbitRateScanLocal(...)` it was only possible to scan one VFAT at a time which caused the scan to take an exceptionally long time (especially in the case of a channel scan).  I had added `sbitRateScanParallelLocal(...)` which uses the new FW functionality (OHv3 version 3.0.7.A or higher) to scan all VFATs in parallel.

### Changes to sbitRateScan(const RPCMsg *request, RPCMsg *response)

The previous functionality, described in https://github.com/cms-gem-daq-project/ctp7_modules/pull/15, has been preserved.  New functionality has been added:

| Argument | Type | Description |
| ---------- | ----- | ----------- |
| `maskOh` | `uint32_t` | If the the `isParallel` flag is true this acts as the standard `vfatmask` otherwise see https://github.com/cms-gem-daq-project/ctp7_modules/pull/15. |
| `isParallel` | `bool` | If true `sbitRateScan(...)` will call `sbitRateScanParallelLocal(...)` instead of the series version `sbitRateScanLocal(...)`. |
| `data_trigRatePerVFAT` | `uint32_t *` | Pointer to an array that holds the trigger rate values for each VFAT for each scan point of `scanReg`. Note the size of the array is assumed to be `24*(dacMax - dacMin + 1)/dacStep`.  The `idx` for `vfatN` is `N*(dacVal-dacMin+1)/dacStep` and the `dacVal` that corresponds to this trigger rate is then `data_dacVal[idx]`. |

Please note `invertVFATPos` is not used in `sbitRateScanParallelLocal(...)` since from OH FW version [3.0.5.A](https://github.com/cms-gem-daq-project/OptoHybridv3/releases/tag/3.0.5.A) the VFAT numbering in the OH matches the "software" convention;  However since OH FW version 3.0.4.A is still the last "stable" FW release I have kept this flag.

Also the `waitTime` is not used in `sbitRateScanParallelLocal(...)` for simplicity.  The counters will increment for a total of 1 second (40,079,000 clock cycles), thus the rate is simply the count.

If `isParallel` is true then `sbitRateScanParallelLocal(...)` will be called and an additional word array will be retuned in the RPC response `data_trigRatePerVFAT`.  If `isParallel` is false then the current functionality will persist.

###  Description of sbitRateScanParallelLocal(...)

| Argument | Type | Description |
| ---------- | ----- | ----------- |
| `la` | `localArgs` | Struct containing the `rtxn`, `dbi` and RPC `response` objects. |
| `outDataDacVal` | `uint32_t *` | Pointer to an array that will hold the DAC values of each scan point of `scanReg`.  Note the size of the array is assumed to be `(dacMax - daxMin + 1) / dacStep`.  The `idx` position of this array represents the same scan point as the `outDataTrigRateOverall` argument. |
| `outDataTrigRatePerVFAT` | `uint32_t *` | Pointer to an array that holds the trigger rate values for each VFAT for each scan point of `scanReg`. Note the size of the array is assumed to be `24*(dacMax - dacMin + 1)/dacStep`.  The `idx` for `vfatN` is `N*(dacVal-dacMin+1)/dacStep` and the `dacVal` that corresponds to this trigger rate is then `outDataDacVal[idx]`. |
| `outDataTrigRateOverall` | `uint32_t *` | As `outDataDacVal` but for the y-values of the array. |
| `ohN` | `uint32_t` | Link on CTP7 to be scanned. | 
| `vfatmask` | `uint32_t` | VFAT mask to be used, e.g. `0x30` means all VFATs except for 4 & 5 will be scanned. |
| `ch` | `uint32_t` | VFAT Channel to be used, all other channels will be masked.  The original mask settings will be returned after the scan has completed.  Expected to be in the range [0,127].  Note if `ch=128` then the channel mask settings will not be altered and the rate measurement will be an `OR` of all channels. |
| `dacMin` | `uint32_t` | Starting value of `scanReg`.|
| `dacMax` | `uint32_t` | Final value of `scanReg`.|
| `dacStep` | `uint32_t` | Step size used to move from `dacMin` to `dacMax` of `scanReg`.|
| `scanReg` | `std::string` | Register to be scanned, the leading `CFG_` of the register name is omitted when passing to this argument. |

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Due to a FW bug it hasn't yet.  When @andrewpeck releases the new OHv3a FW version addressing  [OptohybridV3 Issue #7](https://github.com/cms-gem-daq-project/OptoHybridv3/issues/7) testing will resume.

### Screenshots (if appropriate):
<img width="1202" alt="sbitratescanparallel" src="https://user-images.githubusercontent.com/6432141/36277409-1324b38c-1291-11e8-9b15-decba23d4726.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
