### PR TITLE
New Feature: genScanLocal uses current pulse mode of calibration module

### DIFF
--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -467,6 +467,7 @@ void genScan(const RPCMsg *request, RPCMsg *response)
     uint32_t dacMax = request->get_word("dacMax");
     uint32_t dacStep = request->get_word("dacStep");
     bool useCalPulse = request->get_word("useCalPulse");
+    bool currentPulse = request->get_word("currentPulse");
     std::string scanReg = request->get_string("scanReg");
 
     bool useUltra = false;
@@ -477,7 +478,7 @@ void genScan(const RPCMsg *request, RPCMsg *response)
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     uint32_t outData[24*(dacMax-dacMin+1)/dacStep];
-    genScanLocal(&la, outData, ohN, mask, ch, useCalPulse, nevts, dacMin, dacMax, dacStep, scanReg, useUltra, useExtTrig);
+    genScanLocal(&la, outData, ohN, mask, ch, useCalPulse, currentPulse, nevts, dacMin, dacMax, dacStep, scanReg, useUltra, useExtTrig);
     response->set_word_array("data",outData,24*(dacMax-dacMin+1)/dacStep);
 
     return;
@@ -657,8 +658,9 @@ void genChannelScan(const RPCMsg *request, RPCMsg *response)
     uint32_t dacMin = request->get_word("dacMin");
     uint32_t dacMax = request->get_word("dacMax");
     uint32_t dacStep = request->get_word("dacStep");
-    uint32_t useCalPulse = request->get_word("useCalPulse");
-    uint32_t useExtTrig = request->get_word("useExtTrig");
+    bool useCalPulse = request->get_word("useCalPulse");
+    bool currentPulse = request->get_word("currentPulse");
+    bool useExtTrig = request->get_word("useExtTrig");
     std::string scanReg = request->get_string("scanReg");
 
     bool useUltra = false;
@@ -670,7 +672,7 @@ void genChannelScan(const RPCMsg *request, RPCMsg *response)
     uint32_t outData[128*24*(dacMax-dacMin+1)/dacStep];
     for(uint32_t ch = 0; ch < 128; ch++)
     {
-        genScanLocal(&la, &(outData[ch*24*(dacMax-dacMin+1)/dacStep]), ohN, mask, ch, useCalPulse, nevts, dacMin, dacMax, dacStep, scanReg, useUltra, useExtTrig);
+        genScanLocal(&la, &(outData[ch*24*(dacMax-dacMin+1)/dacStep]), ohN, mask, ch, useCalPulse, currentPulse, nevts, dacMin, dacMax, dacStep, scanReg, useUltra, useExtTrig);
     }
     response->set_word_array("data",outData,24*128*(dacMax-dacMin+1)/dacStep);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
VFAT3 design team has recommended to use the current pulse mode for injecting cal pulses into the system with the calibration module as it allows a finer granularity scurve than the voltage injection mode.

This PR adds functionality to `genScanLocal(...)` for toggling between the voltage and current pulse injection mode and for setting the current pulse scale factor to be used (`CFG_CAL_FS`).

The current pulse duration is hard coded to 1 clock cycle at the recommendation of the VFAT3 design team (additionally injecting for more than one clock cycle is probably equivalent to just changing the `CFG_PULSE_STRETCH` register).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Two new arguments have been added:
- `bool currentPulse` if set to `true` (`false`) uses the current (voltage) pulse injection, and 
- `uint32_t calScaleFactor` the value to be written to the `CFG_CAL_FS` register, only applicable if `currentPulse == true`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Finer granularity scurves are possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See following e-logs: 
- http://cmsonline.cern.ch/cms-elog/1028418
- http://cmsonline.cern.ch/cms-elog/1028540

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
