### PR TITLE
New Feature: Set Channel Registers

### DIFF
--- a/include/vfat3.h
+++ b/include/vfat3.h
@@ -43,6 +43,26 @@ void configureVFAT3sLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask);
  */
 void configureVFAT3s(const RPCMsg *request, RPCMsg *response);
 
+/*! \fn void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol);
+  + *  \brief writes all vfat3 channel registers from AMC
+  + *  \param ohN Optohybrid optical link number
+  + *  \param vfatMask Bitmask of chip positions determining which chips to use
+  + *  \param calEnable array pointer for calEnable with 3072 entries, the (vfat,chan) pairing determines the array index via: idx = vfat*128 + chan
+  + *  \param masks as calEnable but for channel masks
+  + *  \param trimARM as calEnable but for arming comparator trim value
+  + *  \param trimARMPol as calEnable but for arming comparator trim polarity
+  + *  \param trimZCC as calEnable but for zero crossing comparator trim value
+  + *  \param trimZCCPol as calEnable but for zero crossing comparator trim polarity
+  + */
+void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol);
+
+/*! \fn void setChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response);
+  + *  \brief writes all vfat3 channel registers from host machine
+  + *  \param request RPC request message
+  + *  \param response RPC responce message
+  + */
+void setChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response);
+
 /*! \fn void statusVFAT3sLocal(localArgs * la, uint32_t ohN)
  *  \brief Local callable version of statusVFAT3s
  *  \param la Local arguments structure
@@ -51,7 +71,7 @@ void configureVFAT3s(const RPCMsg *request, RPCMsg *response);
 void statusVFAT3sLocal(localArgs * la, uint32_t ohN);
 
 /*! \fn void statusVFAT3s(const RPCMsg *request, RPCMsg *response)
- *  \brief Returns list of values of the most important VFAT3 register 
+ *  \brief Returns list of values of the most important VFAT3 register
  *  \param request RPC request message
  *  \param response RPC responce message
  */

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -118,6 +118,7 @@ void ttcGenToggleLocal(localArgs * la, uint32_t ohN, bool enable)
             else{
                 writeReg(la, "GEM_AMC.TTC.GENERATOR.ENABLE", 0x0); //Internal TTC generator disabled, TTC cmds from backplane
             }
+            break;
         }//End v3 electronics behavior
         case 1: //v2b electronics behavior
         {
@@ -136,10 +137,12 @@ void ttcGenToggleLocal(localArgs * la, uint32_t ohN, bool enable)
                     writeReg(la, contBase + ".TOGGLE", 0x0);   //Disable
                 }
             }
+            break;
         }//End v2b electronics behavior
         default:
         {
             LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major!");
+            break;
         }
     }
 
@@ -210,13 +213,14 @@ void ttcGenConfLocal(localArgs * la, uint32_t ohN, uint32_t mode, uint32_t type,
 {
     //Check firmware version
     switch(fw_version_check("ttcGenToggle", la)) {
-        case 3: //v3 electronics behavior
+        case 0x3: //v3 electronics behavior
         {
             writeReg(la, "GEM_AMC.TTC.GENERATOR.RESET", 0x1);
             writeReg(la, "GEM_AMC.TTC.GENERATOR.CYCLIC_L1A_GAP", L1Ainterval);
             writeReg(la, "GEM_AMC.TTC.GENERATOR.CYCLIC_CALPULSE_TO_L1A_GAP", pulseDelay);
+            break;
         }//End v3 electronics behavior
-        case 1: //v2b electronics behavior
+        case 0x1: //v2b electronics behavior
         {
             //base reg
             std::stringstream sstream;
@@ -265,12 +269,12 @@ void ttcGenConfLocal(localArgs * la, uint32_t ohN, uint32_t mode, uint32_t type,
                         readReg(la, contBase + ".NUMBER")
                         )
                     );
-
-            //ttcGenToggleLocal(la, ohN, enable);
+            break;
         }//End v2b electronics behavior
         default:
         {
             LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major!");
+            break;
         }
     }
 
@@ -493,6 +497,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                     }
                 }
             }
+            break;
         }//End v3 electronics behavior
         case 1: //v2b electronics behavior
         {
@@ -573,10 +578,12 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
 
             //Get scan results
             getUltraScanResultsLocal(la, outData, ohN, nevts, dacMin, dacMax, dacStep);
+            break;
         }//End v2b electronics behavior
         default:
         {
             LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major!");
+            break;
         }
     }
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -30,7 +30,7 @@ unsigned int fw_version_check(const char* caller_name, localArgs *la)
 /*! \fn std::unordered_map<uint32_t, uint32_t> setSingleChanMask(int ohN, int vfatN, unsigned int ch, localArgs *la)
  *  \brief Unmask the channel of interest and masks all the other
  *  \param ohN Optical link number
- *  \param vfatN VFAT position 
+ *  \param vfatN VFAT position
  *  \param ch Channel of interest
  *  \param la Local arguments structure
  *  \return Original channel mask in a form of an unordered map <chanMaskAddr, mask>
@@ -183,7 +183,7 @@ void ttcGenToggle(const RPCMsg *request, RPCMsg *response)
  *    * enable = true (false) turn on CTP7 internal TTC generator and ignore ttc commands from backplane for this AMC (turn off CTP7 internal TTC generator and take ttc commands from backplane link)
  *  - **v2b** electronics behavior:
  *    * Configure the T1 controller
- *    * mode: 
+ *    * mode:
  *      * 0 (Single T1 signal),
  *      * 1 (CalPulse followed by L1A),
  *      * 2 (pattern)
@@ -289,7 +289,7 @@ void ttcGenConfLocal(localArgs * la, uint32_t ohN, uint32_t mode, uint32_t type,
  *    * enable = true (false) ignore (take) ttc commands from backplane for this AMC (affects all links)
  *  - **v2b** electronics behavior:
  *    * Configure the T1 controller
- *    * mode: 
+ *    * mode:
  *      * 0 (Single T1 signal),
  *      * 1 (CalPulse followed by L1A),
  *      * 2 (pattern)
@@ -339,12 +339,12 @@ void ttcGenConf(const RPCMsg *request, RPCMsg *response)
  *  \param ch Channel of interest
  *  \param useCalPulse Use  calibration pulse if true
  *  \param currentPulse Selects whether to use current or volage pulse
- *  \param calScaleFactor 
+ *  \param calScaleFactor
  *  \param nevts Number of events per calibration point
  *  \param dacMin Minimal value of scan variable
  *  \param dacMax Maximal value of scan variable
  *  \param dacStep Scan variable change step
- *  \param scanReg DAC register to scan over name 
+ *  \param scanReg DAC register to scan over name
  *  \param useUltra Set to 1 in order to use the ultra scan
  *  \param useExtTrig Set to 1 in order to use the backplane triggers
  */
@@ -460,7 +460,10 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                     } //End TTC Commands from TTC.GENERATOR
                 }
 
+                //Stop the DAQ monitor counters from incrementing
+                writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.ENABLE", 0x0, la->response);
 
+                //Read the DAQ Monitor counters
                 for(int vfatN = 0; vfatN < 24; vfatN++){
                     if ( !( (notmask >> vfatN) & 0x1)) continue;
 
@@ -632,18 +635,18 @@ void genScan(const RPCMsg *request, RPCMsg *response)
  *  * Each measured point will take waitTime milliseconds (recommond between 1000->3000)
  *  * The measurement is performed for all channels (ch=128) or a specific channel (0 <= ch <= 127)
  *  * invertVFATPos is for FW backwards compatiblity; if true then the vfatN =  23 - map_maskOh2vfatN[maskOh]
- *  
+ *
  *  \param la Local arguments structure
- *  \param outDataDacVal 
+ *  \param outDataDacVal
  *  \param outDataTrigRate
- *  \param ohN Optohybrid optical link number 
+ *  \param ohN Optohybrid optical link number
  *  \param maskOh VFAT mask, should only have one unmasked chip
  *  \param invertVFATPos is for FW backwards compatiblity; if true then the vfatN =  23 - map_maskOh2vfatN[maskOh]
- *  \param ch Channel of interest 
+ *  \param ch Channel of interest
  *  \param dacMin Minimal value of scan variable
  *  \param dacMax Maximal value of scan variable
  *  \param dacStep Scan variable change step
- *  \param scanReg DAC register to scan over name 
+ *  \param scanReg DAC register to scan over name
  *  \waitTime Measurement duration per point
  */
 void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRate, uint32_t ohN, uint32_t maskOh, bool invertVFATPos, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg, uint32_t waitTime)
@@ -743,18 +746,18 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
  *  * For the overall y-value (e.g. rate) will be stored in outDataTrigRateOverall
  *  * Each measured point will take one second
  *  * The measurement is performed for all channels (ch=128) or a specific channel (0 <= ch <= 127)
- *   
+ *
  *  \param la Local arguments structure
- *  \param outDataDacVal 
+ *  \param outDataDacVal
  *  \param outDataTrigRatePerVFAT
  *  \param outDataTrigRateOverall
- *  \param ohN Optohybrid optical link number 
- *  \param vfatMask VFAT mask 
- *  \param ch Channel of interest 
+ *  \param ohN Optohybrid optical link number
+ *  \param vfatMask VFAT mask
+ *  \param ch Channel of interest
  *  \param dacMin Minimal value of scan variable
  *  \param dacMax Maximal value of scan variable
  *  \param dacStep Scan variable change step
- *  \param scanReg DAC register to scan over name 
+ *  \param scanReg DAC register to scan over name
  */
 void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ohN, uint32_t vfatmask, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg)
 {
@@ -837,7 +840,7 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
 } //End sbitRateScanParallel(...)
 
 /*! \fn void sbitRateScan(const RPCMsg *request, RPCMsg *response)
- *  \brief SBIT rate scan. See the local callable methods documentation for details 
+ *  \brief SBIT rate scan. See the local callable methods documentation for details
  *  \param request RPC response message
  *  \param response RPC response message
  */
@@ -882,7 +885,7 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response)
 } //End sbitRateScan(...)
 
 /*! \fn void genChannelScan(const RPCMsg *request, RPCMsg *response)
- *  \brief Generic per channel scan. See the local callable methods documentation for details 
+ *  \brief Generic per channel scan. See the local callable methods documentation for details
  *  \param request RPC response message
  *  \param response RPC response message
  */

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -461,7 +461,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                 }
 
                 //Stop the DAQ monitor counters from incrementing
-                writeReg(la->rtxn, la->dbi, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.ENABLE", 0x0, la->response);
+                writeReg(la, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.ENABLE", 0x0);
 
                 //Read the DAQ Monitor counters
                 for(int vfatN = 0; vfatN < 24; vfatN++){

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -123,7 +123,7 @@ void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMa
             std::string strBaseNode = stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i",ohN,vfatN,chan);
 
             //Channel mask
-            writeReg(la->rtxn, la->dbi, stdsprintf("%s.MASK",strBaseNode.c_str()), masks[idx], la->response);
+            writeReg(la, stdsprintf("%s.MASK",strBaseNode.c_str()), masks[idx]);
             if (masks[idx] > 0){ //We write the mask, and then if the mask is not zero skip the channel
                 continue;
             }
@@ -134,13 +134,13 @@ void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMa
                 la->response->set_string("error",regBuf);
                 return;
             }
-            writeReg(la->rtxn, la->dbi, stdsprintf("%s.ARM_TRIM_AMPLITUDE",strBaseNode.c_str()), trimARM[idx], la->response);
+            writeReg(la, stdsprintf("%s.ARM_TRIM_AMPLITUDE",strBaseNode.c_str()), trimARM[idx]);
 
             //ARM trim polarity
-            writeReg(la->rtxn, la->dbi, stdsprintf("%s.ARM_TRIM_POLARITY",strBaseNode.c_str()), trimARMPol[idx], la->response);
+            writeReg(la, stdsprintf("%s.ARM_TRIM_POLARITY",strBaseNode.c_str()), trimARMPol[idx]);
 
             //Cal enable
-            writeReg(la->rtxn, la->dbi, stdsprintf("%s.CALPULSE_ENABLE",strBaseNode.c_str()), calEnable[idx], la->response);
+            writeReg(la, stdsprintf("%s.CALPULSE_ENABLE",strBaseNode.c_str()), calEnable[idx]);
 
             //ZCC trim
             if ( trimZCC[idx] > 0x7F || trimZCC[idx] < 0x0){
@@ -148,10 +148,10 @@ void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMa
                 la->response->set_string("error",regBuf);
                 return;
             }
-            writeReg(la->rtxn, la->dbi, stdsprintf("%s.ZCC_TRIM_AMPLITUDE",strBaseNode.c_str()), trimZCC[idx], la->response);
+            writeReg(la, stdsprintf("%s.ZCC_TRIM_AMPLITUDE",strBaseNode.c_str()), trimZCC[idx]);
 
             //ZCC trim polarity
-            writeReg(la->rtxn, la->dbi, stdsprintf("%s.ZCC_TRIM_POLARITY",strBaseNode.c_str()), trimZCCPol[idx], la->response);
+            writeReg(la, stdsprintf("%s.ZCC_TRIM_POLARITY",strBaseNode.c_str()), trimZCCPol[idx]);
         } //End Loop over channels
     } //End Loop over VFATs
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses: https://github.com/cms-gem-daq-project/ctp7_modules/issues/14

New RPC method for setting channel registers `setChannelRegistersVFAT3Local(...)`.  Here's a snap shot of the `doxygen` documentation:

```
*! \fn void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol);                          
 *  \brief writes all vfat3 channel registers from AMC
 *  \param ohN Optohybrid optical link number
 *  \param vfatMask Bitmask of chip positions determining which chips to use
 *  \param calEnable array pointer for calEnable with 3072 entries, the (vfat,chan) pairing determines the array index via: idx = vfat*128 + chan
 *  \param masks as calEnable but for channel masks
 *  \param trimARM as calEnable but for arming comparator trim value
 *  \param trimARMPol as calEnable but for arming comparator trim polarity
 *  \param trimZCC as calEnable but for zero crossing comparator trim value
 *  \param trimZCCPol as calEnable but for zero crossing comparator trim polarity
 */
void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol)
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
For trimming VFAT3 need to write between 3-6 channel registers per channel per VFAT.  So it's not feasible for the host machine to do this; the CTP7 should do this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested when trimming VFAT3, was able to achieve the following:

### Before Trimming
<img width="697" alt="summary_vfat0_beforetrimming" src="https://user-images.githubusercontent.com/6432141/38979010-50ea74d2-43b9-11e8-9c3e-20088e067221.png">

### After Trimming
<img width="695" alt="summary_vfat_aftertrimming" src="https://user-images.githubusercontent.com/6432141/38979011-5102aa48-43b9-11e8-8233-c3c3dc77e1a8.png">

<img width="640" alt="fitsummary_vfat0_beforeandaftertrimming" src="https://user-images.githubusercontent.com/6432141/38979009-50d280e8-43b9-11e8-97e7-601481de9808.png">
The black distribution is the trimmed distribution.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->