### PR TITLE
Bug Fix: fixed a bug where env was using wrong address_table.mdb location

### DIFF
--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -161,7 +161,9 @@ void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMa
 void setChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response){
     auto env = lmdb::env::create();
     env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    env.open("/mnt/persistent/texas/address_table.mdb", 0, 0664);
+    std::string gem_path = std::getenv("GEM_PATH");
+    std::string lmdb_data_file = gem_path+"/address_table.mdb";
+    env.open(lmdb_data_file.c_str(), 0, 0664);
     auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
     auto dbi = lmdb::dbi::open(rtxn, nullptr);
     LOGGER->log_message(LogManager::INFO, "Setting VFAT3 Channel Registers");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`setChannelRegistersVFAT3(...)` was using a `texas` directory instead of the correct directory set by `GEM_PATH`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Caused a non-zero rpc response generating a crash.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Before change:

```
(default)[dorney@gem904qc8daq]~/scratch0/CMS_GEM/CMS_GEM_DAQ% confChamber.py --shelf=2 -s5 -g0 --zeroChan --vfatmask=0x1000
2018.06.01.18.08
Open pickled address table if available  /afs/cern.ch/user/d/dorney/scratch0/CMS_GEM/CMS_GEM_DAQ/xhal/etc/gem_amc_top.pickle...
Initializing AMC eagle60
My FW release major =  3
opened connection
Configuring VFATs with chamber_vfatDACSettings dictionary values
biased VFATs
Set CFG_THR_ARM_DAC to 100
zero'ing all channel registers
Caught exception: Unable to read response length from server
Traceback (most recent call last):
  File "/afs/cern.ch/user/d/dorney/scratch0/CMS_GEM/CMS_GEM_DAQ/vfatqc-python-scripts/confChamber.py", line 133, in <module>
    raise Exception("RPC response was non-zero, zero'ing all channel registers failed")
Exception: RPC response was non-zero, zero'ing all channel registers failed
```

After change:

```
(default)[dorney@gem904qc8daq]~/scratch0/CMS_GEM/CMS_GEM_DAQ% confChamber.py --shelf=2 -s5 -g0 --zeroChan --vfatmask=0x1000
2018.06.01.18.18
Open pickled address table if available  /afs/cern.ch/user/d/dorney/scratch0/CMS_GEM/CMS_GEM_DAQ/xhal/etc/gem_amc_top.pickle...
Initializing AMC eagle60
My FW release major =  3
opened connection
Configuring VFATs with chamber_vfatDACSettings dictionary values
biased VFATs
Set CFG_THR_ARM_DAC to 100
zero'ing all channel registers
Chamber Configured
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
