### PR TITLE
Reading back channel registers and faster writing of channel registers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ include apps.common.mk
 
 IncludeDirs = ${CTP7_MOD_ROOT}/include
 IncludeDirs += ${CTP7_MOD_ROOT}/src
-IncludeDirs += ${XHAL_ROOT}/include
+IncludeDirs += ${XHAL_ROOT}/xhalcore/include
 IncludeDirs += ${XHAL_ROOT}/xcompile/xerces-c-3.1.4/src
 IncludeDirs += ${XHAL_ROOT}/xcompile/log4cplus-1.1.2/include
 IncludeDirs += ${XHAL_ROOT}/xcompile/lmdb-LMDB_0.9.19/include

--- a/include/vfat3.h
+++ b/include/vfat3.h
@@ -43,6 +43,22 @@ void configureVFAT3sLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask);
  */
 void configureVFAT3s(const RPCMsg *request, RPCMsg *response);
 
+/*! \fn void getChannelRegistersVFAT3Local(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t *chanRegData)
+ *  \brief reads all channel registers for unmasked vfats and stores values in chanRegData
+ *  \param la Local arguments structure
+ *  \param ohN Optical link
+ *  \param mask VFAT mask
+ *  \param chanRegData pointer to the container holding channel registers; expected to be an array of 3072 channels with idx = vfatN * 128 + chan
+ */
+void getChannelRegistersVFAT3Local(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t *chanRegData);
+
+/*! \fn void setChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response);
+  + *  \brief reads all vfat3 channel registers from host machine
+  + *  \param request RPC request message
+  + *  \param response RPC responce message
+  + */
+void getChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response);
+
 /*! \fn void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol);
   + *  \brief writes all vfat3 channel registers from AMC
   + *  \param ohN Optohybrid optical link number

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -100,6 +100,7 @@ void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMa
     uint32_t notmask = ~vfatMask & 0xFFFFFF;
 
     char regBuf[200];
+    LOGGER->log_message(LogManager::INFO, "Load channel register settings");
     for(int vfatN=0; vfatN < 24; ++vfatN){
         // Check if vfat is masked
         if(!((notmask >> vfatN) & 0x1)){
@@ -123,6 +124,7 @@ void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMa
             std::string strBaseNode = stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i",ohN,vfatN,chan);
 
             //Channel mask
+            LOGGER->log_message(LogManager::INFO, stdsprintf("Setting %s.MASK VFAT%i chan %i",strBaseNode.c_str(),vfatN,chan));
             writeReg(la, stdsprintf("%s.MASK",strBaseNode.c_str()), masks[idx]);
             if (masks[idx] > 0){ //We write the mask, and then if the mask is not zero skip the channel
                 continue;
@@ -134,12 +136,15 @@ void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMa
                 la->response->set_string("error",regBuf);
                 return;
             }
+            LOGGER->log_message(LogManager::INFO, stdsprintf("Setting ARM_TRIM_AMPLITUDE VFAT%i chan %i",vfatN,chan));
             writeReg(la, stdsprintf("%s.ARM_TRIM_AMPLITUDE",strBaseNode.c_str()), trimARM[idx]);
 
             //ARM trim polarity
+            LOGGER->log_message(LogManager::INFO, stdsprintf("Setting ARM_TRIM_POLARITY VFAT%i chan %i",vfatN,chan));
             writeReg(la, stdsprintf("%s.ARM_TRIM_POLARITY",strBaseNode.c_str()), trimARMPol[idx]);
 
             //Cal enable
+            LOGGER->log_message(LogManager::INFO, stdsprintf("Setting CALPULSE_ENABLE VFAT%i chan %i",vfatN,chan));
             writeReg(la, stdsprintf("%s.CALPULSE_ENABLE",strBaseNode.c_str()), calEnable[idx]);
 
             //ZCC trim
@@ -148,9 +153,11 @@ void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMa
                 la->response->set_string("error",regBuf);
                 return;
             }
+            LOGGER->log_message(LogManager::INFO, stdsprintf("Setting ZCC_TRIM_AMPLITUDE VFAT%i chan %i",vfatN,chan));
             writeReg(la, stdsprintf("%s.ZCC_TRIM_AMPLITUDE",strBaseNode.c_str()), trimZCC[idx]);
 
             //ZCC trim polarity
+            LOGGER->log_message(LogManager::INFO, stdsprintf("Setting ZCC_TRIM_POLARITY VFAT%i chan %i",vfatN,chan));
             writeReg(la, stdsprintf("%s.ZCC_TRIM_POLARITY",strBaseNode.c_str()), trimZCCPol[idx]);
         } //End Loop over channels
     } //End Loop over VFATs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Current `setChannelRegistersVFAT3Local()` method performs 6 write transactions per channel (calenable, maks, trimARM, trimARM polarity, trimZCC, trimZCC polarity).  This is excessive and unnecessary.  I have updated the module to build the overall channel register in the appropriate bits and then perform a single write transaction for the channel. 

Additionally this provides a function for reading back the channel registers `getChannelRegistersVFAT3Local()` and it's "remote" equivalent.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
The `setChannelRegistersVFAT3Local()` runs slow and there was no RPC method for reading back the vfat3 settings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
(py2.7) [dorney@gem904qc8daq]~/scratch0/CMS_GEM/CMS_GEM_DAQ% date
Fri Jul 13 15:10:13 CEST 2018
(py2.7) [dorney@gem904qc8daq]~/scratch0/CMS_GEM/CMS_GEM_DAQ% confChamber.py -c eagle60 -g1 --vfatmask=0xf9f0f --zero
2018.07.13.15.10
Open pickled address table if available  /opt/cmsgemos/etc/maps/amc_address_table_top.pickle...
Initializing AMC eagle60
My FW release major =  3
opened connection
biased VFATs
Set CFG_THR_ARM_DAC to 100
zero'ing all channel registers
Chamber Configured
(py2.7) [dorney@gem904qc8daq]~/scratch0/CMS_GEM/CMS_GEM_DAQ% date
Fri Jul 13 15:10:20 CEST 2018
```

The log on the card is:

```
eagle60:/mnt/persistent/rpcmodules$ tail -25 /var/log/messages
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 104
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 105
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 106
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 107
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 108
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 109
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 110
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 111
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 112
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 113
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 114
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 115
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 116
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 117
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 118
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 119
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 120
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 121
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 122
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 123
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 124
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 125
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 126
Jul 13 13:10:04 CTP7 local0.info rpcsvc[8863]: vfat3.setChannelRegistersVFAT3: Setting channel register for VFAT23 chan 127
Jul 13 13:10:05 CTP7 local0.notice rpcsvc[8863]: rpcsvc: Client disconnected cleanly
```

Working as expected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
