### PR TITLE
New Feature: Cross-check SBIT Mapping & Rate Calculation in OH FPGA

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -50,8 +50,14 @@ std::string serialize(xhal::utils::Node n) {
   return std::to_string((uint32_t)n.real_address)+"|"+n.permission+"|"+std::to_string((uint32_t)n.mask);
 }
 
+/*! \fn uint32_t getNumNonzeroBits(uint32_t value)
+ *  \brief returns the number of nonzero bits in an integer
+ *  \param value integer to check the number of nonzero bits
+ */
+uint32_t getNumNonzeroBits(uint32_t value);
+
 /*! \fn void writeRawAddress(uint32_t address, uint32_t value, RPCMsg *response)
- *  \brief Writes a value to a raw register address. Register mask is not applied  
+ *  \brief Writes a value to a raw register address. Register mask is not applied
  *  \param address Register address
  *  \param value Value to write
  *  \param response RPC response message
@@ -88,7 +94,7 @@ void writeAddress(lmdb::val & db_res, uint32_t value, RPCMsg *response);
 uint32_t readAddress(lmdb::val & db_res, RPCMsg *response);
 
 /*! \fn void writeRawReg(localArgs * la, const std::string & regName, uint32_t value)
- *  \brief Writes a value to a raw register. Register mask is not applied  
+ *  \brief Writes a value to a raw register. Register mask is not applied
  *  \param la Local arguments structure
  *  \param regName Register name
  *  \param value Value to write
@@ -117,7 +123,7 @@ uint32_t applyMask(uint32_t data, uint32_t mask);
 uint32_t readReg(localArgs * la, const std::string & regName);
 
 /*! \fn void writeReg(localArgs * la, const std::string & regName, uint32_t value)
- *  \brief Writes a value to a register. Register mask is applied  
+ *  \brief Writes a value to a register. Register mask is applied
  *  \param la Local arguments structure
  *  \param regName Register name
  *  \param value Value to write

--- a/include/vfat3.h
+++ b/include/vfat3.h
@@ -59,24 +59,33 @@ void getChannelRegistersVFAT3Local(localArgs *la, uint32_t ohN, uint32_t mask, u
   + */
 void getChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response);
 
+/*! \fn void void setChannelRegistersVFAT3SimpleLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData)
+ *  \brief writes all vfat3 channel registers from AMC
+ *  \param la Local arguments structure
+ *  \param ohN Optical link
+ *  \param vfatMask VFAT mask
+ *  \param chanRegData pointer to the container holding channel registers; expected to be an array of 3072 channels with idx = vfatN * 128 + chan
+ */
+void setChannelRegistersVFAT3SimpleLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData);
+
 /*! \fn void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol);
-  + *  \brief writes all vfat3 channel registers from AMC
-  + *  \param ohN Optohybrid optical link number
-  + *  \param vfatMask Bitmask of chip positions determining which chips to use
-  + *  \param calEnable array pointer for calEnable with 3072 entries, the (vfat,chan) pairing determines the array index via: idx = vfat*128 + chan
-  + *  \param masks as calEnable but for channel masks
-  + *  \param trimARM as calEnable but for arming comparator trim value
-  + *  \param trimARMPol as calEnable but for arming comparator trim polarity
-  + *  \param trimZCC as calEnable but for zero crossing comparator trim value
-  + *  \param trimZCCPol as calEnable but for zero crossing comparator trim polarity
-  + */
+ *  \brief writes all vfat3 channel registers from AMC
+ *  \param ohN Optohybrid optical link number
+ *  \param vfatMask Bitmask of chip positions determining which chips to use
+ *  \param calEnable array pointer for calEnable with 3072 entries, the (vfat,chan) pairing determines the array index via: idx = vfat*128 + chan
+ *  \param masks as calEnable but for channel masks
+ *  \param trimARM as calEnable but for arming comparator trim value
+ *  \param trimARMPol as calEnable but for arming comparator trim polarity
+ *  \param trimZCC as calEnable but for zero crossing comparator trim value
+ *  \param trimZCCPol as calEnable but for zero crossing comparator trim polarity
+ */
 void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol);
 
 /*! \fn void setChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response);
-  + *  \brief writes all vfat3 channel registers from host machine
-  + *  \param request RPC request message
-  + *  \param response RPC responce message
-  + */
+ *  \brief writes all vfat3 channel registers from host machine
+ *  \param request RPC request message
+ *  \param response RPC responce message
+ */
 void setChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response);
 
 /*! \fn void statusVFAT3sLocal(localArgs * la, uint32_t ohN)

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1244,7 +1244,7 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
     //Prep the SBIT counters
     LOGGER->log_message(LogManager::INFO, stdsprintf("Preping SBIT Counters for ohN %i", ohN));
     writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.FPGA.TRIG.CNT.SBIT_CNT_PERSIST",ohN), 0x0); //reset all counters after SBIT_CNT_TIME_MAX
-    writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.FPGA.TRIG.CNT.SBIT_CNT_TIME_MAX",ohN), 0x02638e98); //count for 1 second
+    writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.FPGA.TRIG.CNT.SBIT_CNT_TIME_MAX",ohN), 0x02638e98*int(waitTime/1000) ); //count for a number of BX's specified by waitTime
 
     if(!((notmask >> vfatN) & 0x1)){
         la->response->set_string("error",stdsprintf("The vfat of interest %i should not be part of the vfats to be masked: %x",vfatN, mask));

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1039,7 +1039,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, uint32_
     //Monitor which sbit is seen when sending a calupluse
     for(int vfatN=0; vfatN < 24; ++vfatN){ //Loop over all vfats
         //Skip masked vfats
-        if((notmask >> vfatN) & 0x0){
+        if((notmask >> vfatN) & 0x1){
             continue;
         }
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1375,7 +1375,7 @@ extern "C" {
             return; // Do not register our functions, we depend on memsvc.
         }
         modmgr->register_method("calibration_routines", "checkSbitMappingWithCalPulse", checkSbitMappingWithCalPulse);
-        modmgr->register_method("calibration_routines", "checkSbitRateWithCalPulse", checkSbitMappingWithCalPulse);
+        modmgr->register_method("calibration_routines", "checkSbitRateWithCalPulse", checkSbitRateWithCalPulse);
         modmgr->register_method("calibration_routines", "genScan", genScan);
         modmgr->register_method("calibration_routines", "genChannelScan", genChannelScan);
         modmgr->register_method("calibration_routines", "sbitRateScan", sbitRateScan);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1244,7 +1244,7 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
     //Prep the SBIT counters
     LOGGER->log_message(LogManager::INFO, stdsprintf("Preping SBIT Counters for ohN %i", ohN));
     writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.FPGA.TRIG.CNT.SBIT_CNT_PERSIST",ohN), 0x0); //reset all counters after SBIT_CNT_TIME_MAX
-    writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.FPGA.TRIG.CNT.SBIT_CNT_TIME_MAX",ohN), 0x02638e98*int(waitTime/1000) ); //count for a number of BX's specified by waitTime
+    writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.FPGA.TRIG.CNT.SBIT_CNT_TIME_MAX",ohN), uint32_t(0x02638e98*waitTime/1000.) ); //count for a number of BX's specified by waitTime
 
     if(!((notmask >> vfatN) & 0x1)){
         la->response->set_string("error",stdsprintf("The vfat of interest %i should not be part of the vfats to be masked: %x",vfatN, mask));
@@ -1292,8 +1292,8 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
         //Read All Trigger Registers
         LOGGER->log_message(LogManager::INFO, "Reading trigger counters");
         outDataCTP7Rate[chan]=readRawAddress(ohTrigRateAddr[25], la->response);
-        outDataFPGAClusterCntRate[chan]=readRawAddress(ohTrigRateAddr[24], la->response);
-        outDataVFATSBits[chan]=readRawAddress(ohTrigRateAddr[vfatN], la->response);
+        outDataFPGAClusterCntRate[chan]=readRawAddress(ohTrigRateAddr[24], la->response)*waitTime/1000.;
+        outDataVFATSBits[chan]=readRawAddress(ohTrigRateAddr[vfatN], la->response)*waitTime/1000.;
 
         //Reset the TTC Generator
         LOGGER->log_message(LogManager::INFO, "Stopping TTC Generator");

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1039,7 +1039,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, uint32_
     //Monitor which sbit is seen when sending a calupluse
     for(int vfatN=0; vfatN < 24; ++vfatN){ //Loop over all vfats
         //Skip masked vfats
-        if((notmask >> vfatN) & 0x1){
+        if(!((notmask >> vfatN) & 0x1)){
             continue;
         }
 
@@ -1055,7 +1055,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, uint32_
             writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.MASK",ohN,vfatN,chan), 0x0);
 
             //Turn on the calpulse for this channel
-            if (confCalPulseLocal(la, ohN, ((0x1)<<vfatN), chan, false, currentPulse, calScaleFactor) == false){
+            if (confCalPulseLocal(la, ohN, ~((0x1)<<vfatN) & 0xFFFFFF, chan, false, currentPulse, calScaleFactor) == false){
                 return; //Calibration pulse is not configured correctly
             }
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -967,7 +967,7 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response)
 } //End sbitRateScan(...)
 
 /*! \fn void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask, bool currentPulse, uint32_t calScaleFactor, uint32_t nevts, uint32_t L1Ainterval, uint32_t pulseDelay)
- *  \brief With all but one channel masked, pulses a given channel, and then checks which sbits are seen by the CTP7, repeats for all channels on vfatN; reports the (vfat,chan) pulsed and (vfat,sbit) observed where sbit=chan*2; additionally reports if the cluster was valid
+ *  \brief With all but one channel masked, pulses a given channel, and then checks which sbits are seen by the CTP7, repeats for all channels on vfatN; reports the (vfat,chan) pulsed and (vfat,sbit) observed where sbit=chan*2; additionally reports if the cluster was valid.  The sbit size is the number of trigger pads from the sbit reported that where part of this cluster, size ranges from 0 to 7.
  *  \param la Local arguments structure
  *  \param outData pointer to an array of size (24*128*8*nevts) which stores the results of the scan, bits [0,7] channel pulsed; bits [8:15] sbit observed; bits [16:20] vfat pulsed; bits [21,25] vfat observed; bit 26 isValid; bits [27,29] are the cluster size
  *  \param ohN Optical link

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -93,8 +93,20 @@ void readRegFromDB(const RPCMsg *request, RPCMsg *response) {
   rtxn.abort();
 }
 
+uint32_t getNumNonzeroBits(uint32_t value){
+    //See: https://stackoverflow.com/questions/4244274/how-do-i-count-the-number-of-zero-bits-in-an-integer
+    uint32_t numNonzeroBits=0;
+    for(size_t i=0; i < CHAR_BIT * sizeof value; ++i){
+        if ((value & (1 << i)) == 1){
+            numNonzeroBits++;
+        }
+    }
+
+    return numNonzeroBits;
+} //End numNonzeroBits()
+
 void writeRawAddress(uint32_t address, uint32_t value, RPCMsg *response){
-  uint32_t data[1]; 
+  uint32_t data[1];
   data[0] = value;
   if (memsvc_write(memsvc, address, 1, data) != 0) {
   	response->set_string("error", std::string("memsvc error: ")+memsvc_get_last_error(memsvc));
@@ -154,11 +166,11 @@ uint32_t readAddress(lmdb::val & db_res, RPCMsg *response) {
   uint32_t data[1];
   uint32_t address = stoi(tmp[0]);
   int n_current_tries = 0;
-  while (true) 
+  while (true)
   {
-      if (memsvc_read(memsvc, address, 1, data) != 0) 
+      if (memsvc_read(memsvc, address, 1, data) != 0)
       {
-          if (n_current_tries < 9) 
+          if (n_current_tries < 9)
           {
               n_current_tries++;
               LOGGER->log_message(LogManager::ERROR, stdsprintf("Reading reg %08X failed %i times.", address, n_current_tries));
@@ -206,7 +218,7 @@ uint32_t applyMask(uint32_t data, uint32_t mask) {
   uint32_t result = data & mask;
   for (int i = 0; i < 32; i++)
   {
-    if (mask & 1) 
+    if (mask & 1)
     {
       break;
     }else {
@@ -274,11 +286,11 @@ void writeReg(localArgs * la, const std::string & regName, uint32_t value) {
   	    LOGGER->log_message(LogManager::ERROR, stdsprintf("Writing masked reg failed due to reading problem: %s", regName.c_str()));
         return;
       }
-      int shift_amount = 0; 
+      int shift_amount = 0;
       uint32_t mask_copy = mask;
       for (int i = 0; i < 32; i++)
       {
-        if (mask & 1) 
+        if (mask & 1)
         {
           break;
         } else {

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -189,7 +189,6 @@ void setChannelRegistersVFAT3SimpleLocal(localArgs * la, uint32_t ohN, uint32_t 
 
         //Loop over the channels
         uint32_t chanAddr;
-        uint32_t chanRegVal;
         for(int chan=0; chan < 128; ++chan){
             //Deterime the idx
             int idx = vfatN*128 + chan;
@@ -275,7 +274,7 @@ void setChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response){
     uint32_t vfatMask = request->get_word("vfatMask");
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-    if (request.get_key_exists("simple")){
+    if (request->get_key_exists("simple")){
         uint32_t chanRegData[3072];
 
         request->get_word_array("chanRegData",chanRegData);

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -167,6 +167,44 @@ void getChannelRegistersVFAT3Local(localArgs *la, uint32_t ohN, uint32_t vfatMas
     return;
 } //end getChannelRegistersVFAT3Local()
 
+void setChannelRegistersVFAT3SimpleLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData){
+    //Determine the inverse of the vfatmask
+    uint32_t notmask = ~vfatMask & 0xFFFFFF;
+
+    char regBuf[200];
+    LOGGER->log_message(LogManager::INFO, "Write channel register settings");
+    for(int vfatN=0; vfatN < 24; ++vfatN){
+        // Check if vfat is masked
+        if(!((notmask >> vfatN) & 0x1)){
+            continue;
+        } //End check if VFAT is masked
+
+        // Check if vfatN is sync'd
+        uint32_t goodVFATs = vfatSyncCheckLocal(la, ohN);
+        if( !( (goodVFATs >> vfatN ) & 0x1 ) ){
+            sprintf(regBuf,"The requested VFAT is not synced; goodVFATs: %x\t requested VFAT: %i; maskOh: %x", goodVFATs, vfatN, vfatMask);
+            la->response->set_string("error",regBuf);
+            return;
+        }
+
+        //Loop over the channels
+        uint32_t chanAddr;
+        uint32_t chanRegVal;
+        for(int chan=0; chan < 128; ++chan){
+            //Deterime the idx
+            int idx = vfatN*128 + chan;
+
+            //Get the address
+            sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i",ohN,vfatN,chan);
+            chanAddr = getAddress(la, regBuf);
+            writeRawAddress(chanAddr, chanRegData[idx], la->response);
+            std::this_thread::sleep_for(std::chrono::microseconds(200));
+        } //End Loop over channels
+    } //End Loop over VFATs
+
+    return;
+} //End setChannelRegistersVFAT3SimpleLocal()
+
 void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol){
     //Determine the inverse of the vfatmask
     uint32_t notmask = ~vfatMask & 0xFFFFFF;
@@ -236,23 +274,31 @@ void setChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response){
     uint32_t ohN = request->get_word("ohN");
     uint32_t vfatMask = request->get_word("vfatMask");
 
-    uint32_t calEnable[3072];
-    uint32_t masks[3072];
-    uint32_t trimARM[3072];
-    uint32_t trimARMPol[3072];
-    uint32_t trimZCC[3072];
-    uint32_t trimZCCPol[3072];
-
-    request->get_word_array("calEnable",calEnable);
-    request->get_word_array("masks",masks);
-    request->get_word_array("trimARM",trimARM);
-    request->get_word_array("trimARMPol",trimARMPol);
-    request->get_word_array("trimZCC",trimZCC);
-    request->get_word_array("trimZCCPol",trimZCCPol);
-
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+    if (request.get_key_exists("simple")){
+        uint32_t chanRegData[3072];
 
-    setChannelRegistersVFAT3Local(&la, ohN, vfatMask, calEnable, masks, trimARM, trimARMPol, trimZCC, trimZCCPol);
+        request->get_word_array("chanRegData",chanRegData);
+
+        setChannelRegistersVFAT3SimpleLocal(&la, ohN, vfatMask, chanRegData);
+    } //End Case: user provided a single array
+    else{ //Case: user provided multiple arrays
+        uint32_t calEnable[3072];
+        uint32_t masks[3072];
+        uint32_t trimARM[3072];
+        uint32_t trimARMPol[3072];
+        uint32_t trimZCC[3072];
+        uint32_t trimZCCPol[3072];
+
+        request->get_word_array("calEnable",calEnable);
+        request->get_word_array("masks",masks);
+        request->get_word_array("trimARM",trimARM);
+        request->get_word_array("trimARMPol",trimARMPol);
+        request->get_word_array("trimZCC",trimZCC);
+        request->get_word_array("trimZCCPol",trimZCCPol);
+
+        setChannelRegistersVFAT3Local(&la, ohN, vfatMask, calEnable, masks, trimARM, trimARMPol, trimZCC, trimZCCPol);
+    } //End Case: user provided multiple arrays
 
     return;
 } //End setChannelRegistersVFAT3()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have long suspected there is an issue in the trigger data the v3 electronics are sending.  This provides several new calibration routines (and supporting infrastructure) to qualify the trigger data in the v3 electronics.  When a new set of electronics hardware, CTP7 firmware, or OH firmware is released two main questions should be asked:

1. Is the mapping of `vfat` channel to sbit in the OH correct?
2. Is the measurement of rate of sbits done by the OH/CTP7 correct?

This PR adds the required RPC methods for answering these questions.

### New Supporting Methods

#### `setChannelRegistersVFAT3SimpleLocal(...)`
The present RPC method for setting VFAT3 channel registers `setChannelRegistersVFAT3Local(...)` and it's non-local counterpart takes six separate arrays for:

- calEnable,
- mask,
- trim ZCC,
- trim ZCC polarity,
- trim ARM, and
- trim ARM polarity 

While this offers flexibility it doesn't pair well with the getting the channel registers using `getChannelRegistersVFAT3Local(...)` which returns a single array of channel register data where each element is the 16 bit channel register in question.  Additionally looking to the future the DB will most likely *not* store six different columns for the channel register data.

Hence an additional function has been added which takes only a single array and pairs well with the existing `get` method.

It has been incorporated into the same remote method and a check for the key `simple` toggles between `setChannelRegistersVFAT3Local(...)` and `setChannelRegistersVFAT3SimpleLocal(...)`.

See documentation in `include/vfat3.h` found in this PR for usage.

#### `confCalPulseLocal(...)`
Multiple local methods:

- `genScanLocal(...)`,
- `checkSbitMappingWithCalPulseLocal(...), and
- `checkSbitRateWithCalPulseLocal(...)`.

Require configuring the cal pulse for a particular channel.  This method provides the functionality to do so.  

See documentation found in `src/calibration_routines.cpp` for usage.  Not sure if this should be placed in `vfat3.cpp/h` but it seemed appropriate to be found in the calibration library.

#### `checkSbitMappingWithCalPulseLocal(...)`
This specifically addresses the first goal mentioned at the top of this PR.  This method will:

1. Store the current channel register settings,
2. Mask all channels and disable the calpulse for all unmasked vfats,
3. For the vfat of interest unmask a single channel and enable the calpulse,
4. Send `nevts` number of calpulses,
5. readout the sbits observed by the CTP7 and unpack the data,
6. Mask the channel again and disable the calpulse
7. repeat steps 3 through 6 for all channels on the vfat of interest
8. Revert to the original channel register settings

This allows the user to check that the (vfat,chan) being pulsed is the same as the (vfat,sbit) being observed by the OH/CTP7 and confirm the mapping.  It will also report the sbit cluster size.

See documentation in `src/calibration_routines.cpp` for usage.

#### `checkSbitRateWithCalPulseLocal()`
This specifically addresses the second goal mentioned at the top of this PR.  This method will:

1. Store the current channel register settings,
2. Mask all channels and disable the calpulse for all unmasked vfats,
3. For the vfat of interest unmask a single channel and enable the calpulse,
4. Send calpulses at a specific rate using the TTC Generator for a fixed time,
5. readout the rate counters on the  CTP7 and OH,
6. Stop sending calpulses, then mask the channel again and disable the calpulse,
7. repeat steps 3 through 6 for all channels on the vfat of interest
8. revert to the original channel register settings

This allows to confirm that the known rate pulsed matches the measured rate by the CTP7, specifically this is reading out registers:

- `GEM_AMC.OH.OHY.FPGA.TRIG.CNT.VFATX_SBITS` for vfat X of interest on OH Y,
- `GEM_AMC.OH.OHY.FPGA.TRIG.CNT.CLUSTER_COUNT` for OH Y
- `GEM_AMC.TRIGGER.OHY.TRIGGER_RATE` for OH Y

The first is the number of sbits for VFATX seen in `GEM_AMC.OH.OHX.FPGA.TRIG.CNT.SBIT_CNT_TIME_MAX` which then gives the rate.

The second is the sum of all sbit clusters from all vfats observed by the OH.

The third is the rate observed by the CTP7.  

In this case all three values should be the same. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Goals 1 & 2 at the top of this page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
http://cmsonline.cern.ch/cms-elog/1058329

### Screenshots (if appropriate):
Channel pulsed, sbit observed
![sbitobsvschanpulsed_validsbits_calenabled_sumofallrates](https://user-images.githubusercontent.com/6432141/44210470-de1d5300-a166-11e8-9aa4-e6b7e67cbd6b.png)

rate pulsed, rate observed
![rateobservedvsratepulsed_validsbits](https://user-images.githubusercontent.com/6432141/44211543-7e747700-a169-11e8-8b0f-5ae9af629471.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
