### PR TITLE
New Features: DAC Scans & ADC Monitoring in VFAT3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ TARGET_LIBS=lib/memory.so
 TARGET_LIBS+=lib/optical.so
 TARGET_LIBS+=lib/utils.so
 TARGET_LIBS+=lib/extras.so
+TARGET_LIBS+=lib/amc.so
 TARGET_LIBS+=lib/vfat3.so
 TARGET_LIBS+=lib/optohybrid.so
 TARGET_LIBS+=lib/calibration_routines.so
-TARGET_LIBS+=lib/amc.so
 
 all: $(TARGET_LIBS)
 
@@ -46,18 +46,17 @@ lib/utils.so: src/utils.cpp
 lib/extras.so: src/extras.cpp
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,extras.so -o $@ $< -lwisci2c -lxhal -llmdb
 
-lib/vfat3.so: src/vfat3.cpp 
-	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,vfat3.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so
-
-lib/optohybrid.so: src/optohybrid.cpp
-	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,optohybrid.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so
-
-lib/calibration_routines.so: src/calibration_routines.cpp
-	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,calibration_routines.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so -l:optohybrid.so -l:vfat3.so
-
 lib/amc.so: src/amc.cpp
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,amc.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so
 
+lib/vfat3.so: src/vfat3.cpp 
+	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,vfat3.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so -l:amc.so
+
+lib/optohybrid.so: src/optohybrid.cpp
+	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,optohybrid.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so -l:amc.so
+
+lib/calibration_routines.so: src/calibration_routines.cpp
+	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,calibration_routines.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so -l:optohybrid.so -l:vfat3.so -l:amc.so
 
 clean:
 	-rm -rf lib/*.so

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ ifndef CTP7_MOD_ROOT
 $(error "Error: CTP7_MOD_ROOT environment variable not set. Source setup.sh file")
 endif
 
-
 include apps.common.mk
 
 IncludeDirs = ${CTP7_MOD_ROOT}/include
@@ -17,8 +16,6 @@ IncludeDirs += ${XHAL_ROOT}/xcompile/log4cplus-1.1.2/include
 IncludeDirs += ${XHAL_ROOT}/xcompile/lmdb-LMDB_0.9.19/include
 IncludeDirs += /opt/cactus/include
 INC=$(IncludeDirs:%=-I%)
-
-
 
 LDFLAGS+= -L$(XHAL_ROOT)/lib/arm
 LDFLAGS+= -L$(XHAL_ROOT)/xcompile/lmdb-LMDB_0.9.19/lib
@@ -36,12 +33,6 @@ TARGET_LIBS+=lib/calibration_routines.so
 TARGET_LIBS+=lib/amc.so
 
 all: $(TARGET_LIBS)
-
-#optohybrid: lib/optohybrid.so
-#
-#$(TARGET_LIBS): $(SRCS)
-#lib/%.so:src/%.cpp
-#	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -o $@ $^ -lwisci2c -lxhal -llmdb
 
 lib/memory.so: src/memory.cpp 
 	$(CXX) $(CFLAGS) $(INC) $(LDFLAGS) -fPIC -shared -o $@ $< -lwisci2c
@@ -72,4 +63,3 @@ clean:
 	-rm -rf lib/*.so
 
 .PHONY: all
-

--- a/include/amc.h
+++ b/include/amc.h
@@ -65,8 +65,9 @@ void getmonOHmain(const RPCMsg *request, RPCMsg *response);
  *  \brief Local version of getmonOHSCAmainLocal
  *  \param la Local arguments
  *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
  */
-void getmonOHSCAmainLocal(localArgs *la, int NOH);
+void getmonOHSCAmainLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
 
 /* !\fn void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
  *  \brief Reads the SCA Monitoring values of all OH's (voltage and temperature) including FPGA core temperature

--- a/include/amc.h
+++ b/include/amc.h
@@ -109,6 +109,7 @@ void getmonTTCmain(const RPCMsg *request, RPCMsg *response);
 
 /*! \fn uint32_t getOHVFATMaskLocal(uint32_t ohN)
  *  \brief returns the vfatMask for the optohybrid ohN
+ *  \details Reads the SYNC_ERR_CNT counter for each VFAT on ohN.  If for a given VFAT the counter returns a non-zero value the given VFAT will be masked.
  *  \param la Local arguments structure
  *  \param ohN Optical link
  */

--- a/include/amc.h
+++ b/include/amc.h
@@ -1,0 +1,154 @@
+/*! \file amc.h
+ *  \brief RPC module for optohybrid methods
+ *  \author Mykhailo Dalchenko <mykhailo.dalchenko@cern.ch>
+ *  \author Cameron Bravo <cbravo135@gmail.com>
+ *  \author Brin Dorney <brian.l.dorney@cern.ch>
+ */
+
+#ifndef AMC_H
+#define AMC_H
+
+#include "utils.h"
+#include <unistd.h>
+
+/*! \fn unsigned int fw_version_check(const char* caller_name, localArgs *la)
+ *  \brief Returns AMC FW version
+ *  in case FW version is not 1.X or 3.X sets an error string in response
+ *  \param caller_name Name of methods which called the FW version check
+ *  \param la Local arguments structure
+ */
+unsigned int fw_version_check(const char* caller_name, localArgs *la);
+
+/*! \fn void getmonDAQmainLocal(localArgs * la)
+ *  \brief Local version of getmonDAQmain
+ *  \param la Local arguments
+ */
+void getmonDAQmainLocal(localArgs * la);
+
+/*! \fn void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of DAQ monitoring registers
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+
+void getmonDAQmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonDAQOHmainLocal(localArgs * la, int NOH)
+ *  \brief Local version of getmonDAQOHmain
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ */
+void getmonDAQOHmainLocal(localArgs * la, int NOH);
+
+/*! \fn void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of DAQ monitoring registers at the OH
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonOHmainLocal(localArgs * la, int NOH)
+ *  \brief Local version of getmonOHmain
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ */
+void getmonOHmainLocal(localArgs * la, int NOH);
+
+/*! \fn void getmonOHmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of OH monitoring registers at the OH
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonOHmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonTRIGGERmainLocal(localArgs * la, int NOH)
+ *  \brief Local version of getmonTRIGGERmain
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ */
+void getmonTRIGGERmainLocal(localArgs * la, int NOH);
+
+/*! \fn void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of trigger monitoring registers
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonTRIGGEROHmainLocal(localArgs * la, int NOH)
+ *  \brief Local version of getmonTRIGGEROHmain
+ *  * LINK{0,1}_SBIT_OVERFLOW_CNT -- this is an interesting counter to monitor from operations perspective, but is not related to the health of the link itself. Rather it shows how many times OH had too many clusters which it couldn't fit into the 8 cluster per BX bandwidth. If this counter is going up it just means that OH is seeing a very high hit occupancy, which could be due to high radiation background, or thresholds configured too low.
+ *
+ *  The other 3 counters reflect the health of the optical links:
+ *  * LINK{0,1}_OVERFLOW_CNT and LINK{0,1}_UNDERFLOW_CNT going up indicate a clocking issue, specifically they go up when the frequency of the clock on the OH doesn't match the frequency on the CTP7. Given that CTP7 is providing the clock to OH, this in principle should not happen unless the OH is sending complete garbage and thus the clock cannot be recovered on CTP7 side, or the bit-error rate is insanely high, or the fiber is just disconnected, or OH is off. In other words, this indicates a critical problem.
+ *  * LINK{0,1}_MISSED_COMMA_CNT also monitors the health of the link, but it's more sensitive, because it can go up due to isolated single bit errors. With radiation around, this might count one or two counts in a day or two. But if it starts running away, that would indicate a real problem, but in this case most likely the overflow and underflow counters would also see it.
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ */
+void getmonTRIGGEROHmainLocal(localArgs * la, int NOH);
+
+/*! \fn void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of trigger monitoring registers at the OH
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonTTCmainLocal(localArgs * la)
+ *  \brief Local version of getmonTTCmain
+ *  \param la Local arguments
+ */
+void getmonTTCmainLocal(localArgs * la);
+
+/*! \fn void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of TTC monitoring registers
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonTTCmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn uint32_t getOHVFATMaskLocal(uint32_t ohN)
+ *  \brief returns the vfatMask for the optohybrid ohN
+ *  \param la Local arguments structure
+ *  \param ohN Optical link
+ */
+uint32_t getOHVFATMaskLocal(localArgs * la, uint32_t ohN);
+
+/*! \fn void getOHVFATMask(const RPCMsg *request, RPCMsg *response)
+ *  \brief Determines the vfatMask for a given OH, see local method for details
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getOHVFATMask(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response)
+ *  \brief As getOHVFATMask(...) but for all optical links specified in ohMask on the AMC
+ *  \details Here the RPCMsg request should have a "ohMask" word which specifies which OH's to read from, this is a 12 bit number where a 1 in the n^th bit indicates that the n^th OH should be read back.  Additionally there should be a "ohVfatMaskArray" which is an array of size 12 where each element is the standard vfatMask for OH specified by the array index.
+ *  \param request RPC request message
+ *  \param response RPC responce message
+ */
+void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acquireTime, bool *maxNetworkSizeReached)
+ *  \brief reads out sbits from optohybrid ohN for a number of seconds given by acquireTime and returns them to the user.
+ *  \details The SBIT Monitor stores the 8 SBITs that are sent from the OH (they are all sent at the same time and correspond to the same clock cycle). Each SBIT clusters readout from the SBIT Monitor is a 16 bit word with bits [0:10] being the sbit address and bits [12:14] being the sbit size, bits 11 and 15 are not used.
+ *  \details The possible values of the SBIT Address are [0,1535].  Clusters with address less than 1536 are considered valid (e.g. there was an sbit); otherwise an invalid (no sbit) cluster is returned.  The SBIT address maps to a given trigger pad following the equation \f$sbit = addr % 64\f$.  There are 64 such trigger pads per VFAT.  Each trigger pad corresponds to two VFAT channels.  The SBIT to channel mapping follows \f$sbit=floor(chan/2)\f$.  You can determine the VFAT position of the sbit via the equation \f$vfatPos=7-int(addr/192)+int((addr%192)/64)*8\f$.
+ *  \details The SBIT size represents the number of adjacent trigger pads are part of this cluster.  The SBIT address always reports the lowest trigger pad number in the cluster.  The sbit size takes values [0,7].  So an sbit cluster with address 13 and with size of 2 includes 3 trigger pads for a total of 6 vfat channels and starts at channel \f$13*2=26\f$ and continues to channel \f$(2*15)+1=31\f$.
+ *  \details The output vector will always be of size N * 8 where N is the number of readouts of the SBIT Monitor.  For each readout the SBIT Monitor will be reset and then readout after 4095 clock cycles (~102.4 microseconds).  The SBIT clusters will only be added to the output vector if at least one of them was valid.  The SBIT clusters stored in the SBIT Monitor will not be over-written until a module reset is sent.  The readout will stop before acquireTime finishes if the size of the returned vector approaches the max TCP/IP size (~65000 btyes) and sets maxNetworkSize to true.
+ *  \details Each element of the output vector will be a 32 bit word.  Bits [0,10] will the address of the SBIT Cluster, bits [11:13] will be the cluster size, and bits [14:26] will be the difference between the SBIT and the input L1A (if any) in clock cycles.  While the SBIT Monitor stores the difference between the SBIT and input L1A as a 32 bit number (0xFFFFFFFF) any value higher 0xFFF (12 bits) will be truncated to 0xFFF.  This matches the time between readouts of 4095 clock cycles.
+ *  \param la Local arguments structure
+ *  \param ohN Optical link
+ *  \param acquireTime acquisition time on the wall clock in seconds
+ *  \param maxNetworkSize pointer to a boolean, set to true if the returned vector reaches a byte count of 65000
+ */
+std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acquireTime, bool *maxNetworkSizeReached);
+
+/*! \fn sbitReadOut(const RPCMsg *request, RPCMsg *response)
+ *  \brief readout sbits using the SBIT Monitor.  See the local callable methods documentation for details.
+ *  \param request RPC response message
+ *  \param response RPC response message
+ */
+void sbitReadOut(const RPCMsg *request, RPCMsg *response);
+
+
+#endif

--- a/include/amc.h
+++ b/include/amc.h
@@ -61,6 +61,20 @@ void getmonOHmainLocal(localArgs * la, int NOH);
  */
 void getmonOHmain(const RPCMsg *request, RPCMsg *response);
 
+/*! \fn void getmonOHSCAmainLocal(localArgs *la, int NOH);
+ *  \brief Local version of getmonOHSCAmainLocal
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ */
+void getmonOHSCAmainLocal(localArgs *la, int NOH);
+
+/* !\fn void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads the SCA Monitoring values of all OH's (voltage and temperature) including FPGA core temperature
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response);
+
 /*! \fn void getmonTRIGGERmainLocal(localArgs * la, int NOH)
  *  \brief Local version of getmonTRIGGERmain
  *  \param la Local arguments

--- a/include/optohybrid.h
+++ b/include/optohybrid.h
@@ -11,6 +11,14 @@
 #include "vfat_parameters.h"
 #include <unistd.h>
 
+/*! \fn void biasAllVFATsLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000)
+ *  \brief Local callable. Sets default values to VFAT parameters. VFATs will remain in sleep mode
+ *  \param la Local arguments structure
+ *  \param ohN Optohybrid optical link number (string)
+ *  \param mask VFAT mask. Default: no chips will be masked
+ */
+void biasAllVFATsLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000);
+
 /*! \fn void broadcastWriteLocal(localArgs * la, uint32_t ohN, std::string regName, uint32_t value, uint32_t mask = 0xFF000000)
  *  \brief Local callable version of broadcastWrite
  *  \param la Local arguments structure
@@ -46,69 +54,6 @@ void broadcastReadLocal(localArgs * la, uint32_t *outData, uint32_t ohN, std::st
  */
 void broadcastRead(const RPCMsg *request, RPCMsg *response);
 
-/*! \fn void biasAllVFATsLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000)
- *  \brief Local callable. Sets default values to VFAT parameters. VFATs will remain in sleep mode
- *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number (string)
- *  \param mask VFAT mask. Default: no chips will be masked
- */
-void biasAllVFATsLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000);
-
-/*! \fn void setAllVFATsToRunModeLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000)
- *  \brief Local callable. Sets VFATs to run mode
- *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number (string)
- *  \param mask VFAT mask. Default: no chips will be masked
- */
-void setAllVFATsToRunModeLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000);
-
-/*! \fn void setAllVFATsToSleepModeLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000)
- *  \brief Local callable. Sets VFATs to sleep mode
- *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number (string)
- *  \param mask VFAT mask. Default: no chips will be masked
- */
-void setAllVFATsToSleepModeLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000);
-
-/*! \fn void loadVT1Local(localArgs * la, uint32_t ohN, std::string config_file, uint32_t vt1 = 0x64)
- *  \brief Local callable version of loadVT1
- *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number
- *  \param config_file Configuration file with VT1 and trim values. Optional (could be supplied as an empty string)
- *  \param vt1. Default: 0x64, used if the config_file is not provided
- *  \return Bitmask of sync'ed VFATs
- */
-void loadVT1Local(localArgs * la, uint32_t ohN, std::string config_file, uint32_t vt1 = 0x64);
-
-/*! \fn void loadVT1(const RPCMsg *request, RPCMsg *response)
- *  \brief Sets threshold and trim range for each VFAT2 chip
- *  \param request RPC response message
- *  \param response RPC response message
- */
-void loadVT1(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void loadTRIMDACLocal(localArgs * la, uint32_t ohN, std::string config_file)
- *  \brief Local callable version of loadTRIMDAC
- *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number
- *  \param config_file Configuration file with trimming parameters
- */
-void loadTRIMDACLocal(localArgs * la, uint32_t ohN, std::string config_file);
-
-/*! \fn void loadTRIMDAC(const RPCMsg *request, RPCMsg *response)
- *  \brief Sets trimming DAC parameters for each channel of each chip
- *  \param request RPC response message
- *  \param response RPC response message
- */
-void loadTRIMDAC(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void configureVFATs(const RPCMsg *request, RPCMsg *response)
- *  \brief Configures VFAT chips (V2B only). Calls biasVFATs, loads VT1 and TRIMDAC values from the config files
- *  \param request RPC response message
- *  \param response RPC response message
- */
-void configureVFATs(const RPCMsg *request, RPCMsg *response);
-
 /*! \fn configureScanModuleLocal(localArgs * la, uint32_t ohN, uint32_t vfatN, uint32_t scanmode, bool useUltra, uint32_t mask, uint32_t ch, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep)
  *  \brief Local callable version of configureScanModule
  *
@@ -142,35 +87,12 @@ void configureScanModuleLocal(localArgs * la, uint32_t ohN, uint32_t vfatN, uint
  */
 void configureScanModule(const RPCMsg *request, RPCMsg *response);
 
-/*! \fn void printScanConfigurationLocal(localArgs * la, uint32_t ohN, bool useUltra)
- *  \brief Local callable version of printScanConfiguration
- *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number
- *  \param useUltra Set to 1 in order to use the ultra scan
- */
-void printScanConfigurationLocal(localArgs * la, uint32_t ohN, bool useUltra);
-
-/*! \fn void printScanConfiguration(const RPCMsg *request, RPCMsg *response)
- *  \brief Prints V2b FW scan module configuration
+/*! \fn void configureVFATs(const RPCMsg *request, RPCMsg *response)
+ *  \brief Configures VFAT chips (V2B only). Calls biasVFATs, loads VT1 and TRIMDAC values from the config files
  *  \param request RPC response message
  *  \param response RPC response message
  */
-void printScanConfiguration(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void startScanModuleLocal(localArgs * la, uint32_t ohN, bool useUltra)
- *  \brief Local callable version of startScanModule
- *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number
- *  \param useUltra Set to 1 in order to use the ultra scan
- */
-void startScanModuleLocal(localArgs * la, uint32_t ohN, bool useUltra);
-
-/*! \fn void startScanModule(const RPCMsg *request, RPCMsg *response)
- *  \brief Starts V2b FW scan module
- *  \param request RPC response message
- *  \param response RPC response message
- */
-void startScanModule(const RPCMsg *request, RPCMsg *response);
+void configureVFATs(const RPCMsg *request, RPCMsg *response);
 
 /*! \fn void getUltraScanResultsLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep)
  *  \brief Local callable version of getUltraScanResults
@@ -190,6 +112,98 @@ void getUltraScanResultsLocal(localArgs *la, uint32_t *outData, uint32_t ohN, ui
  */
 void getUltraScanResults(const RPCMsg *request, RPCMsg *response);
 
+/*! \fn void loadTRIMDACLocal(localArgs * la, uint32_t ohN, std::string config_file)
+ *  \brief Local callable version of loadTRIMDAC
+ *  \param la Local arguments structure
+ *  \param ohN Optohybrid optical link number
+ *  \param config_file Configuration file with trimming parameters
+ */
+void loadTRIMDACLocal(localArgs * la, uint32_t ohN, std::string config_file);
+
+/*! \fn void loadTRIMDAC(const RPCMsg *request, RPCMsg *response)
+ *  \brief Sets trimming DAC parameters for each channel of each chip
+ *  \param request RPC response message
+ *  \param response RPC response message
+ */
+void loadTRIMDAC(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void loadVT1Local(localArgs * la, uint32_t ohN, std::string config_file, uint32_t vt1 = 0x64)
+ *  \brief Local callable version of loadVT1
+ *  \param la Local arguments structure
+ *  \param ohN Optohybrid optical link number
+ *  \param config_file Configuration file with VT1 and trim values. Optional (could be supplied as an empty string)
+ *  \param vt1. Default: 0x64, used if the config_file is not provided
+ *  \return Bitmask of sync'ed VFATs
+ */
+void loadVT1Local(localArgs * la, uint32_t ohN, std::string config_file, uint32_t vt1 = 0x64);
+
+/*! \fn void loadVT1(const RPCMsg *request, RPCMsg *response)
+ *  \brief Sets threshold and trim range for each VFAT2 chip
+ *  \param request RPC response message
+ *  \param response RPC response message
+ */
+void loadVT1(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void printScanConfigurationLocal(localArgs * la, uint32_t ohN, bool useUltra)
+ *  \brief Local callable version of printScanConfiguration
+ *  \param la Local arguments structure
+ *  \param ohN Optohybrid optical link number
+ *  \param useUltra Set to 1 in order to use the ultra scan
+ */
+void printScanConfigurationLocal(localArgs * la, uint32_t ohN, bool useUltra);
+
+/*! \fn void printScanConfiguration(const RPCMsg *request, RPCMsg *response)
+ *  \brief Prints V2b FW scan module configuration
+ *  \param request RPC response message
+ *  \param response RPC response message
+ */
+void printScanConfiguration(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void setAllVFATsToRunModeLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000)
+ *  \brief Local callable. Sets VFATs to run mode
+ *  \param la Local arguments structure
+ *  \param ohN Optohybrid optical link number (string)
+ *  \param mask VFAT mask. Default: no chips will be masked
+ */
+void setAllVFATsToRunModeLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000);
+
+/*! \fn void setAllVFATsToSleepModeLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000)
+ *  \brief Local callable. Sets VFATs to sleep mode
+ *  \param la Local arguments structure
+ *  \param ohN Optohybrid optical link number (string)
+ *  \param mask VFAT mask. Default: no chips will be masked
+ */
+void setAllVFATsToSleepModeLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0xFF000000);
+
+/*! \fn void startScanModuleLocal(localArgs * la, uint32_t ohN, bool useUltra)
+ *  \brief Local callable version of startScanModule
+ *  \param la Local arguments structure
+ *  \param ohN Optohybrid optical link number
+ *  \param useUltra Set to 1 in order to use the ultra scan
+ */
+void startScanModuleLocal(localArgs * la, uint32_t ohN, bool useUltra);
+
+/*! \fn void startScanModule(const RPCMsg *request, RPCMsg *response)
+ *  \brief Starts V2b FW scan module
+ *  \param request RPC response message
+ *  \param response RPC response message
+ */
+void startScanModule(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void statusOHLocal(localArgs * la, uint32_t ohEnMask)
+ *  \brief Local callable version of statusOH
+ *  \param la Local arguments structure
+ *  \param ohEnMask Bit mask of enabled optical links
+ */
+void statusOHLocal(localArgs * la, uint32_t ohEnMask);
+
+/*! \fn void statusOH(const RPCMsg *request, RPCMsg *response)
+ *  \brief Returns a list of the most important monitoring registers of optohybrids
+ *  \param request RPC response message
+ *  \param response RPC response message
+ */
+void statusOH(const RPCMsg *request, RPCMsg *response);
+
 /*! \fn void stopCalPulse2AllChannelsLocal(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t ch_min, uint32_t ch_max)
  *  \brief Local callable version of stopCalPulse2AllChannels
  *  \param la Local arguments structure
@@ -206,19 +220,5 @@ void stopCalPulse2AllChannelsLocal(localArgs *la, uint32_t ohN, uint32_t mask, u
  *  \param response RPC response message
  */
 void stopCalPulse2AllChannels(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void statusOHLocal(localArgs * la, uint32_t ohEnMask)
- *  \brief Local callable version of statusOH
- *  \param la Local arguments structure
- *  \param ohEnMask Bit mask of enabled optical links
- */
-void statusOHLocal(localArgs * la, uint32_t ohEnMask);
-
-/*! \fn void statusOH(const RPCMsg *request, RPCMsg *response)
- *  \brief Returns a list of the most important monitoring registers of optohybrids
- *  \param request RPC response message
- *  \param response RPC response message
- */
-void statusOH(const RPCMsg *request, RPCMsg *response);
 
 #endif

--- a/include/optohybrid.h
+++ b/include/optohybrid.h
@@ -14,7 +14,7 @@
 /*! \fn void broadcastWriteLocal(localArgs * la, uint32_t ohN, std::string regName, uint32_t value, uint32_t mask = 0xFF000000)
  *  \brief Local callable version of broadcastWrite
  *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number 
+ *  \param ohN Optohybrid optical link number
  *  \param regName Register name
  *  \param value Register value to write
  *  \param mask VFAT mask. Default: no chips will be masked
@@ -22,7 +22,7 @@
  */
 void broadcastWriteLocal(localArgs * la, uint32_t ohN, std::string regName, uint32_t value, uint32_t mask = 0xFF000000);
 /*! \fn void broadcastWrite(const RPCMsg *request, RPCMsg *response)
- *  \brief Performs broadcast write a given regiser on all the VFAT chips of a given optohybrid 
+ *  \brief Performs broadcast write a given regiser on all the VFAT chips of a given optohybrid
  *  \param request RPC response message
  *  \param response RPC response message
  */
@@ -31,15 +31,16 @@ void broadcastWrite(const RPCMsg *request, RPCMsg *response);
 /*! \fn void broadcastReadLocal(localArgs * la, uint32_t ohN, std::string regName, uint32_t mask = 0xFF000000)
  *  \brief Local callable version of broadcastRead
  *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number 
+ *  \param outData pointer to the results of the broadcast read
+ *  \param ohN Optohybrid optical link number
  *  \param regName Register name
  *  \param mask VFAT mask. Default: no chips will be masked
  *  \return Bitmask of sync'ed VFATs
  */
-void broadcastReadLocal(localArgs * la, uint32_t ohN, std::string regName, uint32_t mask = 0xFF000000);
+void broadcastReadLocal(localArgs * la, uint32_t *outData, uint32_t ohN, std::string regName, uint32_t mask = 0xFF000000);
 
 /*! \fn void broadcastRead(const RPCMsg *request, RPCMsg *response)
- *  \brief Performs broadcast read of a given regiser on all the VFAT chips of a given optohybrid 
+ *  \brief Performs broadcast read of a given regiser on all the VFAT chips of a given optohybrid
  *  \param request RPC response message
  *  \param response RPC response message
  */
@@ -72,7 +73,7 @@ void setAllVFATsToSleepModeLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0
 /*! \fn void loadVT1Local(localArgs * la, uint32_t ohN, std::string config_file, uint32_t vt1 = 0x64)
  *  \brief Local callable version of loadVT1
  *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number 
+ *  \param ohN Optohybrid optical link number
  *  \param config_file Configuration file with VT1 and trim values. Optional (could be supplied as an empty string)
  *  \param vt1. Default: 0x64, used if the config_file is not provided
  *  \return Bitmask of sync'ed VFATs
@@ -80,7 +81,7 @@ void setAllVFATsToSleepModeLocal(localArgs * la, uint32_t ohN, uint32_t mask = 0
 void loadVT1Local(localArgs * la, uint32_t ohN, std::string config_file, uint32_t vt1 = 0x64);
 
 /*! \fn void loadVT1(const RPCMsg *request, RPCMsg *response)
- *  \brief Sets threshold and trim range for each VFAT2 chip 
+ *  \brief Sets threshold and trim range for each VFAT2 chip
  *  \param request RPC response message
  *  \param response RPC response message
  */
@@ -89,13 +90,13 @@ void loadVT1(const RPCMsg *request, RPCMsg *response);
 /*! \fn void loadTRIMDACLocal(localArgs * la, uint32_t ohN, std::string config_file)
  *  \brief Local callable version of loadTRIMDAC
  *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number 
+ *  \param ohN Optohybrid optical link number
  *  \param config_file Configuration file with trimming parameters
  */
 void loadTRIMDACLocal(localArgs * la, uint32_t ohN, std::string config_file);
 
 /*! \fn void loadTRIMDAC(const RPCMsg *request, RPCMsg *response)
- *  \brief Sets trimming DAC parameters for each channel of each chip 
+ *  \brief Sets trimming DAC parameters for each channel of each chip
  *  \param request RPC response message
  *  \param response RPC response message
  */
@@ -109,7 +110,7 @@ void loadTRIMDAC(const RPCMsg *request, RPCMsg *response);
 void configureVFATs(const RPCMsg *request, RPCMsg *response);
 
 /*! \fn configureScanModuleLocal(localArgs * la, uint32_t ohN, uint32_t vfatN, uint32_t scanmode, bool useUltra, uint32_t mask, uint32_t ch, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep)
- *  \brief Local callable version of configureScanModule 
+ *  \brief Local callable version of configureScanModule
  *
      *     Configure the firmware scan controller
      *      mode: 0 Threshold scan
@@ -121,7 +122,7 @@ void configureVFATs(const RPCMsg *request, RPCMsg *response);
      *            for ULTRA scan, specify the VFAT mask
  *
  *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number 
+ *  \param ohN Optohybrid optical link number
  *  \param vfatN VFAT chip position
  *  \param scammode Scan mode
  *  \param useUltra Set to 1 in order to use the ultra scan
@@ -144,7 +145,7 @@ void configureScanModule(const RPCMsg *request, RPCMsg *response);
 /*! \fn void printScanConfigurationLocal(localArgs * la, uint32_t ohN, bool useUltra)
  *  \brief Local callable version of printScanConfiguration
  *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number 
+ *  \param ohN Optohybrid optical link number
  *  \param useUltra Set to 1 in order to use the ultra scan
  */
 void printScanConfigurationLocal(localArgs * la, uint32_t ohN, bool useUltra);
@@ -159,13 +160,13 @@ void printScanConfiguration(const RPCMsg *request, RPCMsg *response);
 /*! \fn void startScanModuleLocal(localArgs * la, uint32_t ohN, bool useUltra)
  *  \brief Local callable version of startScanModule
  *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number 
+ *  \param ohN Optohybrid optical link number
  *  \param useUltra Set to 1 in order to use the ultra scan
  */
 void startScanModuleLocal(localArgs * la, uint32_t ohN, bool useUltra);
 
 /*! \fn void startScanModule(const RPCMsg *request, RPCMsg *response)
- *  \brief Starts V2b FW scan module 
+ *  \brief Starts V2b FW scan module
  *  \param request RPC response message
  *  \param response RPC response message
  */
@@ -192,7 +193,7 @@ void getUltraScanResults(const RPCMsg *request, RPCMsg *response);
 /*! \fn void stopCalPulse2AllChannelsLocal(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t ch_min, uint32_t ch_max)
  *  \brief Local callable version of stopCalPulse2AllChannels
  *  \param la Local arguments structure
- *  \param ohN Optohybrid optical link number 
+ *  \param ohN Optohybrid optical link number
  *  \param mask VFAT mask. Default: no chips will be masked
  *  \param chMin Minimal channel number
  *  \param chMax Maximal channel number

--- a/include/utils.h
+++ b/include/utils.h
@@ -56,6 +56,13 @@ std::string serialize(xhal::utils::Node n) {
  */
 uint32_t getNumNonzeroBits(uint32_t value);
 
+/*! \fn uint32_t getMask(localArgs * la, const std::string & regName)
+ *  \brief Returns the mask for a given register
+ *  \param la Local arguments structure
+ *  \param regName Register name
+ */
+uint32_t getMask(localArgs * la, const std::string & regName);
+
 /*! \fn void writeRawAddress(uint32_t address, uint32_t value, RPCMsg *response)
  *  \brief Writes a value to a raw register address. Register mask is not applied
  *  \param address Register address

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,6 +1,7 @@
 /*! \file utils.h
  *  \brief Util methods for RPC modules
  *  \author Mykhailo Dalchenko <mykhailo.dalchenko@cern.ch>
+ *  \author Brian Dorney <brian.l.dorney@cern.ch>
  */
 
 #ifndef UTILS_H

--- a/include/vfat3.h
+++ b/include/vfat3.h
@@ -10,6 +10,7 @@
 #include "utils.h"
 #include <string>
 
+
 /*! \fn uint32_t vfatSyncCheckLocal(localArgs * la, uint32_t ohN)
  *  \brief Local callable version of vfatSyncCheck
  *  \param la Local arguments structure
@@ -24,6 +25,22 @@ uint32_t vfatSyncCheckLocal(localArgs * la, uint32_t ohN);
  *  \param response RPC responce message
  */
 void vfatSyncCheck(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void configureVFAT3DacMonitorLocal(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t dacSelect)
+ *  \brief configures the VFAT3s on optohybrid ohN to use their ADCs to monitor the DAC provided by dacSelect.
+ *  \param la Local arguments structure
+ *  \param ohN Optical link
+ *  \param mask VFAT mask
+ *  \param dacSelect the monitoring selection for the VFAT3 ADC, possible values are [0,16] and [32,41].  See VFAT3 manual for details
+ */
+void configureVFAT3DacMonitorLocal(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t dacSelect);
+
+/*! \fn void configureVFAT3DacMonitor(const RPCMsg *request, RPCMsg *response)
+ *  \brief Allows the host machine to configure the VFAT3s on optohybrid ohN to use their ADCs to monitor a given DAC
+ *  \param request RPC request message
+ *  \param response RPC responce message
+ */
+void configureVFAT3DacMonitor(const RPCMsg *request, RPCMsg *response);
 
 /*! \fn void configureVFAT3sLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask)
  *  \brief Local callable version of configureVFAT3s
@@ -53,13 +70,38 @@ void configureVFAT3s(const RPCMsg *request, RPCMsg *response);
 void getChannelRegistersVFAT3Local(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t *chanRegData);
 
 /*! \fn void setChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response);
-  + *  \brief reads all vfat3 channel registers from host machine
-  + *  \param request RPC request message
-  + *  \param response RPC responce message
-  + */
+ *  \brief reads all vfat3 channel registers from host machine
+ *  \param request RPC request message
+ *  \param response RPC responce message
+ */
 void getChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response);
 
-/*! \fn void void setChannelRegistersVFAT3SimpleLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData)
+/*! \fn void readVFAT3ADCLocal(localArgs * la, uint32_t * outData, uint32_t ohN, bool useExtRefADC=false, uint32_t mask=0xFF000000)
+ *  \brief reads the ADC of all unmasked VFATs
+ *  \param la Local arguments structure
+ *  \param outData pointer to the array containing the ADC results
+ *  \param ohN Optical link
+ *  \param useExtRefADC true (false) read the ADC1 (ADC0) which uses an external (internal) reference
+ *  \param mask VFAT mask
+ */
+void readVFAT3ADCLocal(localArgs * la, uint32_t * outData, uint32_t ohN, bool useExtRefADC=false, uint32_t mask=0xFF000000);
+
+/*! \fn readVFAT3ADC(const RPCMsg *request, RPCMsg *response)
+ *  \brief Allows the hsot machine to read the ADC value from all unmasked VFATs
+ *  \param request RPC request message
+ *  \param response RPC responce message
+ */
+void readVFAT3ADC(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void readVFAT3ADCAllLinks(const RPCMsg *request, RPCMsg *response);
+ *  \brief As readVFAT3ADC(...) but for all optical links on the AMC
+ *  \details Here the RPCMsg request should have a "ohMask" word which specifies which OH's to read from, this is a 12 bit number where a 1 in the n^th bit indicates that the n^th OH should be read back.  Additionally there should be a "ohVfatMaskArray" which is an array of size 12 where each element is the standard vfatMask for OH specified by the array index.
+ *  \param request RPC request message
+ *  \param response RPC responce message
+ */
+void readVFAT3ADCAllLinks(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void setChannelRegistersVFAT3SimpleLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData)
  *  \brief writes all vfat3 channel registers from AMC
  *  \param la Local arguments structure
  *  \param ohN Optical link

--- a/include/vfat3.h
+++ b/include/vfat3.h
@@ -42,6 +42,14 @@ void configureVFAT3DacMonitorLocal(localArgs *la, uint32_t ohN, uint32_t mask, u
  */
 void configureVFAT3DacMonitor(const RPCMsg *request, RPCMsg *response);
 
+/*! \fn void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response)
+ *  \brief As configureVFAT3DacMonitor(...) but for all optical links specified in ohMask on the AMC
+ *  \details Here the RPCMsg request should have a "ohMask" word which specifies which OH's to read from, this is a 12 bit number where a 1 in the n^th bit indicates that the n^th OH should be read back.  Additionally there should be a "ohVfatMaskArray" which is an array of size 12 where each element is the standard vfatMask for OH specified by the array index.
+ *  \param request RPC request message
+ *  \param response RPC responce message
+ */
+void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response);
+
 /*! \fn void configureVFAT3sLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask)
  *  \brief Local callable version of configureVFAT3s
  *  \param la Local arguments structure
@@ -87,19 +95,19 @@ void getChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response);
 void readVFAT3ADCLocal(localArgs * la, uint32_t * outData, uint32_t ohN, bool useExtRefADC=false, uint32_t mask=0xFF000000);
 
 /*! \fn readVFAT3ADC(const RPCMsg *request, RPCMsg *response)
- *  \brief Allows the hsot machine to read the ADC value from all unmasked VFATs
+ *  \brief Allows the host machine to read the ADC value from all unmasked VFATs
  *  \param request RPC request message
  *  \param response RPC responce message
  */
 void readVFAT3ADC(const RPCMsg *request, RPCMsg *response);
 
-/*! \fn void readVFAT3ADCAllLinks(const RPCMsg *request, RPCMsg *response);
- *  \brief As readVFAT3ADC(...) but for all optical links on the AMC
+/*! \fn void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response);
+ *  \brief As readVFAT3ADC(...) but for all optical links specified in ohMask on the AMC
  *  \details Here the RPCMsg request should have a "ohMask" word which specifies which OH's to read from, this is a 12 bit number where a 1 in the n^th bit indicates that the n^th OH should be read back.  Additionally there should be a "ohVfatMaskArray" which is an array of size 12 where each element is the standard vfatMask for OH specified by the array index.
  *  \param request RPC request message
  *  \param response RPC responce message
  */
-void readVFAT3ADCAllLinks(const RPCMsg *request, RPCMsg *response);
+void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response);
 
 /*! \fn void setChannelRegistersVFAT3SimpleLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData)
  *  \brief writes all vfat3 channel registers from AMC

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -351,7 +351,7 @@ void getmonOHmain(const RPCMsg *request, RPCMsg *response)
 void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask){
     std::string strRegName, strKeyName;
 
-    for (unsigned int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
+    for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
         // If this Optohybrid is masked skip it
         if(((ohMask >> ohN) & 0x0)){
             continue;

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -400,19 +400,20 @@ void getmonOHmain(const RPCMsg *request, RPCMsg *response)
 }
 
 extern "C" {
-	const char *module_version_key = "amc v1.0.1";
-	int module_activity_color = 4;
-	void module_init(ModuleManager *modmgr) {
-		if (memsvc_open(&memsvc) != 0) {
-			LOGGER->log_message(LogManager::ERROR, stdsprintf("Unable to connect to memory service: %s", memsvc_get_last_error(memsvc)));
-			LOGGER->log_message(LogManager::ERROR, "Unable to load module");
-			return; // Do not register our functions, we depend on memsvc.
-		}
-		modmgr->register_method("amc", "getmonTTCmain", getmonTTCmain);
-		modmgr->register_method("amc", "getmonTRIGGERmain", getmonTRIGGERmain);
-		modmgr->register_method("amc", "getmonTRIGGEROHmain", getmonTRIGGEROHmain);
-		modmgr->register_method("amc", "getmonDAQmain", getmonDAQmain);
-		modmgr->register_method("amc", "getmonDAQOHmain", getmonDAQOHmain);
-		modmgr->register_method("amc", "getmonOHmain", getmonOHmain);
-	}
+    const char *module_version_key = "amc v1.0.1";
+    int module_activity_color = 4;
+    void module_init(ModuleManager *modmgr) {
+        if (memsvc_open(&memsvc) != 0) {
+            LOGGER->log_message(LogManager::ERROR, stdsprintf("Unable to connect to memory service: %s", memsvc_get_last_error(memsvc)));
+            LOGGER->log_message(LogManager::ERROR, "Unable to load module");
+            return; // Do not register our functions, we depend on memsvc.
+        }
+        modmgr->register_method("amc", "getmonTTCmain", getmonTTCmain);
+        modmgr->register_method("amc", "getmonTRIGGERmain", getmonTRIGGERmain);
+        modmgr->register_method("amc", "getmonTRIGGEROHmain", getmonTRIGGEROHmain);
+        modmgr->register_method("amc", "getmonDAQmain", getmonDAQmain);
+        modmgr->register_method("amc", "getmonDAQOHmain", getmonDAQOHmain);
+        modmgr->register_method("amc", "getmonOHmain", getmonOHmain);
+        modmgr->register_method("amc", "sbitReadOut", sbitReadOut);
+    }
 }

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -1,8 +1,10 @@
 /*! \file amc.cpp
  *  \brief AMC methods for RPC modules
  *  \author Mykhailo Dalchenko <mykhailo.dalchenko@cern.ch>
+ *  \author Brian Dorney <brian.l.dorney@cern.ch>
  */
 
+#include "amc.h"
 #include <chrono>
 #include <map>
 #include <time.h>
@@ -10,18 +12,6 @@
 #include "utils.h"
 #include <vector>
 
-/*! \fn std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acquireTime, bool *maxNetworkSizeReached)
- *  \brief reads out sbits from optohybrid ohN for a number of seconds given by acquireTime and returns them to the user.
- *  \details The SBIT Monitor stores the 8 SBITs that are sent from the OH (they are all sent at the same time and correspond to the same clock cycle). Each SBIT clusters readout from the SBIT Monitor is a 16 bit word with bits [0:10] being the sbit address and bits [12:14] being the sbit size, bits 11 and 15 are not used.
- *  \details The possible values of the SBIT Address are [0,1535].  Clusters with address less than 1536 are considered valid (e.g. there was an sbit); otherwise an invalid (no sbit) cluster is returned.  The SBIT address maps to a given trigger pad following the equation \f$sbit = addr % 64\f$.  There are 64 such trigger pads per VFAT.  Each trigger pad corresponds to two VFAT channels.  The SBIT to channel mapping follows \f$sbit=floor(chan/2)\f$.  You can determine the VFAT position of the sbit via the equation \f$vfatPos=7-int(addr/192)+int((addr%192)/64)*8\f$.
- *  \details The SBIT size represents the number of adjacent trigger pads are part of this cluster.  The SBIT address always reports the lowest trigger pad number in the cluster.  The sbit size takes values [0,7].  So an sbit cluster with address 13 and with size of 2 includes 3 trigger pads for a total of 6 vfat channels and starts at channel \f$13*2=26\f$ and continues to channel \f$(2*15)+1=31\f$.
- *  \details The output vector will always be of size N * 8 where N is the number of readouts of the SBIT Monitor.  For each readout the SBIT Monitor will be reset and then readout after 4095 clock cycles (~102.4 microseconds).  The SBIT clusters will only be added to the output vector if at least one of them was valid.  The SBIT clusters stored in the SBIT Monitor will not be over-written until a module reset is sent.  The readout will stop before acquireTime finishes if the size of the returned vector approaches the max TCP/IP size (~65000 btyes) and sets maxNetworkSize to true.
- *  \details Each element of the output vector will be a 32 bit word.  Bits [0,10] will the address of the SBIT Cluster, bits [11:13] will be the cluster size, and bits [14:26] will be the difference between the SBIT and the input L1A (if any) in clock cycles.  While the SBIT Monitor stores the difference between the SBIT and input L1A as a 32 bit number (0xFFFFFFFF) any value higher 0xFFF (12 bits) will be truncated to 0xFFF.  This matches the time between readouts of 4095 clock cycles.
- *  \param la Local arguments structure
- *  \param ohN Optical link
- *  \param acquireTime acquisition time on the wall clock in seconds
- *  \param maxNetworkSize pointer to a boolean, set to true if the returned vector reaches a byte count of 65000
- */
 std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acquireTime, bool *maxNetworkSizeReached){
     //Setup the sbit monitor
     const int nclusters = 8;
@@ -97,11 +87,6 @@ std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acq
     return storedSbits;
 } //End sbitReadOutLocal(...)
 
-/*! \fn sbitReadOut(const RPCMsg *request, RPCMsg *response)
- *  \brief readout sbits using the SBIT Monitor.  See the local callable methods documentation for details.
- *  \param request RPC response message
- *  \param response RPC response message
- */
 void sbitReadOut(const RPCMsg *request, RPCMsg *response){
     auto env = lmdb::env::create();
     env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
@@ -130,12 +115,6 @@ void sbitReadOut(const RPCMsg *request, RPCMsg *response){
     return;
 } //End sbitReadOut()
 
-/*! \fn unsigned int fw_version_check(const char* caller_name, localArgs *la)
- *  \brief Returns AMC FW version
- *  in case FW version is not 1.X or 3.X sets an error string in response
- *  \param caller_name Name of methods which called the FW version check
- *  \param la Local arguments structure
- */
 unsigned int fw_version_check(const char* caller_name, localArgs *la)
 {
     int iFWVersion = readReg(la, "GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR");
@@ -162,10 +141,6 @@ unsigned int fw_version_check(const char* caller_name, localArgs *la)
     return iFWVersion;
 }
 
-/*! \fn void getmonTTCmainLocal(localArgs * la)
- *  \brief Local version of getmonTTCmain
- *  \param la Local arguments
- */
 void getmonTTCmainLocal(localArgs * la)
 {
   LOGGER->log_message(LogManager::INFO, "Called getmonTTCmainLocal");
@@ -176,11 +151,6 @@ void getmonTTCmainLocal(localArgs * la)
   la->response->set_word("L1A_RATE",readReg(la,"GEM_AMC.TTC.L1A_RATE"));
 }
 
-/*! \fn void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of TTC monitoring registers
- *  \param request RPC request message
- *  \param response RPC response message
- */
 void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
 {
   auto env = lmdb::env::create();
@@ -195,11 +165,6 @@ void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-/*! \fn void getmonTRIGGERmainLocal(localArgs * la, int NOH)
- *  \brief Local version of getmonTRIGGERmain
- *  \param la Local arguments
- *  \param NOH Number of optohybrids in FW
- */
 void getmonTRIGGERmainLocal(localArgs * la, int NOH)
 {
   std::string t1,t2;
@@ -211,11 +176,6 @@ void getmonTRIGGERmainLocal(localArgs * la, int NOH)
   }
 }
 
-/*! \fn void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of trigger monitoring registers
- *  \param request RPC request message
- *  \param response RPC response message
- */
 void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
 {
   auto env = lmdb::env::create();
@@ -231,16 +191,6 @@ void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-/*! \fn void getmonTRIGGEROHmainLocal(localArgs * la, int NOH)
- *  \brief Local version of getmonTRIGGEROHmain
- *  * LINK{0,1}_SBIT_OVERFLOW_CNT -- this is an interesting counter to monitor from operations perspective, but is not related to the health of the link itself. Rather it shows how many times OH had too many clusters which it couldn't fit into the 8 cluster per BX bandwidth. If this counter is going up it just means that OH is seeing a very high hit occupancy, which could be due to high radiation background, or thresholds configured too low.
- *
- *  The other 3 counters reflect the health of the optical links:
- *  * LINK{0,1}_OVERFLOW_CNT and LINK{0,1}_UNDERFLOW_CNT going up indicate a clocking issue, specifically they go up when the frequency of the clock on the OH doesn't match the frequency on the CTP7. Given that CTP7 is providing the clock to OH, this in principle should not happen unless the OH is sending complete garbage and thus the clock cannot be recovered on CTP7 side, or the bit-error rate is insanely high, or the fiber is just disconnected, or OH is off. In other words, this indicates a critical problem.
- *  * LINK{0,1}_MISSED_COMMA_CNT also monitors the health of the link, but it's more sensitive, because it can go up due to isolated single bit errors. With radiation around, this might count one or two counts in a day or two. But if it starts running away, that would indicate a real problem, but in this case most likely the overflow and underflow counters would also see it.
- *  \param la Local arguments
- *  \param NOH Number of optohybrids in FW
- */
 void getmonTRIGGEROHmainLocal(localArgs * la, int NOH)
 {
   std::string t1,t2;
@@ -272,11 +222,6 @@ void getmonTRIGGEROHmainLocal(localArgs * la, int NOH)
   }
 }
 
-/*! \fn void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of trigger monitoring registers at the OH
- *  \param request RPC request message
- *  \param response RPC response message
- */
 void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
 {
   auto env = lmdb::env::create();
@@ -292,10 +237,6 @@ void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-/*! \fn void getmonDAQmainLocal(localArgs * la)
- *  \brief Local version of getmonDAQmain
- *  \param la Local arguments
- */
 void getmonDAQmainLocal(localArgs * la)
 {
   la->response->set_word("DAQ_ENABLE",readReg(la,"GEM_AMC.DAQ.CONTROL.DAQ_ENABLE"));
@@ -309,11 +250,6 @@ void getmonDAQmainLocal(localArgs * la)
   la->response->set_word("TTS_STATE",readReg(la,"GEM_AMC.DAQ.STATUS.TTS_STATE"));
 }
 
-/*! \fn void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of DAQ monitoring registers
- *  \param request RPC request message
- *  \param response RPC response message
- */
 void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
 {
   auto env = lmdb::env::create();
@@ -328,11 +264,6 @@ void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-/*! \fn void getmonDAQOHmainLocal(localArgs * la, int NOH)
- *  \brief Local version of getmonDAQOHmain
- *  \param la Local arguments
- *  \param NOH Number of optohybrids in FW
- */
 void getmonDAQOHmainLocal(localArgs * la, int NOH)
 {
   std::string t1,t2;
@@ -358,11 +289,6 @@ void getmonDAQOHmainLocal(localArgs * la, int NOH)
   }
 }
 
-/*! \fn void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of DAQ monitoring registers at the OH
- *  \param request RPC request message
- *  \param response RPC response message
- */
 void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
 {
   auto env = lmdb::env::create();
@@ -378,11 +304,6 @@ void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-/*! \fn void getmonOHmainLocal(localArgs * la, int NOH)
- *  \brief Local version of getmonOHmain
- *  \param la Local arguments
- *  \param NOH Number of optohybrids in FW
- */
 void getmonOHmainLocal(localArgs * la, int NOH)
 {
   std::string t1,t2;
@@ -411,11 +332,6 @@ void getmonOHmainLocal(localArgs * la, int NOH)
   }
 }
 
-/*! \fn void getmonOHmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of OH monitoring registers at the OH
- *  \param request RPC request message
- *  \param response RPC response message
- */
 void getmonOHmain(const RPCMsg *request, RPCMsg *response)
 {
   auto env = lmdb::env::create();
@@ -431,11 +347,6 @@ void getmonOHmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-/*! \fn uint32_t getOHVFATMaskLocal(uint32_t ohN)
- *  \brief returns the vfatMask for the optohybrid ohN
- *  \param la Local arguments structure
- *  \param ohN Optical link
- */
 uint32_t getOHVFATMaskLocal(localArgs * la, uint32_t ohN){
     uint32_t mask = 0x0;
     for(int vfatN=0; vfatN<24; ++vfatN){ //Loop over all vfats
@@ -449,11 +360,6 @@ uint32_t getOHVFATMaskLocal(localArgs * la, uint32_t ohN){
     return mask;
 } //End getOHVFATMaskLocal()
 
-/*! \fn void getOHVFATMask(const RPCMsg *request, RPCMsg *response)
- *  \brief Determines the vfatMask for a given OH, see local method for details
- *  \param request RPC request message
- *  \param response RPC response message
- */
 void getOHVFATMask(const RPCMsg *request, RPCMsg *response){
     auto env = lmdb::env::create();
     env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
@@ -473,12 +379,6 @@ void getOHVFATMask(const RPCMsg *request, RPCMsg *response){
     return;
 } //End getOHVFATMask(...)
 
-/*! \fn void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response)
- *  \brief As getOHVFATMask(...) but for all optical links specified in ohMask on the AMC
- *  \details Here the RPCMsg request should have a "ohMask" word which specifies which OH's to read from, this is a 12 bit number where a 1 in the n^th bit indicates that the n^th OH should be read back.  Additionally there should be a "ohVfatMaskArray" which is an array of size 12 where each element is the standard vfatMask for OH specified by the array index.
- *  \param request RPC request message
- *  \param response RPC responce message
- */
 void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
     auto env = lmdb::env::create();
     env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1469,6 +1469,9 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
     int nDacValues = (dacMax-dacMin+1)/dacStep;
     std::vector<uint32_t> vec_dacScanData(24*nDacValues); //Each element has bits [0:7] as the current dacValue, and bits [8:17] as the ADC read back value
 
+    //Configure the DAC Monitoring on all the VFATs
+    configureVFAT3DacMonitorLocal(la, ohN, mask, dacSelect);
+
     //Take the VFATs out of slow control only mode
     writeReg(la, "GEM_AMC.GEM_SYSTEM.VFAT3.SC_ONLY_MODE", 0x0);
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -5,15 +5,16 @@
  */
 
 #include <algorithm>
-#include <math.h>
 #include <chrono>
+#include <math.h>
+#include <map>
 #include <pthread.h>
 #include "optohybrid.h"
 #include <thread>
-#include "vfat3.h"
 #include <tuple>
 #include "utils.h"
 #include <vector>
+#include "vfat3.h"
 
 /*! \fn unsigned int fw_version_check(const char* caller_name, localArgs *la)
  *  \brief Returns AMC FW version
@@ -1539,13 +1540,13 @@ void dacScan(const RPCMsg *request, RPCMsg *response){
     return;
 } //End dacScan(...)
 
-/*! \fn void dacScanAllLinks(const RPCMsg *request, RPCMsg *response)
+/*! \fn void dacScanMultiLink(const RPCMsg *request, RPCMsg *response)
  *  \brief As dacScan(...) but for all optohybrids on the AMC
  *  \details Here the RPCMsg request should have a "ohMask" word which specifies which OH's to read from, this is a 12 bit number where a 1 in the n^th bit indicates that the n^th OH should be read back.  Additionally there should be a "ohVfatMaskArray" which is an array of size 12 where each element is the standard vfatMask for OH specified by the array index.
  *  \param request rpc request message
  *  \param response rpc responce message
  */
-void dacScanAllLinks(const RPCMsg *request, RPCMsg *response){
+void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
     auto env = lmdb::env::create();
     env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
     std::string gem_path = std::getenv("GEM_PATH");
@@ -1580,7 +1581,7 @@ void dacScanAllLinks(const RPCMsg *request, RPCMsg *response){
     response->set_word_array("dacScanResultsAll",dacScanResultsAll);
 
     return;
-} //End dacScanAllLinks(...)
+} //End dacScanMultiLink(...)
 
 /*! \fn void genChannelScan(const RPCMsg *request, RPCMsg *response)
  *  \brief Generic per channel scan. See the local callable methods documentation for details
@@ -1637,7 +1638,7 @@ extern "C" {
         modmgr->register_method("calibration_routines", "checkSbitMappingWithCalPulse", checkSbitMappingWithCalPulse);
         modmgr->register_method("calibration_routines", "checkSbitRateWithCalPulse", checkSbitRateWithCalPulse);
         modmgr->register_method("calibration_routines", "dacScan", dacScan);
-        modmgr->register_method("calibration_routines", "dacScanAllLinks", dacScanAllLinks);
+        modmgr->register_method("calibration_routines", "dacScanMultiLink", dacScanMultiLink);
         modmgr->register_method("calibration_routines", "genScan", genScan);
         modmgr->register_method("calibration_routines", "genChannelScan", genChannelScan);
         modmgr->register_method("calibration_routines", "sbitRateScan", sbitRateScan);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -926,14 +926,14 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response)
         uint32_t outDataTrigRatePerVFAT[24*(dacMax-dacMin+1)/dacStep];
         sbitRateScanParallelLocal(&la, outDataDacVal, outDataTrigRatePerVFAT, outDataTrigRate, ohN, maskOh, ch, dacMin, dacMax, dacStep, scanReg);
 
-        response->set_word_array("data_trigRatePerVFAT", outDataTrigRatePerVFAT, 24*(dacMax-dacMin+1)/dacStep);
+        response->set_word_array("outDataVFATRate", outDataTrigRatePerVFAT, 24*(dacMax-dacMin+1)/dacStep);
     }
     else{
         sbitRateScanLocal(&la, outDataDacVal, outDataTrigRate, ohN, maskOh, invertVFATPos, ch, dacMin, dacMax, dacStep, scanReg, waitTime);
     }
 
-    response->set_word_array("data_dacVal", outDataDacVal, (dacMax-dacMin+1)/dacStep);
-    response->set_word_array("data_trigRate", outDataTrigRate, (dacMax-dacMin+1)/dacStep);
+    response->set_word_array("outDataDacValue", outDataDacVal, (dacMax-dacMin+1)/dacStep);
+    response->set_word_array("outDataCTP7Rate", outDataTrigRate, (dacMax-dacMin+1)/dacStep);
 
     return;
 } //End sbitRateScan(...)

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1636,6 +1636,8 @@ extern "C" {
         }
         modmgr->register_method("calibration_routines", "checkSbitMappingWithCalPulse", checkSbitMappingWithCalPulse);
         modmgr->register_method("calibration_routines", "checkSbitRateWithCalPulse", checkSbitRateWithCalPulse);
+        modmgr->register_method("calibration_routines", "dacScan", dacScan);
+        modmgr->register_method("calibration_routines", "dacScanAllLinks", dacScanAllLinks);
         modmgr->register_method("calibration_routines", "genScan", genScan);
         modmgr->register_method("calibration_routines", "genChannelScan", genChannelScan);
         modmgr->register_method("calibration_routines", "sbitRateScan", sbitRateScan);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1371,6 +1371,16 @@ void checkSbitRateWithCalPulse(const RPCMsg *request, RPCMsg *response){
     return;
 } //End checkSbitRateWithCalPulse()
 
+/*! \fn std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSelect, uint32_t dacStep=1, uint32_t mask=0xFF000000, bool useExtRefADC=false)
+ *  \brief configures the VFAT3 DAC Monitoring and then scans the DAC and records the measured ADC values for all unmasked VFATs
+ *  \param la Local arguments structure
+ *  \param ohN Optical link
+ *  \param dacSelect Monitor Sel for ADC monitoring in VFAT3, see documentation for GBL_CFG_CTR_4 in VFAT3 manual for more details
+ *  \param dacStep step size to scan the dac in
+ *  \param mask VFAT mask to use, a value of 1 in the N^th bit indicates the N^th VFAT is masked
+ *  \param useExtRefADC if (true) false use the (externally) internally referenced ADC on the VFAT3 for monitoring
+ *  \return Returns a std::vector<uint32_t> object of size 24*(dacMax-dacMin+1)/dacStep where dacMax and dacMin are described in the VFAT3 manual.  For each element bits [7:0] are the dacValue and bits [17:8] are the ADC readback value in either current or voltage units depending on dacSelect (again, see VFAT3 manual).
+ */
 std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSelect, uint32_t dacStep=1, uint32_t mask=0xFF000000, bool useExtRefADC=false){
     //Ensure VFAT3 Hardware
     if(fw_version_check("dacScanLocal", la) < 3){
@@ -1500,6 +1510,14 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
 
     return vec_dacScanData;
 } //End dacScanLocal(...)
+
+void dacScan(const RPCMsg *request, RPCMsg *response){
+
+} //End dacScan(...)
+
+void dacScanAllLinks(const RPCMsg *request, RPCMsg *response){
+
+} //End dacScanAllLinks(...)
 
 /*! \fn void genChannelScan(const RPCMsg *request, RPCMsg *response)
  *  \brief Generic per channel scan. See the local callable methods documentation for details

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <algorithm>
+#include "amc.cpp"
 #include <chrono>
 #include <math.h>
 #include <map>
@@ -15,38 +16,6 @@
 #include "utils.h"
 #include <vector>
 #include "vfat3.h"
-
-/*! \fn unsigned int fw_version_check(const char* caller_name, localArgs *la)
- *  \brief Returns AMC FW version
- *  in case FW version is not 1.X or 3.X sets an error string in response
- *  \param caller_name Name of methods which called the FW version check
- *  \param la Local arguments structure
- */
-unsigned int fw_version_check(const char* caller_name, localArgs *la)
-{
-    int iFWVersion = readReg(la, "GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR");
-    char regBuf[200];
-    switch (iFWVersion){
-        case 1:
-        {
-            LOGGER->log_message(LogManager::INFO, "System release major is 1, v2B electronics behavior");
-            break;
-        }
-        case 3:
-        {
-            LOGGER->log_message(LogManager::INFO, "System release major is 3, v3 electronics behavior");
-            break;
-        }
-        default:
-        {
-            LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major!");
-            sprintf(regBuf,"Unexpected value for system release major!");
-            la->response->set_string("error",regBuf);
-            break;
-        }
-    }
-    return iFWVersion;
-}
 
 /*! \fn std::unordered_map<uint32_t, uint32_t> setSingleChanMask(int ohN, int vfatN, unsigned int ch, localArgs *la)
  *  \brief Unmask the channel of interest and masks all the other
@@ -165,7 +134,6 @@ void dacMonConfLocal(localArgs * la, uint32_t ohN, uint32_t ch)
             writeReg(la, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.OH_SELECT", ohN);
             if(ch>127)
             {
-                //writeReg(la, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.VFAT_CHANNEL_SELECT", 0);
                 writeReg(la, "GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.VFAT_CHANNEL_GLOBAL_OR", 0x1);
             }
             else

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <algorithm>
-#include "amc.cpp"
+#include "amc.h"
 #include <chrono>
 #include <math.h>
 #include <map>

--- a/src/optohybrid.cpp
+++ b/src/optohybrid.cpp
@@ -1,3 +1,4 @@
+#include "amc.h"
 #include "optohybrid.h"
 
 void broadcastWriteLocal(localArgs * la, uint32_t ohN, std::string regName, uint32_t value, uint32_t mask) {
@@ -106,7 +107,7 @@ void biasAllVFATsLocal(localArgs * la, uint32_t ohN, uint32_t mask) {
 }
 
 void setAllVFATsToRunModeLocal(localArgs * la, uint32_t ohN, uint32_t mask) {
-    switch(fw_version_check("setAllVFATsToRunMode", la))
+    switch(fw_version_check("setAllVFATsToRunMode", la)){
         case 3:
             broadcastWriteLocal(la, ohN, "CFG_RUN", 0x1, mask);
             break;
@@ -116,11 +117,13 @@ void setAllVFATsToRunModeLocal(localArgs * la, uint32_t ohN, uint32_t mask) {
         default:
             LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major, do nothing");
             break;
+    }
+
     return;
 }
 
 void setAllVFATsToSleepModeLocal(localArgs * la, uint32_t ohN, uint32_t mask) {
-    switch(fw_version_check("setAllVFATsToRunMode", la))
+    switch(fw_version_check("setAllVFATsToRunMode", la)){
         case 3:
             broadcastWriteLocal(la, ohN, "CFG_RUN", 0x0, mask);
             break;
@@ -130,6 +133,8 @@ void setAllVFATsToSleepModeLocal(localArgs * la, uint32_t ohN, uint32_t mask) {
         default:
             LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major, do nothing");
             break;
+    }
+
     return;
 }
 

--- a/src/optohybrid.cpp
+++ b/src/optohybrid.cpp
@@ -106,11 +106,31 @@ void biasAllVFATsLocal(localArgs * la, uint32_t ohN, uint32_t mask) {
 }
 
 void setAllVFATsToRunModeLocal(localArgs * la, uint32_t ohN, uint32_t mask) {
-  broadcastWriteLocal(la, ohN, "ContReg0", 0x37, mask);
+    switch(fw_version_check("setAllVFATsToRunMode", la))
+        case 3:
+            broadcastWriteLocal(la, ohN, "CFG_RUN", 0x1, mask);
+            break;
+        case 1:
+            broadcastWriteLocal(la, ohN, "ContReg0", 0x37, mask);
+            break;
+        default:
+            LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major, do nothing");
+            break;
+    return;
 }
 
 void setAllVFATsToSleepModeLocal(localArgs * la, uint32_t ohN, uint32_t mask) {
-  broadcastWriteLocal(la, ohN, "ContReg0", 0x36, mask);
+    switch(fw_version_check("setAllVFATsToRunMode", la))
+        case 3:
+            broadcastWriteLocal(la, ohN, "CFG_RUN", 0x0, mask);
+            break;
+        case 1:
+            broadcastWriteLocal(la, ohN, "ContReg0", 0x36, mask);
+            break;
+        default:
+            LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major, do nothing");
+            break;
+    return;
 }
 
 void loadVT1Local(localArgs * la, uint32_t ohN, std::string config_file, uint32_t vt1) {

--- a/src/optohybrid.cpp
+++ b/src/optohybrid.cpp
@@ -93,7 +93,7 @@ void broadcastRead(const RPCMsg *request, RPCMsg *response) {
   struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   uint32_t outData[24];
   broadcastReadLocal(&la, outData, ohN, regName, mask);
-  la->response->set_word_array("data", outData, 24);
+  response->set_word_array("data", outData, 24);
   rtxn.abort();
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -105,6 +105,25 @@ uint32_t getNumNonzeroBits(uint32_t value){
     return numNonzeroBits;
 } //End numNonzeroBits()
 
+uint32_t getMask(localArgs * la, const std::string & regName){
+    lmdb::val key, db_res;
+    bool found=false;
+    key.assign(regName.c_str());
+    found = la->dbi.get(la->rtxn,key,db_res);
+    uint32_t mask = 0x0;
+    if (found){
+        std::vector<std::string> tmp;
+        std::string t_db_res = std::string(db_res.data());
+        t_db_res = t_db_res.substr(0,db_res.size());
+        tmp = split(t_db_res,'|');
+        mask = stoll(tmp[2]);
+    } else {
+        LOGGER->log_message(LogManager::ERROR, stdsprintf("Key: %s is NOT found", regName.c_str()));
+        la->response->set_string("error", "Register not found");
+    }
+    return mask;
+} //End getMask(...)
+
 void writeRawAddress(uint32_t address, uint32_t value, RPCMsg *response){
   uint32_t data[1];
   data[0] = value;

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -497,6 +497,8 @@ extern "C" {
         }
         modmgr->register_method("vfat3", "configureVFAT3s", configureVFAT3s);
         modmgr->register_method("vfat3", "getChannelRegistersVFAT3", getChannelRegistersVFAT3);
+        modmgr->register_method("vfat3", "readVFAT3ADC", readVFAT3ADC);
+        modmgr->register_method("vfat3", "readVFAT3ADCAllLinks", readVFAT3ADCAllLinks);
         modmgr->register_method("vfat3", "setChannelRegistersVFAT3", setChannelRegistersVFAT3);
         modmgr->register_method("vfat3", "statusVFAT3s", statusVFAT3s);
         modmgr->register_method("vfat3", "vfatSyncCheck", vfatSyncCheck);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provides features for making DAC scans of VFAT registers using the VFAT3 ADC and also for ADC monitoring of various parameters:

- Provided new functions for DAC monitoring with VFAT3 ADC:
   - `configureVFAT3DacMonitor` for configuring ADC Monitoring of a particular VFAT3 DAC (local & non-local versions)
   - `configureVFAT3DacMonitorMultiLink` as `configureVFAT3DacMonitor` but for a set of OH's (e.g. multiple OH's for one RPC message).
   - `readVFAT3ADC` for reading ADC values on VFAT3s on a given OH (local & non-local versions).
   - `readVFAT3ADCMultiLink` as `readVFAT3ADC` but for a set of OH's.
- Provided new calibration routines  for performing a DAC scan and comparing DAC bias current/voltage with ADC reference current/voltage:
   - `dacScan` for performing DAC scan of all VFATs on a given OH (local & non-local versions).
   - `dacScanMultiLink` as `dacScan` but for multiple OH's; note scans proceed in series.  Don't think this can be parallelized due to potential overlapping transactions on AXI Bus.

Please consult relevant header files for function documentation.

Supporting changes for the above include:
- Updated order shared object libraries are built in `Makefile`.
- Created a header file `include/amc.h` which contains function definition and documentation for amc related functions (before this was all in `src/amc.cpp` with no header file).
- The `broadcastReadLocal()` now takes as input a pointer to an array which stores the readback values. 
- Alphabetised header file `include/Optohybrid.h`
- Provided a utility function for returning register mask `getMask(...)` in `include/utils.h`.
- `fw_version_check` has been moved to `amc.h/cpp`from `calibration_routines.cpp`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
The DAC's behavior will change in time as radiation dosage increases.  Need methods for monitoring this change via DAC scans.  Also need methods for monitoring VFAT3 ADC values (e.g. temperature).

 The "breaking" change is to `broadcastRead` local and non-local versions.  Before the result of the broadcast read was being set to the RPC response by the local function; the non-local version was just calling the local version.  This prohibited other local functions from acting on broadcastRead results.  Now the local function takes an array pointer as an input and the broadcast read results are stored in that array the pointer points to.  This array is set in the RPC response by the non-local function.  This enables other local functions to call `broadcastReadLocal` and act on results which was highly desireable in this PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests of the supporting changes have been done extensively by myself.  However the new the DAC monitoring and DAC scan functions have not yet been tested.  Several of our colleagues from PKU are trying to write some scripts to test these scripts and also measure ADC and readback values (e.g. temperature).

I ask that this PR be merged so they can make tests and follow-up bug fixes themselves.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
