### PR TITLE
Bug Fix: Cluster Size Set to Wrong Bit Position in Output word of sbitReadoutLocal

### DIFF
--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -72,7 +72,7 @@ std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acq
             }
 
             //Store the sbit
-            tempSBits.push_back( (l1ADelay << 14) + (clusterSize << 12) + sbitAddress);
+            tempSBits.push_back( (l1ADelay << 14) + (clusterSize << 11) + sbitAddress);
         } //End Loop over clusters
 
         if(anyValid){


### PR DESCRIPTION
cluster address is a 10 bit number, cluster size is a 3 bit number.  Cluster size was being stored in the wrong place and L1A delay was over writting the 3rd bit of cluster size.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`clusterSize` is a 3 bit number.
`sbitAddress` is a 10 bit number.

Right now clusterSize is being written incorrectly to bits [14:12] but should be bits [13:11].  This causes L1A delay to overwrite the 3rd bit of clusterSize (L1A delay starts at bit 14).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Output data word was incorrect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change is trivial.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
