### PR TITLE
Bug Fix: ohMask was being ignored in multi link functions

### DIFF
--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -490,7 +490,7 @@ void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
     uint32_t ohVfatMaskArray[12];
     for(int ohN=0; ohN<12; ++ohN){
         // If this Optohybrid is masked skip it
-        if(((ohMask >> ohN) & 0x0)){
+        if(!((ohMask >> ohN) & 0x1)){
             continue;
         }
 

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -466,8 +466,8 @@ void getOHVFATMask(const RPCMsg *request, RPCMsg *response){
 
     uint32_t ohN = request->get_word("ohN");
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-    LOGGER->log_message(LogManager::INFO, stdsprintf("Determining VFAT Mask for OH%i",ohN));
     uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
+    LOGGER->log_message(LogManager::INFO, stdsprintf("Determined VFAT Mask for OH%i to be 0x%x",ohN,vfatMask));
 
     response->set_word("vfatMask",vfatMask);
 
@@ -491,11 +491,20 @@ void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
     for(int ohN=0; ohN<12; ++ohN){
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
+            ohVfatMaskArray[ohN] = 0xffffff;
             continue;
         }
-
-        ohVfatMaskArray[ohN] = getOHVFATMaskLocal(&la, ohN);
+        else{
+            ohVfatMaskArray[ohN] = getOHVFATMaskLocal(&la, ohN);
+            LOGGER->log_message(LogManager::INFO, stdsprintf("Determined VFAT Mask for OH%i to be 0x%x",ohN,ohVfatMaskArray[ohN]));
+        }
     } //End Loop over all Optohybrids
+
+    //Debugging
+    LOGGER->log_message(LogManager::DEBUG, "All VFAT Masks found, listing:");
+    for(int ohN=0; ohN<12; ++ohN){
+        LOGGER->log_message(LogManager::DEBUG, stdsprintf("VFAT Mask for OH%i to be 0x%x",ohN,ohVfatMaskArray[ohN]));
+    }
 
     response->set_word_array("ohVfatMaskArray",ohVfatMaskArray,12);
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1535,7 +1535,7 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
     std::vector<uint32_t> dacScanResultsAll;
     for(int ohN=0; ohN<12; ++ohN){
         // If this Optohybrid is masked skip it
-        if(((ohMask >> ohN) & 0x0)){
+        if(!((ohMask >> ohN) & 0x1)){
             continue;
         }
 

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -116,7 +116,7 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     for(int ohN=0; ohN<12; ++ohN){
         // If this Optohybrid is masked skip it
-        if(((ohMask >> ohN) & 0x0)){
+        if(!((ohMask >> ohN) & 0x1)){
             continue;
         }
 
@@ -303,9 +303,11 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
     uint32_t adcDataAll[12*24] = {0};
     for(int ohN=0; ohN<12; ++ohN){
         // If this Optohybrid is masked skip it
-        if(((ohMask >> ohN) & 0x0)){
+        if(!((ohMask >> ohN) & 0x1)){
             continue;
         }
+
+        LOGGER->log_message(LogManager::INFO, stdsprintf("Reading VFAT3 ADC Values for all chips on OH%i",ohN));
 
         //Get all ADC values
         readVFAT3ADCLocal(&la, adcData, ohN, useExtRefADC, ohVfatMaskArray[ohN]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The ohMask was not being evaluated correctly and was causing all 12 links to be considered.

This patch resolves this bug.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
`ohMask` should work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked before and afterward:

```
Sep 14 15:31:04 eagle26 local0.err rpcsvc[24039]: vfat3.configureVFAT3DacMonitorMultiLink: Key: GEM_AMC.OH_LINKS.OH11.VFAT19.LINK_GOOD is NOT found
Sep 14 15:31:04 eagle26 local0.err rpcsvc[24039]: vfat3.configureVFAT3DacMonitorMultiLink: Key: GEM_AMC.OH_LINKS.OH11.VFAT19.SYNC_ERR_CNT is NOT found
Sep 14 15:31:04 eagle26 local0.err rpcsvc[24039]: vfat3.configureVFAT3DacMonitorMultiLink: Key: GEM_AMC.OH_LINKS.OH11.VFAT20.LINK_GOOD is NOT found
Sep 14 15:31:04 eagle26 local0.err rpcsvc[24039]: vfat3.configureVFAT3DacMonitorMultiLink: Key: GEM_AMC.OH_LINKS.OH11.VFAT20.SYNC_ERR_CNT is NOT found
Sep 14 15:31:04 eagle26 local0.err rpcsvc[24039]: vfat3.configureVFAT3DacMonitorMultiLink: Key: GEM_AMC.OH_LINKS.OH11.VFAT21.LINK_GOOD is NOT found
Sep 14 15:31:04 eagle26 local0.err rpcsvc[24039]: vfat3.configureVFAT3DacMonitorMultiLink: Key: GEM_AMC.OH_LINKS.OH11.VFAT21.SYNC_ERR_CNT is NOT found
Sep 14 15:31:04 eagle26 local0.err rpcsvc[24039]: vfat3.configureVFAT3DacMonitorMultiLink: Key: GEM_AMC.OH_LINKS.OH11.VFAT22.LINK_GOOD is NOT found
Sep 14 15:31:04 eagle26 local0.err rpcsvc[24039]: vfat3.configureVFAT3DacMonitorMultiLink: Key: GEM_AMC.OH_LINKS.OH11.VFAT22.SYNC_ERR_CNT is NOT found
Sep 14 15:31:04 eagle26 local0.err rpcsvc[24039]: vfat3.configureVFAT3DacMonitorMultiLink: Key: GEM_AMC.OH_LINKS.OH11.VFAT23.LINK_GOOD is NOT found
Sep 14 15:31:04 eagle26 local0.err rpcsvc[24039]: vfat3.configureVFAT3DacMonitorMultiLink: Key: GEM_AMC.OH_LINKS.OH11.VFAT23.SYNC_ERR_CNT is NOT found
...
...
Sep 14 15:59:20 eagle26 local0.notice rpcsvc[24064]: rpcsvc: Client connected from 192.168.0.180
Sep 14 15:59:21 eagle26 local0.info rpcsvc[24064]: vfat3.configureVFAT3DacMonitorMultiLink: Programming VFAT3 ADC Monitoring on OH2 for Selection 37
Sep 14 15:59:22 eagle26 local0.notice rpcsvc[24064]: rpcsvc: Client disconnected cleanly
```

Not found messages printed by `configureVFAT3DacMonitorMultiLink` due to the fact that it was looking for `OH11` in the address table.  It was given an OH mask of 0x4.  In the later case you can see only OH2 was being considered (correct). 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
