### PR TITLE
New Feature: OH Sysmon from OH FW & Splitting Monitoring Into Dedicated Files 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ TARGET_LIBS=lib/memory.so
 TARGET_LIBS+=lib/optical.so
 TARGET_LIBS+=lib/utils.so
 TARGET_LIBS+=lib/extras.so
+TARGET_LIBS+=lib/daq_monitor.so
 TARGET_LIBS+=lib/amc.so
 TARGET_LIBS+=lib/vfat3.so
 TARGET_LIBS+=lib/optohybrid.so
@@ -45,6 +46,9 @@ lib/utils.so: src/utils.cpp
 
 lib/extras.so: src/extras.cpp
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,extras.so -o $@ $< -lwisci2c -lxhal -llmdb
+
+lib/daq_monitor.so: src/daq_monitor.cpp
+	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,daq_monitor.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so
 
 lib/amc.so: src/amc.cpp
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,amc.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so

--- a/include/amc.h
+++ b/include/amc.h
@@ -2,7 +2,7 @@
  *  \brief RPC module for amc methods
  *  \author Cameron Bravo <cbravo135@gmail.com>
  *  \author Mykhailo Dalchenko <mykhailo.dalchenko@cern.ch>
- *  \author Brin Dorney <brian.l.dorney@cern.ch>
+ *  \author Brian Dorney <brian.l.dorney@cern.ch>
  */
 
 #ifndef AMC_H

--- a/include/amc.h
+++ b/include/amc.h
@@ -1,7 +1,7 @@
 /*! \file amc.h
- *  \brief RPC module for optohybrid methods
- *  \author Mykhailo Dalchenko <mykhailo.dalchenko@cern.ch>
+ *  \brief RPC module for amc methods
  *  \author Cameron Bravo <cbravo135@gmail.com>
+ *  \author Mykhailo Dalchenko <mykhailo.dalchenko@cern.ch>
  *  \author Brin Dorney <brian.l.dorney@cern.ch>
  */
 
@@ -18,129 +18,6 @@
  *  \param la Local arguments structure
  */
 unsigned int fw_version_check(const char* caller_name, localArgs *la);
-
-/*! \fn void getmonDAQmainLocal(localArgs * la)
- *  \brief Local version of getmonDAQmain
- *  \param la Local arguments
- */
-void getmonDAQmainLocal(localArgs * la);
-
-/*! \fn void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of DAQ monitoring registers
- *  \param request RPC request message
- *  \param response RPC response message
- */
-
-void getmonDAQmain(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void getmonDAQOHmainLocal(localArgs * la, int NOH, int ohMask)
- *  \brief Local version of getmonDAQOHmain
- *  \param la Local arguments
- *  \param NOH Number of optohybrids in FW
- *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
- */
-void getmonDAQOHmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
-
-/*! \fn void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of DAQ monitoring registers at the OH
- *  \param request RPC request message
- *  \param response RPC response message
- */
-void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
- *  \brief Local version of getmonOHmain
- *  \param la Local arguments
- *  \param NOH Number of optohybrids in FW
- *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
- */
-void getmonOHmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
-
-/*! \fn void getmonOHmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of OH monitoring registers at the OH
- *  \param request RPC request message
- *  \param response RPC response message
- */
-void getmonOHmain(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask)
- *  \brief Local version of getmonOHSCAmain
- *  \param la Local arguments
- *  \param NOH Number of optohybrids in FW
- *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
- */
-void getmonOHSCAmainLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
-
-/* !\fn void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads the SCA Monitoring values of all OH's (voltage and temperature)
- *  \param request RPC request message
- *  \param response RPC response message
- */
-void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff)
- *  \brief Local version of getmonOHSysmon
- *  \param la Local arguments
- *  \param NOH Number of optohybrids in FW
- *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
- */
-void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
-
-/*! \fn void getmonOHSysmon(const RPCMsg *request, RPCMsg *response)
- *  \brief reads FPGA Sysmon values of all unmasked OH's
- *  \details Reads FPGA core temperature, core voltage (1V), and I/O voltage (2.5V).  Will also check error conditions (over temperature, 1V VCCINT, and 2.5V VCCAUX), and the error conunters for those conditions.
- *  \param request RPC request message
- *  \param response RPC response message
- */
-void getmonOHSysmon(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void getmonTRIGGERmainLocal(localArgs * la, int NOH, int ohMask)
- *  \brief Local version of getmonTRIGGERmain
- *  \param la Local arguments
- *  \param NOH Number of optohybrids in FW
- *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
- */
-void getmonTRIGGERmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
-
-/*! \fn void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of trigger monitoring registers
- *  \param request RPC request message
- *  \param response RPC response message
- */
-void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void getmonTRIGGEROHmainLocal(localArgs * la, int NOH, int ohMask)
- *  \brief Local version of getmonTRIGGEROHmain
- *  * LINK{0,1}_SBIT_OVERFLOW_CNT -- this is an interesting counter to monitor from operations perspective, but is not related to the health of the link itself. Rather it shows how many times OH had too many clusters which it couldn't fit into the 8 cluster per BX bandwidth. If this counter is going up it just means that OH is seeing a very high hit occupancy, which could be due to high radiation background, or thresholds configured too low.
- *
- *  The other 3 counters reflect the health of the optical links:
- *  * LINK{0,1}_OVERFLOW_CNT and LINK{0,1}_UNDERFLOW_CNT going up indicate a clocking issue, specifically they go up when the frequency of the clock on the OH doesn't match the frequency on the CTP7. Given that CTP7 is providing the clock to OH, this in principle should not happen unless the OH is sending complete garbage and thus the clock cannot be recovered on CTP7 side, or the bit-error rate is insanely high, or the fiber is just disconnected, or OH is off. In other words, this indicates a critical problem.
- *  * LINK{0,1}_MISSED_COMMA_CNT also monitors the health of the link, but it's more sensitive, because it can go up due to isolated single bit errors. With radiation around, this might count one or two counts in a day or two. But if it starts running away, that would indicate a real problem, but in this case most likely the overflow and underflow counters would also see it.
- *  \param la Local arguments
- *  \param NOH Number of optohybrids in FW
- *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
- */
-void getmonTRIGGEROHmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
-
-/*! \fn void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of trigger monitoring registers at the OH
- *  \param request RPC request message
- *  \param response RPC response message
- */
-void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void getmonTTCmainLocal(localArgs * la)
- *  \brief Local version of getmonTTCmain
- *  \param la Local arguments
- */
-void getmonTTCmainLocal(localArgs * la);
-
-/*! \fn void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads a set of TTC monitoring registers
- *  \param request RPC request message
- *  \param response RPC response message
- */
-void getmonTTCmain(const RPCMsg *request, RPCMsg *response);
 
 /*! \fn uint32_t getOHVFATMaskLocal(uint32_t ohN)
  *  \brief returns the vfatMask for the optohybrid ohN

--- a/include/amc.h
+++ b/include/amc.h
@@ -33,12 +33,13 @@ void getmonDAQmainLocal(localArgs * la);
 
 void getmonDAQmain(const RPCMsg *request, RPCMsg *response);
 
-/*! \fn void getmonDAQOHmainLocal(localArgs * la, int NOH)
+/*! \fn void getmonDAQOHmainLocal(localArgs * la, int NOH, int ohMask)
  *  \brief Local version of getmonDAQOHmain
  *  \param la Local arguments
  *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
  */
-void getmonDAQOHmainLocal(localArgs * la, int NOH);
+void getmonDAQOHmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
 
 /*! \fn void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
  *  \brief Reads a set of DAQ monitoring registers at the OH
@@ -47,12 +48,13 @@ void getmonDAQOHmainLocal(localArgs * la, int NOH);
  */
 void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response);
 
-/*! \fn void getmonOHmainLocal(localArgs * la, int NOH)
+/*! \fn void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
  *  \brief Local version of getmonOHmain
  *  \param la Local arguments
  *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
  */
-void getmonOHmainLocal(localArgs * la, int NOH);
+void getmonOHmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
 
 /*! \fn void getmonOHmain(const RPCMsg *request, RPCMsg *response)
  *  \brief Reads a set of OH monitoring registers at the OH
@@ -60,6 +62,21 @@ void getmonOHmainLocal(localArgs * la, int NOH);
  *  \param response RPC response message
  */
 void getmonOHmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask)
+ *  \brief Local version of getmonOHSCAmain
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+ */
+void getmonOHSCAmainLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
+
+/* !\fn void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads the SCA Monitoring values of all OH's (voltage and temperature)
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response);
 
 /*! \fn void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff)
  *  \brief Local version of getmonOHSysmon
@@ -77,27 +94,13 @@ void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
  */
 void getmonOHSysmon(const RPCMsg *request, RPCMsg *response);
 
-/*! \fn void getmonOHSCAmainLocal(localArgs *la, int NOH)
- *  \brief Local version of getmonOHSCAmain
+/*! \fn void getmonTRIGGERmainLocal(localArgs * la, int NOH, int ohMask)
+ *  \brief Local version of getmonTRIGGERmain
  *  \param la Local arguments
  *  \param NOH Number of optohybrids in FW
  *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
  */
-void getmonOHSCAmainLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
-
-/* !\fn void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads the SCA Monitoring values of all OH's (voltage and temperature)
- *  \param request RPC request message
- *  \param response RPC response message
- */
-void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response);
-
-/*! \fn void getmonTRIGGERmainLocal(localArgs * la, int NOH)
- *  \brief Local version of getmonTRIGGERmain
- *  \param la Local arguments
- *  \param NOH Number of optohybrids in FW
- */
-void getmonTRIGGERmainLocal(localArgs * la, int NOH);
+void getmonTRIGGERmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
 
 /*! \fn void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
  *  \brief Reads a set of trigger monitoring registers
@@ -106,7 +109,7 @@ void getmonTRIGGERmainLocal(localArgs * la, int NOH);
  */
 void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response);
 
-/*! \fn void getmonTRIGGEROHmainLocal(localArgs * la, int NOH)
+/*! \fn void getmonTRIGGEROHmainLocal(localArgs * la, int NOH, int ohMask)
  *  \brief Local version of getmonTRIGGEROHmain
  *  * LINK{0,1}_SBIT_OVERFLOW_CNT -- this is an interesting counter to monitor from operations perspective, but is not related to the health of the link itself. Rather it shows how many times OH had too many clusters which it couldn't fit into the 8 cluster per BX bandwidth. If this counter is going up it just means that OH is seeing a very high hit occupancy, which could be due to high radiation background, or thresholds configured too low.
  *
@@ -115,8 +118,9 @@ void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response);
  *  * LINK{0,1}_MISSED_COMMA_CNT also monitors the health of the link, but it's more sensitive, because it can go up due to isolated single bit errors. With radiation around, this might count one or two counts in a day or two. But if it starts running away, that would indicate a real problem, but in this case most likely the overflow and underflow counters would also see it.
  *  \param la Local arguments
  *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
  */
-void getmonTRIGGEROHmainLocal(localArgs * la, int NOH);
+void getmonTRIGGEROHmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
 
 /*! \fn void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
  *  \brief Reads a set of trigger monitoring registers at the OH
@@ -181,6 +185,5 @@ std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acq
  *  \param response RPC response message
  */
 void sbitReadOut(const RPCMsg *request, RPCMsg *response);
-
 
 #endif

--- a/include/amc.h
+++ b/include/amc.h
@@ -61,8 +61,24 @@ void getmonOHmainLocal(localArgs * la, int NOH);
  */
 void getmonOHmain(const RPCMsg *request, RPCMsg *response);
 
-/*! \fn void getmonOHSCAmainLocal(localArgs *la, int NOH);
- *  \brief Local version of getmonOHSCAmainLocal
+/*! \fn void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff)
+ *  \brief Local version of getmonOHSysmon
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+ */
+void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
+
+/*! \fn void getmonOHSysmon(const RPCMsg *request, RPCMsg *response)
+ *  \brief reads FPGA Sysmon values of all unmasked OH's
+ *  \details Reads FPGA core temperature, core voltage (1V), and I/O voltage (2.5V).  Will also check error conditions (over temperature, 1V VCCINT, and 2.5V VCCAUX), and the error conunters for those conditions.
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonOHSysmon(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonOHSCAmainLocal(localArgs *la, int NOH)
+ *  \brief Local version of getmonOHSCAmain
  *  \param la Local arguments
  *  \param NOH Number of optohybrids in FW
  *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
@@ -70,7 +86,7 @@ void getmonOHmain(const RPCMsg *request, RPCMsg *response);
 void getmonOHSCAmainLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
 
 /* !\fn void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads the SCA Monitoring values of all OH's (voltage and temperature) including FPGA core temperature
+ *  \brief Reads the SCA Monitoring values of all OH's (voltage and temperature)
  *  \param request RPC request message
  *  \param response RPC response message
  */

--- a/include/daq_monitor.h
+++ b/include/daq_monitor.h
@@ -69,13 +69,14 @@ void getmonOHSCAmainLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
  */
 void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response);
 
-/*! \fn void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff)
+/*! \fn void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff, bool doReset=false)
  *  \brief Local version of getmonOHSysmon
  *  \param la Local arguments
  *  \param NOH Number of optohybrids in FW
  *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+ *  \param doReset reset counters CNT_OVERTEMP, CNT_VCCAUX_ALARM and CNT_VCCINT_ALARM (presently not working in FW)
  */
-void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
+void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff, bool doReset=false);
 
 /*! \fn void getmonOHSysmon(const RPCMsg *request, RPCMsg *response)
  *  \brief reads FPGA Sysmon values of all unmasked OH's

--- a/include/daq_monitor.h
+++ b/include/daq_monitor.h
@@ -1,0 +1,136 @@
+/*! \file daq_monitor.h
+ *  \brief RPC module for daq monitoring methods
+ *  \author Mykhailo Dalchenko <mykhailo.dalchenko@cern.ch>
+ *  \author Brin Dorney <brian.l.dorney@cern.ch>
+ */
+
+#ifndef DAQ_MONITOR_H
+#define DAQ_MONITOR_H
+
+#include "utils.h"
+#include <unistd.h>
+
+/*! \fn void getmonDAQmainLocal(localArgs * la)
+ *  \brief Local version of getmonDAQmain
+ *  \param la Local arguments
+ */
+void getmonDAQmainLocal(localArgs * la);
+
+/*! \fn void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of DAQ monitoring registers
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+
+void getmonDAQmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonDAQOHmainLocal(localArgs * la, int NOH, int ohMask)
+ *  \brief Local version of getmonDAQOHmain
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+ */
+void getmonDAQOHmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
+
+/*! \fn void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of DAQ monitoring registers at the OH
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
+ *  \brief Local version of getmonOHmain
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+ */
+void getmonOHmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
+
+/*! \fn void getmonOHmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of OH monitoring registers at the OH
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonOHmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask)
+ *  \brief Local version of getmonOHSCAmain
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+ */
+void getmonOHSCAmainLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
+
+/* !\fn void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads the SCA Monitoring values of all OH's (voltage and temperature)
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff)
+ *  \brief Local version of getmonOHSysmon
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+ */
+void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
+
+/*! \fn void getmonOHSysmon(const RPCMsg *request, RPCMsg *response)
+ *  \brief reads FPGA Sysmon values of all unmasked OH's
+ *  \details Reads FPGA core temperature, core voltage (1V), and I/O voltage (2.5V).  Will also check error conditions (over temperature, 1V VCCINT, and 2.5V VCCAUX), and the error conunters for those conditions.
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonOHSysmon(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonTRIGGERmainLocal(localArgs * la, int NOH, int ohMask)
+ *  \brief Local version of getmonTRIGGERmain
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+ */
+void getmonTRIGGERmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
+
+/*! \fn void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of trigger monitoring registers
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonTRIGGEROHmainLocal(localArgs * la, int NOH, int ohMask)
+ *  \brief Local version of getmonTRIGGEROHmain
+ *  * LINK{0,1}_SBIT_OVERFLOW_CNT -- this is an interesting counter to monitor from operations perspective, but is not related to the health of the link itself. Rather it shows how many times OH had too many clusters which it couldn't fit into the 8 cluster per BX bandwidth. If this counter is going up it just means that OH is seeing a very high hit occupancy, which could be due to high radiation background, or thresholds configured too low.
+ *
+ *  The other 3 counters reflect the health of the optical links:
+ *  * LINK{0,1}_OVERFLOW_CNT and LINK{0,1}_UNDERFLOW_CNT going up indicate a clocking issue, specifically they go up when the frequency of the clock on the OH doesn't match the frequency on the CTP7. Given that CTP7 is providing the clock to OH, this in principle should not happen unless the OH is sending complete garbage and thus the clock cannot be recovered on CTP7 side, or the bit-error rate is insanely high, or the fiber is just disconnected, or OH is off. In other words, this indicates a critical problem.
+ *  * LINK{0,1}_MISSED_COMMA_CNT also monitors the health of the link, but it's more sensitive, because it can go up due to isolated single bit errors. With radiation around, this might count one or two counts in a day or two. But if it starts running away, that would indicate a real problem, but in this case most likely the overflow and underflow counters would also see it.
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+ */
+void getmonTRIGGEROHmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
+
+/*! \fn void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of trigger monitoring registers at the OH
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonTTCmainLocal(localArgs * la)
+ *  \brief Local version of getmonTTCmain
+ *  \param la Local arguments
+ */
+void getmonTTCmainLocal(localArgs * la);
+
+/*! \fn void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a set of TTC monitoring registers
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonTTCmain(const RPCMsg *request, RPCMsg *response);
+
+#endif

--- a/include/daq_monitor.h
+++ b/include/daq_monitor.h
@@ -63,7 +63,7 @@ void getmonOHmain(const RPCMsg *request, RPCMsg *response);
 void getmonOHSCAmainLocal(localArgs *la, int NOH=12, int ohMask=0xfff);
 
 /* !\fn void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
- *  \brief Reads the SCA Monitoring values of all OH's (voltage and temperature)
+ *  \brief Reads the SCA Monitoring values of all OH's (voltage and temperature); these quantities are reported in ADC units
  *  \param request RPC request message
  *  \param response RPC response message
  */
@@ -80,7 +80,8 @@ void getmonOHSysmonLocal(localArgs *la, int NOH=12, int ohMask=0xfff, bool doRes
 
 /*! \fn void getmonOHSysmon(const RPCMsg *request, RPCMsg *response)
  *  \brief reads FPGA Sysmon values of all unmasked OH's
- *  \details Reads FPGA core temperature, core voltage (1V), and I/O voltage (2.5V).  Will also check error conditions (over temperature, 1V VCCINT, and 2.5V VCCAUX), and the error conunters for those conditions.
+ *  \details Reads FPGA core temperature, core voltage (1V), and I/O voltage (2.5V); these quantities are reported in ADC units.  The LSB for the core temperature correspons to 0.49 C.  The LSB for the core voltage (both 1V and 2.5V) corresponds to 2.93 mV.
+ *  \details Will also check error conditions (over temperature, 1V VCCINT, and 2.5V VCCAUX), and the error conunters for those conditions.
  *  \param request RPC request message
  *  \param response RPC response message
  */

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -1,17 +1,115 @@
 /*! \file amc.cpp
  *  \brief AMC methods for RPC modules
+ *  \author Cameron Bravo <cbravo135@gmail.com>
  *  \author Mykhailo Dalchenko <mykhailo.dalchenko@cern.ch>
  *  \author Brian Dorney <brian.l.dorney@cern.ch>
  */
 
 #include "amc.h"
 #include <chrono>
-#include <map>
 #include <string>
 #include <time.h>
 #include <thread>
 #include "utils.h"
 #include <vector>
+
+unsigned int fw_version_check(const char* caller_name, localArgs *la)
+{
+    int iFWVersion = readReg(la, "GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR");
+    char regBuf[200];
+    switch (iFWVersion){
+        case 1:
+        {
+            LOGGER->log_message(LogManager::INFO, "System release major is 1, v2B electronics behavior");
+            break;
+        }
+        case 3:
+        {
+            LOGGER->log_message(LogManager::INFO, "System release major is 3, v3 electronics behavior");
+            break;
+        }
+        default:
+        {
+            LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major!");
+            sprintf(regBuf,"Unexpected value for system release major!");
+            la->response->set_string("error",regBuf);
+            break;
+        }
+    }
+    return iFWVersion;
+}
+
+uint32_t getOHVFATMaskLocal(localArgs * la, uint32_t ohN){
+    uint32_t mask = 0x0;
+    for(int vfatN=0; vfatN<24; ++vfatN){ //Loop over all vfats
+        uint32_t syncErrCnt = readReg(la, stdsprintf("GEM_AMC.OH_LINKS.OH%i.VFAT%i.SYNC_ERR_CNT",ohN,vfatN));
+
+        if(syncErrCnt > 0x0){ //Case: nonzero sync errors, mask this vfat
+            mask = mask + (0x1 << vfatN);
+        } //End Case: nonzero sync errors, mask this vfat
+    } //End loop over all vfats
+
+    return mask;
+} //End getOHVFATMaskLocal()
+
+void getOHVFATMask(const RPCMsg *request, RPCMsg *response){
+    auto env = lmdb::env::create();
+    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+    std::string gem_path = std::getenv("GEM_PATH");
+    std::string lmdb_data_file = gem_path+"/address_table.mdb";
+    env.open(lmdb_data_file.c_str(), 0, 0664);
+    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+
+    uint32_t ohN = request->get_word("ohN");
+    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+    uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
+    LOGGER->log_message(LogManager::INFO, stdsprintf("Determined VFAT Mask for OH%i to be 0x%x",ohN,vfatMask));
+
+    response->set_word("vfatMask",vfatMask);
+
+    return;
+} //End getOHVFATMask(...)
+
+void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
+    auto env = lmdb::env::create();
+    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+    std::string gem_path = std::getenv("GEM_PATH");
+    std::string lmdb_data_file = gem_path+"/address_table.mdb";
+    env.open(lmdb_data_file.c_str(), 0, 0664);
+    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+
+    int ohMask = 0xfff;
+    if(request->get_key_exists("ohMask")){
+        ohMask = request->get_word("ohMask");
+    }
+
+    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+
+    uint32_t ohVfatMaskArray[12];
+    for(int ohN=0; ohN<12; ++ohN){
+        // If this Optohybrid is masked skip it
+        if(!((ohMask >> ohN) & 0x1)){
+            ohVfatMaskArray[ohN] = 0xffffff;
+            continue;
+        }
+        else{
+            ohVfatMaskArray[ohN] = getOHVFATMaskLocal(&la, ohN);
+            LOGGER->log_message(LogManager::INFO, stdsprintf("Determined VFAT Mask for OH%i to be 0x%x",ohN,ohVfatMaskArray[ohN]));
+        }
+    } //End Loop over all Optohybrids
+
+    //Debugging
+    LOGGER->log_message(LogManager::DEBUG, "All VFAT Masks found, listing:");
+    for(int ohN=0; ohN<12; ++ohN){
+        LOGGER->log_message(LogManager::DEBUG, stdsprintf("VFAT Mask for OH%i to be 0x%x",ohN,ohVfatMaskArray[ohN]));
+    }
+
+    response->set_word_array("ohVfatMaskArray",ohVfatMaskArray,12);
+
+    return;
+} //End getOHVFATMaskMultiLink(...)
 
 std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acquireTime, bool *maxNetworkSizeReached){
     //Setup the sbit monitor
@@ -116,532 +214,6 @@ void sbitReadOut(const RPCMsg *request, RPCMsg *response){
     return;
 } //End sbitReadOut()
 
-unsigned int fw_version_check(const char* caller_name, localArgs *la)
-{
-    int iFWVersion = readReg(la, "GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR");
-    char regBuf[200];
-    switch (iFWVersion){
-        case 1:
-        {
-            LOGGER->log_message(LogManager::INFO, "System release major is 1, v2B electronics behavior");
-            break;
-        }
-        case 3:
-        {
-            LOGGER->log_message(LogManager::INFO, "System release major is 3, v3 electronics behavior");
-            break;
-        }
-        default:
-        {
-            LOGGER->log_message(LogManager::ERROR, "Unexpected value for system release major!");
-            sprintf(regBuf,"Unexpected value for system release major!");
-            la->response->set_string("error",regBuf);
-            break;
-        }
-    }
-    return iFWVersion;
-}
-
-void getmonTTCmainLocal(localArgs * la)
-{
-  LOGGER->log_message(LogManager::INFO, "Called getmonTTCmainLocal");
-  la->response->set_word("MMCM_LOCKED",readReg(la,"GEM_AMC.TTC.STATUS.MMCM_LOCKED"));
-  la->response->set_word("TTC_SINGLE_ERROR_CNT",readReg(la,"GEM_AMC.TTC.STATUS.TTC_SINGLE_ERROR_CNT"));
-  la->response->set_word("BC0_LOCKED",readReg(la,"GEM_AMC.TTC.STATUS.BC0.LOCKED"));
-  la->response->set_word("L1A_ID",readReg(la,"GEM_AMC.TTC.L1A_ID"));
-  la->response->set_word("L1A_RATE",readReg(la,"GEM_AMC.TTC.L1A_RATE"));
-}
-
-void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
-{
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonTTCmainLocal(&la);
-  rtxn.abort();
-}
-
-void getmonTRIGGERmainLocal(localArgs * la, int NOH, int ohMask)
-{
-  std::string t1,t2;
-  la->response->set_word("OR_TRIGGER_RATE",readReg(la,"GEM_AMC.TRIGGER.STATUS.OR_TRIGGER_RATE"));
-  for (int i = 0; i < NOH; i++){
-    // If this Optohybrid is masked skip it
-    if(!((ohMask >> ohN) & 0x1)){
-      continue;
-    }
-    t1 = stdsprintf("OH%s.TRIGGER_RATE",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.TRIGGER_RATE",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-  }
-}
-
-void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
-{
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
-
-  int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
-    ohMask = request->get_word("ohMask");
-  }
-
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonTRIGGERmainLocal(&la, NOH, ohMask);
-  rtxn.abort();
-}
-
-void getmonTRIGGEROHmainLocal(localArgs * la, int NOH, int ohMask)
-{
-  std::string t1,t2;
-  for (int i = 0; i < NOH; i++){
-    // If this Optohybrid is masked skip it
-    if(!((ohMask >> ohN) & 0x1)){
-      continue;
-    }
-    t1 = stdsprintf("OH%s.LINK0_MISSED_COMMA_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_MISSED_COMMA_CNT",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK1_MISSED_COMMA_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_MISSED_COMMA_CNT",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK0_OVERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_OVERFLOW_CNT",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK1_OVERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_OVERFLOW_CNT",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK0_UNDERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_UNDERFLOW_CNT",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK1_UNDERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_UNDERFLOW_CNT",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK0_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK1_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-  }
-}
-
-void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
-{
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
-
-  int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
-    ohMask = request->get_word("ohMask");
-  }
-
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonTRIGGEROHmainLocal(&la, NOH, ohMask);
-  rtxn.abort();
-}
-
-void getmonDAQmainLocal(localArgs * la)
-{
-  la->response->set_word("DAQ_ENABLE",readReg(la,"GEM_AMC.DAQ.CONTROL.DAQ_ENABLE"));
-  la->response->set_word("DAQ_LINK_READY",readReg(la,"GEM_AMC.DAQ.STATUS.DAQ_LINK_RDY"));
-  la->response->set_word("DAQ_LINK_AFULL",readReg(la,"GEM_AMC.DAQ.STATUS.DAQ_LINK_AFULL"));
-  la->response->set_word("DAQ_OFIFO_HAD_OFLOW",readReg(la,"GEM_AMC.DAQ.STATUS.DAQ_OUTPUT_FIFO_HAD_OVERFLOW"));
-  la->response->set_word("L1A_FIFO_HAD_OFLOW",readReg(la,"GEM_AMC.DAQ.STATUS.L1A_FIFO_HAD_OVERFLOW"));
-  la->response->set_word("L1A_FIFO_DATA_COUNT",readReg(la,"GEM_AMC.DAQ.EXT_STATUS.L1A_FIFO_DATA_CNT"));
-  la->response->set_word("DAQ_FIFO_DATA_COUNT",readReg(la,"GEM_AMC.DAQ.EXT_STATUS.DAQ_FIFO_DATA_CNT"));
-  la->response->set_word("EVENT_SENT",readReg(la,"GEM_AMC.DAQ.EXT_STATUS.EVT_SENT"));
-  la->response->set_word("TTS_STATE",readReg(la,"GEM_AMC.DAQ.STATUS.TTS_STATE"));
-}
-
-void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
-{
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonDAQmainLocal(&la);
-  rtxn.abort();
-}
-
-void getmonDAQOHmainLocal(localArgs * la, int NOH, int ohMask)
-{
-  std::string t1,t2;
-  for (int i = 0; i < NOH; i++){
-    // If this Optohybrid is masked skip it
-    if(!((ohMask >> ohN) & 0x1)){
-      continue;
-    }
-    t1 = stdsprintf("OH%s.STATUS.EVT_SIZE_ERR",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.STATUS.EVENT_FIFO_HAD_OFLOW",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.STATUS.INPUT_FIFO_HAD_OFLOW",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.STATUS.INPUT_FIFO_HAD_UFLOW",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.STATUS.VFAT_TOO_MANY",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.STATUS.VFAT_NO_MARKER",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
-    la->response->set_word(t1,readReg(la,t2));
-  }
-}
-
-void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
-{
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
-
-  int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
-    ohMask = request->get_word("ohMask");
-  }
-
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonDAQOHmainLocal(&la, NOH, ohMask);
-  rtxn.abort();
-}
-
-void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
-{
-  std::string t1,t2;
-  for (int i = 0; i < NOH; i++){
-    // If this Optohybrid is masked skip it
-    if(!((ohMask >> ohN) & 0x1)){
-      continue;
-    }
-    t1 = stdsprintf("OH%s.FW_VERSION",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.OH.OH%s.STATUS.FW.VERSION",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.EVENT_COUNTER",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.EVN",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.EVENT_RATE",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.EVT_RATE",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.GTX.TRK_ERR",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GTX_LINK.TRK_ERR",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.GTX.TRG_ERR",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GTX_LINK.TRG_ERR",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.GBT.TRK_ERR",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GBT_LINK.TRK_ERR",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.CORR_VFAT_BLK_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.CORRUPT_VFAT_BLK_CNT",std::to_string(i).c_str());
-    la->response->set_word(t1,readReg(la,t2));
-  }
-}
-
-void getmonOHmain(const RPCMsg *request, RPCMsg *response)
-{
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
-
-  int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
-    ohMask = request->get_word("ohMask");
-  }
-
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonOHmainLocal(&la, NOH, ohMask);
-  rtxn.abort();
-}
-
-void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask){
-    std::string strRegName, strKeyName;
-
-    for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
-        // If this Optohybrid is masked skip it
-        if(!((ohMask >> ohN) & 0x1)){
-            continue;
-        }
-
-        //Log Message
-        LOGGER->log_message(LogManager::INFO, stdsprintf("Reading SCA Monitoring Values for OH%i",ohN));
-
-        //SCA Temperature
-        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.SCA_TEMP",ohN);
-        strKeyName = stdsprintf("OH%i.SCA_TEMP",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegName));
-
-        //OH Temperature Sensors
-        for(int tempVal=1; tempVal <= 9; ++tempVal){ //Loop over optohybrid temperatures sensosrs
-            strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.BOARD_TEMP%i",ohN,tempVal);
-            strKeyName = stdsprintf("OH%i.BOARD_TEMP%i",ohN,tempVal);
-            la->response->set_word(strKeyName, readReg(la, strRegName));
-        } //End Loop over optohybrid temeprature sensors
-
-        //Voltage Monitor - AVCCN
-        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.AVCCN",ohN);
-        strKeyName = stdsprintf("OH%i.AVCCN",ohN);
-        la->response->set_word(strKeyName, readReg(la, strRegName));
-
-        //Voltage Monitor - AVTTN
-        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.AVTTN",ohN);
-        strKeyName = stdsprintf("OH%i.AVTTN",ohN);
-        la->response->set_word(strKeyName, readReg(la, strRegName));
-
-        //Voltage Monitor - 1V0_INT
-        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.1V0_INT",ohN);
-        strKeyName = stdsprintf("OH%i.1V0_INT",ohN);
-        la->response->set_word(strKeyName, readReg(la, strRegName));
-
-        //Voltage Monitor - 1V8F
-        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.1V8F",ohN);
-        strKeyName = stdsprintf("OH%i.1V8F",ohN);
-        la->response->set_word(strKeyName, readReg(la, strRegName));
-
-        //Voltage Monitor - 1V5
-        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.1V5",ohN);
-        strKeyName = stdsprintf("OH%i.1V5",ohN);
-        la->response->set_word(strKeyName, readReg(la, strRegName));
-
-        //Voltage Monitor - 2V5_IO
-        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.2V5_IO",ohN);
-        strKeyName = stdsprintf("OH%i.2V5_IO",ohN);
-        la->response->set_word(strKeyName, readReg(la, strRegName));
-
-        //Voltage Monitor - 3V0
-        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.3V0",ohN);
-        strKeyName = stdsprintf("OH%i.3V0",ohN);
-        la->response->set_word(strKeyName, readReg(la, strRegName));
-
-        //Voltage Monitor - 1V8
-        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.1V8",ohN);
-        strKeyName = stdsprintf("OH%i.1V8",ohN);
-        la->response->set_word(strKeyName, readReg(la, strRegName));
-
-        //Voltage Monitor - VTRX_RSSI2
-        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.VTRX_RSSI2",ohN);
-        strKeyName = stdsprintf("OH%i.VTRX_RSSI2",ohN);
-        la->response->set_word(strKeyName, readReg(la, strRegName));
-
-        //Voltage Monitor - VTRX_RSSI1
-        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.VTRX_RSSI1",ohN);
-        strKeyName = stdsprintf("OH%i.VTRX_RSSI1",ohN);
-        la->response->set_word(strKeyName, readReg(la, strRegName));
-    } //End Loop over all optohybrids
-
-    return;
-} //End getmonOHSCAmainLocal(...)
-
-void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
-{
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
-
-  int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
-    ohMask = request->get_word("ohMask");
-  }
-
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonOHSCAmainLocal(&la, NOH, ohMask);
-  rtxn.abort();
-}
-
-void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask){
-    std::string strKeyName;
-    std::string strRegBase;
-
-    for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
-        // If this Optohybrid is masked skip it
-        if(!((ohMask >> ohN) & 0x1)){
-            continue;
-        }
-
-        //Set regBase
-        strRegBase = stdsprintf("GEM_AMC.OH.OH%i.FPGA.ADC.CTRL.",ohN);
-
-        //Log Message
-        LOGGER->log_message(LogManager::INFO, stdsprintf("Reading Sysmon Values for OH%i",ohN));
-
-        //Issue reset??
-        //writeReg(la, strRegBase+"RESET", 0x1);
-
-        //Read Alarm conditions & counters - OVERTEMP
-        strKeyName = stdsprintf("OH%i.OVERTEMP",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "OVERTEMP"));
-
-        strKeyName = stdsprintf("OH%i.CNT_OVERTEMP",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_OVERTEMP"));
-
-        //Read Alarm conditions & counters - VCCAUX_ALARM
-        strKeyName = stdsprintf("OH%i.VCCAUX_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCAUX_ALARM"));
-
-        strKeyName = stdsprintf("OH%i.CNT_VCCAUX_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCAUX_ALARM"));
-
-        //Read Alarm conditions & counters - VCCINT_ALARM
-        strKeyName = stdsprintf("OH%i.VCCINT_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCINT_ALARM"));
-
-        strKeyName = stdsprintf("OH%i.CNT_VCCINT_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCINT_ALARM"));
-
-        //Enable Sysmon ADC Read
-        writeReg(la, strRegBase + "ENABLE", 0x1);
-
-        //Read Sysmon Values - Core Temperature
-        writeReg(la, strRegBase + "ADR_IN", 0x0);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_TEMP");
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
-
-        //Read Sysmon Values - Core Voltage
-        writeReg(la, strRegBase + "ADR_IN", 0x1);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_1V0");
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
-
-        //Read Sysmon Values - I/O Voltage
-        writeReg(la, strRegBase + "ADR_IN", 0x2);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_2V5_IO");
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
-
-        //Disable Sysmon ADC Read
-        writeReg(la, strRegBase + "ENABLE", 0x0);
-    } //End Loop over all optohybrids
-} //End getmonOHSysmonLocal()
-
-void getmonOHSysmon(const RPCMsg *request, RPCMsg *response){
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
-
-  int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
-    ohMask = request->get_word("ohMask");
-  }
-
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonOHSysmonLocal(&la, NOH, ohMask);
-  rtxn.abort();
-} //End getmonOHSysmon()
-
-uint32_t getOHVFATMaskLocal(localArgs * la, uint32_t ohN){
-    uint32_t mask = 0x0;
-    for(int vfatN=0; vfatN<24; ++vfatN){ //Loop over all vfats
-        uint32_t syncErrCnt = readReg(la, stdsprintf("GEM_AMC.OH_LINKS.OH%i.VFAT%i.SYNC_ERR_CNT",ohN,vfatN));
-
-        if(syncErrCnt > 0x0){ //Case: nonzero sync errors, mask this vfat
-            mask = mask + (0x1 << vfatN);
-        } //End Case: nonzero sync errors, mask this vfat
-    } //End loop over all vfats
-
-    return mask;
-} //End getOHVFATMaskLocal()
-
-void getOHVFATMask(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
-    uint32_t ohN = request->get_word("ohN");
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-    uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
-    LOGGER->log_message(LogManager::INFO, stdsprintf("Determined VFAT Mask for OH%i to be 0x%x",ohN,vfatMask));
-
-    response->set_word("vfatMask",vfatMask);
-
-    return;
-} //End getOHVFATMask(...)
-
-void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
-    int ohMask = 0xfff;
-    if(request->get_key_exists("ohMask")){
-        ohMask = request->get_word("ohMask");
-    }
-
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-
-    uint32_t ohVfatMaskArray[12];
-    for(int ohN=0; ohN<12; ++ohN){
-        // If this Optohybrid is masked skip it
-        if(!((ohMask >> ohN) & 0x1)){
-            ohVfatMaskArray[ohN] = 0xffffff;
-            continue;
-        }
-        else{
-            ohVfatMaskArray[ohN] = getOHVFATMaskLocal(&la, ohN);
-            LOGGER->log_message(LogManager::INFO, stdsprintf("Determined VFAT Mask for OH%i to be 0x%x",ohN,ohVfatMaskArray[ohN]));
-        }
-    } //End Loop over all Optohybrids
-
-    //Debugging
-    LOGGER->log_message(LogManager::DEBUG, "All VFAT Masks found, listing:");
-    for(int ohN=0; ohN<12; ++ohN){
-        LOGGER->log_message(LogManager::DEBUG, stdsprintf("VFAT Mask for OH%i to be 0x%x",ohN,ohVfatMaskArray[ohN]));
-    }
-
-    response->set_word_array("ohVfatMaskArray",ohVfatMaskArray,12);
-
-    return;
-} //End getOHVFATMaskMultiLink(...)
-
 extern "C" {
     const char *module_version_key = "amc v1.0.1";
     int module_activity_color = 4;
@@ -651,14 +223,6 @@ extern "C" {
             LOGGER->log_message(LogManager::ERROR, "Unable to load module");
             return; // Do not register our functions, we depend on memsvc.
         }
-        modmgr->register_method("amc", "getmonTTCmain", getmonTTCmain);
-        modmgr->register_method("amc", "getmonTRIGGERmain", getmonTRIGGERmain);
-        modmgr->register_method("amc", "getmonTRIGGEROHmain", getmonTRIGGEROHmain);
-        modmgr->register_method("amc", "getmonDAQmain", getmonDAQmain);
-        modmgr->register_method("amc", "getmonDAQOHmain", getmonDAQOHmain);
-        modmgr->register_method("amc", "getmonOHmain", getmonOHmain);
-        modmgr->register_method("amc", "getmonOHSCAmain", getmonOHSCAmain);
-        modmgr->register_method("amc", "getmonOHSysmon", getmonOHSysmon);
         modmgr->register_method("amc", "getOHVFATMask", getOHVFATMask);
         modmgr->register_method("amc", "getOHVFATMaskMultiLink", getOHVFATMaskMultiLink);
         modmgr->register_method("amc", "sbitReadOut", sbitReadOut);

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -166,11 +166,15 @@ void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-void getmonTRIGGERmainLocal(localArgs * la, int NOH)
+void getmonTRIGGERmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
   la->response->set_word("OR_TRIGGER_RATE",readReg(la,"GEM_AMC.TRIGGER.STATUS.OR_TRIGGER_RATE"));
   for (int i = 0; i < NOH; i++){
+    // If this Optohybrid is masked skip it
+    if(!((ohMask >> ohN) & 0x1)){
+      continue;
+    }
     t1 = stdsprintf("OH%s.TRIGGER_RATE",std::to_string(i).c_str());
     t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.TRIGGER_RATE",std::to_string(i).c_str());
     la->response->set_word(t1,readReg(la,t2));
@@ -187,15 +191,25 @@ void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
   auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
   auto dbi = lmdb::dbi::open(rtxn, nullptr);
   int NOH = request->get_word("NOH");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
   struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonTRIGGERmainLocal(&la, NOH);
+  getmonTRIGGERmainLocal(&la, NOH, ohMask);
   rtxn.abort();
 }
 
-void getmonTRIGGEROHmainLocal(localArgs * la, int NOH)
+void getmonTRIGGEROHmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
   for (int i = 0; i < NOH; i++){
+    // If this Optohybrid is masked skip it
+    if(!((ohMask >> ohN) & 0x1)){
+      continue;
+    }
     t1 = stdsprintf("OH%s.LINK0_MISSED_COMMA_CNT",std::to_string(i).c_str());
     t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_MISSED_COMMA_CNT",std::to_string(i).c_str());
     la->response->set_word(t1,readReg(la,t2));
@@ -233,8 +247,14 @@ void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
   auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
   auto dbi = lmdb::dbi::open(rtxn, nullptr);
   int NOH = request->get_word("NOH");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
   struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonTRIGGEROHmainLocal(&la, NOH);
+  getmonTRIGGEROHmainLocal(&la, NOH, ohMask);
   rtxn.abort();
 }
 
@@ -265,10 +285,14 @@ void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-void getmonDAQOHmainLocal(localArgs * la, int NOH)
+void getmonDAQOHmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
   for (int i = 0; i < NOH; i++){
+    // If this Optohybrid is masked skip it
+    if(!((ohMask >> ohN) & 0x1)){
+      continue;
+    }
     t1 = stdsprintf("OH%s.STATUS.EVT_SIZE_ERR",std::to_string(i).c_str());
     t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
     la->response->set_word(t1,readReg(la,t2));
@@ -300,15 +324,25 @@ void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
   auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
   auto dbi = lmdb::dbi::open(rtxn, nullptr);
   int NOH = request->get_word("NOH");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
   struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonDAQOHmainLocal(&la, NOH);
+  getmonDAQOHmainLocal(&la, NOH, ohMask);
   rtxn.abort();
 }
 
-void getmonOHmainLocal(localArgs * la, int NOH)
+void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
   for (int i = 0; i < NOH; i++){
+    // If this Optohybrid is masked skip it
+    if(!((ohMask >> ohN) & 0x1)){
+      continue;
+    }
     t1 = stdsprintf("OH%s.FW_VERSION",std::to_string(i).c_str());
     t2 = stdsprintf("GEM_AMC.OH.OH%s.STATUS.FW.VERSION",std::to_string(i).c_str());
     la->response->set_word(t1,readReg(la,t2));
@@ -343,88 +377,16 @@ void getmonOHmain(const RPCMsg *request, RPCMsg *response)
   auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
   auto dbi = lmdb::dbi::open(rtxn, nullptr);
   int NOH = request->get_word("NOH");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
   struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonOHmainLocal(&la, NOH);
+  getmonOHmainLocal(&la, NOH, ohMask);
   rtxn.abort();
 }
-
-void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask){
-    std::string strKeyName;
-    std::string strRegBase;
-
-    for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
-        // If this Optohybrid is masked skip it
-        if(!((ohMask >> ohN) & 0x1)){
-            continue;
-        }
-
-        //Set regBase
-        strRegBase = stdsprintf("GEM_AMC.OH.OH%i.FPGA.ADC.CTRL.",ohN);
-
-        //Log Message
-        LOGGER->log_message(LogManager::INFO, stdsprintf("Reading Sysmon Values for OH%i",ohN));
-
-        //Issue reset??
-        //writeReg(la, strRegBase+"RESET", 0x1);
-
-        //Read Alarm conditions & counters - OVERTEMP
-        strKeyName = stdsprintf("OH%i.OVERTEMP",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "OVERTEMP"));
-
-        strKeyName = stdsprintf("OH%i.CNT_OVERTEMP",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_OVERTEMP"));
-
-        //Read Alarm conditions & counters - VCCAUX_ALARM
-        strKeyName = stdsprintf("OH%i.VCCAUX_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCAUX_ALARM"));
-
-        strKeyName = stdsprintf("OH%i.CNT_VCCAUX_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCAUX_ALARM"));
-
-        //Read Alarm conditions & counters - VCCINT_ALARM
-        strKeyName = stdsprintf("OH%i.VCCINT_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCINT_ALARM"));
-
-        strKeyName = stdsprintf("OH%i.CNT_VCCINT_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCINT_ALARM"));
-
-        //Enable Sysmon ADC Read
-        writeReg(la, strRegBase + "ENABLE", 0x1);
-
-        //Read Sysmon Values - Core Temperature
-        writeReg(la, strRegBase + "ADR_IN", 0x0);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_TEMP");
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
-
-        //Read Sysmon Values - Core Voltage
-        writeReg(la, strRegBase + "ADR_IN", 0x1);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_1V0");
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
-
-        //Read Sysmon Values - I/O Voltage
-        writeReg(la, strRegBase + "ADR_IN", 0x2);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_2V5_IO");
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
-
-        //Disable Sysmon ADC Read
-        writeReg(la, strRegBase + "ENABLE", 0x0);
-    } //End Loop over all optohybrids
-} //End getmonOHSysmonLocal()
-
-void getmonOHSysmon(const RPCMsg *request, RPCMsg *response){
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
-  int ohMask = request->get_word("ohMask");
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonOHSysmonLocal(&la, NOH, ohMask);
-  rtxn.abort();
-} //End getmonOHSysmon()
 
 void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask){
     std::string strRegName, strKeyName;
@@ -514,11 +476,99 @@ void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
   auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
   auto dbi = lmdb::dbi::open(rtxn, nullptr);
   int NOH = request->get_word("NOH");
-  int ohMask = request->get_word("ohMask");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
   struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   getmonOHSCAmainLocal(&la, NOH, ohMask);
   rtxn.abort();
 }
+
+void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask){
+    std::string strKeyName;
+    std::string strRegBase;
+
+    for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
+        // If this Optohybrid is masked skip it
+        if(!((ohMask >> ohN) & 0x1)){
+            continue;
+        }
+
+        //Set regBase
+        strRegBase = stdsprintf("GEM_AMC.OH.OH%i.FPGA.ADC.CTRL.",ohN);
+
+        //Log Message
+        LOGGER->log_message(LogManager::INFO, stdsprintf("Reading Sysmon Values for OH%i",ohN));
+
+        //Issue reset??
+        //writeReg(la, strRegBase+"RESET", 0x1);
+
+        //Read Alarm conditions & counters - OVERTEMP
+        strKeyName = stdsprintf("OH%i.OVERTEMP",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "OVERTEMP"));
+
+        strKeyName = stdsprintf("OH%i.CNT_OVERTEMP",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_OVERTEMP"));
+
+        //Read Alarm conditions & counters - VCCAUX_ALARM
+        strKeyName = stdsprintf("OH%i.VCCAUX_ALARM",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCAUX_ALARM"));
+
+        strKeyName = stdsprintf("OH%i.CNT_VCCAUX_ALARM",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCAUX_ALARM"));
+
+        //Read Alarm conditions & counters - VCCINT_ALARM
+        strKeyName = stdsprintf("OH%i.VCCINT_ALARM",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCINT_ALARM"));
+
+        strKeyName = stdsprintf("OH%i.CNT_VCCINT_ALARM",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCINT_ALARM"));
+
+        //Enable Sysmon ADC Read
+        writeReg(la, strRegBase + "ENABLE", 0x1);
+
+        //Read Sysmon Values - Core Temperature
+        writeReg(la, strRegBase + "ADR_IN", 0x0);
+        strKeyName = stdsprintf("OH%i.FPGA_CORE_TEMP");
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
+
+        //Read Sysmon Values - Core Voltage
+        writeReg(la, strRegBase + "ADR_IN", 0x1);
+        strKeyName = stdsprintf("OH%i.FPGA_CORE_1V0");
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
+
+        //Read Sysmon Values - I/O Voltage
+        writeReg(la, strRegBase + "ADR_IN", 0x2);
+        strKeyName = stdsprintf("OH%i.FPGA_CORE_2V5_IO");
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
+
+        //Disable Sysmon ADC Read
+        writeReg(la, strRegBase + "ENABLE", 0x0);
+    } //End Loop over all optohybrids
+} //End getmonOHSysmonLocal()
+
+void getmonOHSysmon(const RPCMsg *request, RPCMsg *response){
+  auto env = lmdb::env::create();
+  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+  std::string gem_path = std::getenv("GEM_PATH");
+  std::string lmdb_data_file = gem_path+"/address_table.mdb";
+  env.open(lmdb_data_file.c_str(), 0, 0664);
+  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  int NOH = request->get_word("NOH");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  getmonOHSysmonLocal(&la, NOH, ohMask);
+  rtxn.abort();
+} //End getmonOHSysmon()
 
 uint32_t getOHVFATMaskLocal(localArgs * la, uint32_t ohN){
     uint32_t mask = 0x0;
@@ -561,7 +611,10 @@ void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
     auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
     auto dbi = lmdb::dbi::open(rtxn, nullptr);
 
-    uint32_t ohMask = request->get_word("ohMask");
+    int ohMask = 0xfff;
+    if(request->get_key_exists("ohMask")){
+        ohMask = request->get_word("ohMask");
+    }
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
 
@@ -605,6 +658,7 @@ extern "C" {
         modmgr->register_method("amc", "getmonDAQOHmain", getmonDAQOHmain);
         modmgr->register_method("amc", "getmonOHmain", getmonOHmain);
         modmgr->register_method("amc", "getmonOHSCAmain", getmonOHSCAmain);
+        modmgr->register_method("amc", "getmonOHSysmon", getmonOHSysmon);
         modmgr->register_method("amc", "getOHVFATMask", getOHVFATMask);
         modmgr->register_method("amc", "getOHVFATMaskMultiLink", getOHVFATMaskMultiLink);
         modmgr->register_method("amc", "sbitReadOut", sbitReadOut);

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -348,12 +348,37 @@ void getmonOHmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
+void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask){
+    std::string strRegName, strKeyName;
+
+    for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
+        // If this Optohybrid is masked skip it
+        if(!((ohMask >> ohN) & 0x1)){
+            continue;
+        }
+} //End getmonOHSysmonLocal()
+
+void getmonOHSysmon(const RPCMsg *request, RPCMsg *response){
+  auto env = lmdb::env::create();
+  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+  std::string gem_path = std::getenv("GEM_PATH");
+  std::string lmdb_data_file = gem_path+"/address_table.mdb";
+  env.open(lmdb_data_file.c_str(), 0, 0664);
+  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  int NOH = request->get_word("NOH");
+  int ohMask = request->get_word("ohMask");
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  getmonOHSysmonLocal(&la, NOH, ohMask);
+  rtxn.abort();
+} //End getmonOHSysmon()
+
 void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask){
     std::string strRegName, strKeyName;
 
     for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
         // If this Optohybrid is masked skip it
-        if(((ohMask >> ohN) & 0x0)){
+        if(!((ohMask >> ohN) & 0x1)){
             continue;
         }
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1511,7 +1511,7 @@ void dacScan(const RPCMsg *request, RPCMsg *response){
 /*! \fn void dacScanMultiLink(const RPCMsg *request, RPCMsg *response)
  *  \brief As dacScan(...) but for all optohybrids on the AMC
  *  \details Here the RPCMsg request should have a "ohMask" word which specifies which OH's to read from, this is a 12 bit number where a 1 in the n^th bit indicates that the n^th OH should be read back.
- :  \param request rpc request message
+ *  \param request rpc request message
  *  \param response rpc responce message
  */
 void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1538,7 +1538,7 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
         }
 
         //Get vfatmask for this OH
-        uint32_t vfatMask = getOHVFATMaskLocal(la, ohN);
+        uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
 
         //Get dac scan results for this optohybrid
         std::vector<uint32_t> dacScanResults = dacScanLocal(&la, ohN, dacSelect, dacStep, vfatMask, useExtRefADC);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1510,8 +1510,8 @@ void dacScan(const RPCMsg *request, RPCMsg *response){
 
 /*! \fn void dacScanMultiLink(const RPCMsg *request, RPCMsg *response)
  *  \brief As dacScan(...) but for all optohybrids on the AMC
- *  \details Here the RPCMsg request should have a "ohMask" word which specifies which OH's to read from, this is a 12 bit number where a 1 in the n^th bit indicates that the n^th OH should be read back.  Additionally there should be a "ohVfatMaskArray" which is an array of size 12 where each element is the standard vfatMask for OH specified by the array index.
- *  \param request rpc request message
+ *  \details Here the RPCMsg request should have a "ohMask" word which specifies which OH's to read from, this is a 12 bit number where a 1 in the n^th bit indicates that the n^th OH should be read back.
+ :  \param request rpc request message
  *  \param response rpc responce message
  */
 void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
@@ -1526,8 +1526,6 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
     uint32_t ohMask = request->get_word("ohMask");
     uint32_t dacSelect = request->get_word("dacSelect");
     uint32_t dacStep = request->get_word("dacStep");
-    uint32_t ohVfatMaskArray[12];
-    request->get_word_array("ohVfatMaskArray",ohVfatMaskArray);
     bool useExtRefADC = request->get_word("useExtRefADC");
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
@@ -1539,8 +1537,11 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
             continue;
         }
 
+        //Get vfatmask for this OH
+        uint32_t vfatMask = getOHVFATMaskLocal(la, ohN);
+
         //Get dac scan results for this optohybrid
-        std::vector<uint32_t> dacScanResults = dacScanLocal(&la, ohN, dacSelect, dacStep, ohVfatMaskArray[ohN], useExtRefADC);
+        std::vector<uint32_t> dacScanResults = dacScanLocal(&la, ohN, dacSelect, dacStep, vfatMask, useExtRefADC);
 
         //Copy the results into the final container
         std::copy(dacScanResults.begin(), dacScanResults.end(), dacScanResultsAll.end());

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -371,6 +371,7 @@ void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask, bool doReset){
 
         //Issue reset??
         if(doReset){
+            LOGGER->log_message(LogManager::INFO, stdsprintf("Reseting CNT_OVERTEMP, CNT_VCCAUX_ALARM and CNT_VCCINT_ALARM for OH%i",ohN));
             writeReg(la, strRegBase+"RESET", 0x1);
         }
 
@@ -400,17 +401,17 @@ void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask, bool doReset){
 
         //Read Sysmon Values - Core Temperature
         writeReg(la, strRegBase + "ADR_IN", 0x0);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_TEMP");
+        strKeyName = stdsprintf("OH%i.FPGA_CORE_TEMP",ohN);
         la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
 
         //Read Sysmon Values - Core Voltage
         writeReg(la, strRegBase + "ADR_IN", 0x1);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_1V0");
+        strKeyName = stdsprintf("OH%i.FPGA_CORE_1V0",ohN);
         la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
 
         //Read Sysmon Values - I/O Voltage
         writeReg(la, strRegBase + "ADR_IN", 0x2);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_2V5_IO");
+        strKeyName = stdsprintf("OH%i.FPGA_CORE_2V5_IO",ohN);
         la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
 
         //Disable Sysmon ADC Read

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -402,17 +402,17 @@ void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask, bool doReset){
         //Read Sysmon Values - Core Temperature
         writeReg(la, strRegBase + "ADR_IN", 0x0);
         strKeyName = stdsprintf("OH%i.FPGA_CORE_TEMP",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
+        la->response->set_word(strKeyName, ((readReg(la, strRegBase + "DATA_OUT") >> 6) & 0x3ff));
 
         //Read Sysmon Values - Core Voltage
         writeReg(la, strRegBase + "ADR_IN", 0x1);
         strKeyName = stdsprintf("OH%i.FPGA_CORE_1V0",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
+        la->response->set_word(strKeyName, ((readReg(la, strRegBase + "DATA_OUT") >> 6) & 0x3ff));
 
         //Read Sysmon Values - I/O Voltage
         writeReg(la, strRegBase + "ADR_IN", 0x2);
         strKeyName = stdsprintf("OH%i.FPGA_CORE_2V5_IO",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
+        la->response->set_word(strKeyName, ((readReg(la, strRegBase + "DATA_OUT") >> 6) & 0x3ff));
 
         //Disable Sysmon ADC Read
         writeReg(la, strRegBase + "ENABLE", 0x0);

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -36,13 +36,13 @@ void getmonTRIGGERmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
   la->response->set_word("OR_TRIGGER_RATE",readReg(la,"GEM_AMC.TRIGGER.STATUS.OR_TRIGGER_RATE"));
-  for (int i = 0; i < NOH; i++){
+  for (int ohN = 0; ohN < NOH; ohN++){
     // If this Optohybrid is masked skip it
     if(!((ohMask >> ohN) & 0x1)){
       continue;
     }
-    t1 = stdsprintf("OH%s.TRIGGER_RATE",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.TRIGGER_RATE",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.TRIGGER_RATE",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.TRIGGER_RATE",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
   }
 }
@@ -71,34 +71,34 @@ void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
 void getmonTRIGGEROHmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
-  for (int i = 0; i < NOH; i++){
+  for (int ohN = 0; ohN < NOH; ohN++){
     // If this Optohybrid is masked skip it
     if(!((ohMask >> ohN) & 0x1)){
       continue;
     }
-    t1 = stdsprintf("OH%s.LINK0_MISSED_COMMA_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_MISSED_COMMA_CNT",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.LINK0_MISSED_COMMA_CNT",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_MISSED_COMMA_CNT",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK1_MISSED_COMMA_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_MISSED_COMMA_CNT",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.LINK1_MISSED_COMMA_CNT",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_MISSED_COMMA_CNT",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK0_OVERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_OVERFLOW_CNT",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.LINK0_OVERFLOW_CNT",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_OVERFLOW_CNT",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK1_OVERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_OVERFLOW_CNT",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.LINK1_OVERFLOW_CNT",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_OVERFLOW_CNT",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK0_UNDERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_UNDERFLOW_CNT",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.LINK0_UNDERFLOW_CNT",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_UNDERFLOW_CNT",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK1_UNDERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_UNDERFLOW_CNT",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.LINK1_UNDERFLOW_CNT",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_UNDERFLOW_CNT",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK0_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.LINK0_SBIT_OVERFLOW_CNT",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_SBIT_OVERFLOW_CNT",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.LINK1_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.LINK1_SBIT_OVERFLOW_CNT",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_SBIT_OVERFLOW_CNT",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
   }
 }
@@ -154,27 +154,27 @@ void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
 void getmonDAQOHmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
-  for (int i = 0; i < NOH; i++){
+  for (int ohN = 0; ohN < NOH; ohN++){
     // If this Optohybrid is masked skip it
     if(!((ohMask >> ohN) & 0x1)){
       continue;
     }
-    t1 = stdsprintf("OH%s.STATUS.EVT_SIZE_ERR",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.STATUS.EVT_SIZE_ERR",std::to_string(ohN).c_str());
     t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.STATUS.EVENT_FIFO_HAD_OFLOW",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.STATUS.EVENT_FIFO_HAD_OFLOW",std::to_string(ohN).c_str());
     t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.STATUS.INPUT_FIFO_HAD_OFLOW",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.STATUS.INPUT_FIFO_HAD_OFLOW",std::to_string(ohN).c_str());
     t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.STATUS.INPUT_FIFO_HAD_UFLOW",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.STATUS.INPUT_FIFO_HAD_UFLOW",std::to_string(ohN).c_str());
     t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.STATUS.VFAT_TOO_MANY",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.STATUS.VFAT_TOO_MANY",std::to_string(ohN).c_str());
     t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.STATUS.VFAT_NO_MARKER",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.STATUS.VFAT_NO_MARKER",std::to_string(ohN).c_str());
     t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
     la->response->set_word(t1,readReg(la,t2));
   }
@@ -204,31 +204,31 @@ void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
 void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
-  for (int i = 0; i < NOH; i++){
+  for (int ohN = 0; ohN < NOH; ohN++){
     // If this Optohybrid is masked skip it
     if(!((ohMask >> ohN) & 0x1)){
       continue;
     }
-    t1 = stdsprintf("OH%s.FW_VERSION",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.OH.OH%s.STATUS.FW.VERSION",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.FW_VERSION",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.OH.OH%s.STATUS.FW.VERSION",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.EVENT_COUNTER",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.EVN",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.EVENT_COUNTER",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.EVN",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.EVENT_RATE",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.EVT_RATE",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.EVENT_RATE",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.EVT_RATE",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.GTX.TRK_ERR",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GTX_LINK.TRK_ERR",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.GTX.TRK_ERR",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GTX_LINK.TRK_ERR",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.GTX.TRG_ERR",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GTX_LINK.TRG_ERR",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.GTX.TRG_ERR",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GTX_LINK.TRG_ERR",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.GBT.TRK_ERR",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GBT_LINK.TRK_ERR",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.GBT.TRK_ERR",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GBT_LINK.TRK_ERR",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
-    t1 = stdsprintf("OH%s.CORR_VFAT_BLK_CNT",std::to_string(i).c_str());
-    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.CORRUPT_VFAT_BLK_CNT",std::to_string(i).c_str());
+    t1 = stdsprintf("OH%s.CORR_VFAT_BLK_CNT",std::to_string(ohN).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.CORRUPT_VFAT_BLK_CNT",std::to_string(ohN).c_str());
     la->response->set_word(t1,readReg(la,t2));
   }
 }

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -1,0 +1,457 @@
+/*! \file amc.cpp
+ *  \brief AMC methods for RPC modules
+ *  \author Mykhailo Dalchenko <mykhailo.dalchenko@cern.ch>
+ *  \author Brian Dorney <brian.l.dorney@cern.ch>
+ */
+
+#include "daq_monitor.h"
+#include <string>
+#include "utils.h"
+
+void getmonTTCmainLocal(localArgs * la)
+{
+  LOGGER->log_message(LogManager::INFO, "Called getmonTTCmainLocal");
+  la->response->set_word("MMCM_LOCKED",readReg(la,"GEM_AMC.TTC.STATUS.MMCM_LOCKED"));
+  la->response->set_word("TTC_SINGLE_ERROR_CNT",readReg(la,"GEM_AMC.TTC.STATUS.TTC_SINGLE_ERROR_CNT"));
+  la->response->set_word("BC0_LOCKED",readReg(la,"GEM_AMC.TTC.STATUS.BC0.LOCKED"));
+  la->response->set_word("L1A_ID",readReg(la,"GEM_AMC.TTC.L1A_ID"));
+  la->response->set_word("L1A_RATE",readReg(la,"GEM_AMC.TTC.L1A_RATE"));
+}
+
+void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
+{
+  auto env = lmdb::env::create();
+  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+  std::string gem_path = std::getenv("GEM_PATH");
+  std::string lmdb_data_file = gem_path+"/address_table.mdb";
+  env.open(lmdb_data_file.c_str(), 0, 0664);
+  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  getmonTTCmainLocal(&la);
+  rtxn.abort();
+}
+
+void getmonTRIGGERmainLocal(localArgs * la, int NOH, int ohMask)
+{
+  std::string t1,t2;
+  la->response->set_word("OR_TRIGGER_RATE",readReg(la,"GEM_AMC.TRIGGER.STATUS.OR_TRIGGER_RATE"));
+  for (int i = 0; i < NOH; i++){
+    // If this Optohybrid is masked skip it
+    if(!((ohMask >> ohN) & 0x1)){
+      continue;
+    }
+    t1 = stdsprintf("OH%s.TRIGGER_RATE",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.TRIGGER_RATE",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+  }
+}
+
+void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
+{
+  auto env = lmdb::env::create();
+  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+  std::string gem_path = std::getenv("GEM_PATH");
+  std::string lmdb_data_file = gem_path+"/address_table.mdb";
+  env.open(lmdb_data_file.c_str(), 0, 0664);
+  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  int NOH = request->get_word("NOH");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  getmonTRIGGERmainLocal(&la, NOH, ohMask);
+  rtxn.abort();
+}
+
+void getmonTRIGGEROHmainLocal(localArgs * la, int NOH, int ohMask)
+{
+  std::string t1,t2;
+  for (int i = 0; i < NOH; i++){
+    // If this Optohybrid is masked skip it
+    if(!((ohMask >> ohN) & 0x1)){
+      continue;
+    }
+    t1 = stdsprintf("OH%s.LINK0_MISSED_COMMA_CNT",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_MISSED_COMMA_CNT",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.LINK1_MISSED_COMMA_CNT",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_MISSED_COMMA_CNT",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.LINK0_OVERFLOW_CNT",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_OVERFLOW_CNT",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.LINK1_OVERFLOW_CNT",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_OVERFLOW_CNT",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.LINK0_UNDERFLOW_CNT",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_UNDERFLOW_CNT",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.LINK1_UNDERFLOW_CNT",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_UNDERFLOW_CNT",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.LINK0_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK0_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.LINK1_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.TRIGGER.OH%s.LINK1_SBIT_OVERFLOW_CNT",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+  }
+}
+
+void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
+{
+  auto env = lmdb::env::create();
+  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+  std::string gem_path = std::getenv("GEM_PATH");
+  std::string lmdb_data_file = gem_path+"/address_table.mdb";
+  env.open(lmdb_data_file.c_str(), 0, 0664);
+  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  int NOH = request->get_word("NOH");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  getmonTRIGGEROHmainLocal(&la, NOH, ohMask);
+  rtxn.abort();
+}
+
+void getmonDAQmainLocal(localArgs * la)
+{
+  la->response->set_word("DAQ_ENABLE",readReg(la,"GEM_AMC.DAQ.CONTROL.DAQ_ENABLE"));
+  la->response->set_word("DAQ_LINK_READY",readReg(la,"GEM_AMC.DAQ.STATUS.DAQ_LINK_RDY"));
+  la->response->set_word("DAQ_LINK_AFULL",readReg(la,"GEM_AMC.DAQ.STATUS.DAQ_LINK_AFULL"));
+  la->response->set_word("DAQ_OFIFO_HAD_OFLOW",readReg(la,"GEM_AMC.DAQ.STATUS.DAQ_OUTPUT_FIFO_HAD_OVERFLOW"));
+  la->response->set_word("L1A_FIFO_HAD_OFLOW",readReg(la,"GEM_AMC.DAQ.STATUS.L1A_FIFO_HAD_OVERFLOW"));
+  la->response->set_word("L1A_FIFO_DATA_COUNT",readReg(la,"GEM_AMC.DAQ.EXT_STATUS.L1A_FIFO_DATA_CNT"));
+  la->response->set_word("DAQ_FIFO_DATA_COUNT",readReg(la,"GEM_AMC.DAQ.EXT_STATUS.DAQ_FIFO_DATA_CNT"));
+  la->response->set_word("EVENT_SENT",readReg(la,"GEM_AMC.DAQ.EXT_STATUS.EVT_SENT"));
+  la->response->set_word("TTS_STATE",readReg(la,"GEM_AMC.DAQ.STATUS.TTS_STATE"));
+}
+
+void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
+{
+  auto env = lmdb::env::create();
+  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+  std::string gem_path = std::getenv("GEM_PATH");
+  std::string lmdb_data_file = gem_path+"/address_table.mdb";
+  env.open(lmdb_data_file.c_str(), 0, 0664);
+  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  getmonDAQmainLocal(&la);
+  rtxn.abort();
+}
+
+void getmonDAQOHmainLocal(localArgs * la, int NOH, int ohMask)
+{
+  std::string t1,t2;
+  for (int i = 0; i < NOH; i++){
+    // If this Optohybrid is masked skip it
+    if(!((ohMask >> ohN) & 0x1)){
+      continue;
+    }
+    t1 = stdsprintf("OH%s.STATUS.EVT_SIZE_ERR",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.STATUS.EVENT_FIFO_HAD_OFLOW",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.STATUS.INPUT_FIFO_HAD_OFLOW",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.STATUS.INPUT_FIFO_HAD_UFLOW",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.STATUS.VFAT_TOO_MANY",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.STATUS.VFAT_NO_MARKER",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.%s",t1.c_str());
+    la->response->set_word(t1,readReg(la,t2));
+  }
+}
+
+void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
+{
+  auto env = lmdb::env::create();
+  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+  std::string gem_path = std::getenv("GEM_PATH");
+  std::string lmdb_data_file = gem_path+"/address_table.mdb";
+  env.open(lmdb_data_file.c_str(), 0, 0664);
+  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  int NOH = request->get_word("NOH");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  getmonDAQOHmainLocal(&la, NOH, ohMask);
+  rtxn.abort();
+}
+
+void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
+{
+  std::string t1,t2;
+  for (int i = 0; i < NOH; i++){
+    // If this Optohybrid is masked skip it
+    if(!((ohMask >> ohN) & 0x1)){
+      continue;
+    }
+    t1 = stdsprintf("OH%s.FW_VERSION",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.OH.OH%s.STATUS.FW.VERSION",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.EVENT_COUNTER",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.EVN",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.EVENT_RATE",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.EVT_RATE",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.GTX.TRK_ERR",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GTX_LINK.TRK_ERR",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.GTX.TRG_ERR",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GTX_LINK.TRG_ERR",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.GBT.TRK_ERR",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.OH.OH%s.COUNTERS.GBT_LINK.TRK_ERR",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+    t1 = stdsprintf("OH%s.CORR_VFAT_BLK_CNT",std::to_string(i).c_str());
+    t2 = stdsprintf("GEM_AMC.DAQ.OH%s.COUNTERS.CORRUPT_VFAT_BLK_CNT",std::to_string(i).c_str());
+    la->response->set_word(t1,readReg(la,t2));
+  }
+}
+
+void getmonOHmain(const RPCMsg *request, RPCMsg *response)
+{
+  auto env = lmdb::env::create();
+  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+  std::string gem_path = std::getenv("GEM_PATH");
+  std::string lmdb_data_file = gem_path+"/address_table.mdb";
+  env.open(lmdb_data_file.c_str(), 0, 0664);
+  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  int NOH = request->get_word("NOH");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  getmonOHmainLocal(&la, NOH, ohMask);
+  rtxn.abort();
+}
+
+void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask){
+    std::string strRegName, strKeyName;
+
+    for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
+        // If this Optohybrid is masked skip it
+        if(!((ohMask >> ohN) & 0x1)){
+            continue;
+        }
+
+        //Log Message
+        LOGGER->log_message(LogManager::INFO, stdsprintf("Reading SCA Monitoring Values for OH%i",ohN));
+
+        //SCA Temperature
+        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.SCA_TEMP",ohN);
+        strKeyName = stdsprintf("OH%i.SCA_TEMP",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegName));
+
+        //OH Temperature Sensors
+        for(int tempVal=1; tempVal <= 9; ++tempVal){ //Loop over optohybrid temperatures sensosrs
+            strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.BOARD_TEMP%i",ohN,tempVal);
+            strKeyName = stdsprintf("OH%i.BOARD_TEMP%i",ohN,tempVal);
+            la->response->set_word(strKeyName, readReg(la, strRegName));
+        } //End Loop over optohybrid temeprature sensors
+
+        //Voltage Monitor - AVCCN
+        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.AVCCN",ohN);
+        strKeyName = stdsprintf("OH%i.AVCCN",ohN);
+        la->response->set_word(strKeyName, readReg(la, strRegName));
+
+        //Voltage Monitor - AVTTN
+        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.AVTTN",ohN);
+        strKeyName = stdsprintf("OH%i.AVTTN",ohN);
+        la->response->set_word(strKeyName, readReg(la, strRegName));
+
+        //Voltage Monitor - 1V0_INT
+        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.1V0_INT",ohN);
+        strKeyName = stdsprintf("OH%i.1V0_INT",ohN);
+        la->response->set_word(strKeyName, readReg(la, strRegName));
+
+        //Voltage Monitor - 1V8F
+        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.1V8F",ohN);
+        strKeyName = stdsprintf("OH%i.1V8F",ohN);
+        la->response->set_word(strKeyName, readReg(la, strRegName));
+
+        //Voltage Monitor - 1V5
+        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.1V5",ohN);
+        strKeyName = stdsprintf("OH%i.1V5",ohN);
+        la->response->set_word(strKeyName, readReg(la, strRegName));
+
+        //Voltage Monitor - 2V5_IO
+        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.2V5_IO",ohN);
+        strKeyName = stdsprintf("OH%i.2V5_IO",ohN);
+        la->response->set_word(strKeyName, readReg(la, strRegName));
+
+        //Voltage Monitor - 3V0
+        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.3V0",ohN);
+        strKeyName = stdsprintf("OH%i.3V0",ohN);
+        la->response->set_word(strKeyName, readReg(la, strRegName));
+
+        //Voltage Monitor - 1V8
+        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.1V8",ohN);
+        strKeyName = stdsprintf("OH%i.1V8",ohN);
+        la->response->set_word(strKeyName, readReg(la, strRegName));
+
+        //Voltage Monitor - VTRX_RSSI2
+        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.VTRX_RSSI2",ohN);
+        strKeyName = stdsprintf("OH%i.VTRX_RSSI2",ohN);
+        la->response->set_word(strKeyName, readReg(la, strRegName));
+
+        //Voltage Monitor - VTRX_RSSI1
+        strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.VTRX_RSSI1",ohN);
+        strKeyName = stdsprintf("OH%i.VTRX_RSSI1",ohN);
+        la->response->set_word(strKeyName, readReg(la, strRegName));
+    } //End Loop over all optohybrids
+
+    return;
+} //End getmonOHSCAmainLocal(...)
+
+void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
+{
+  auto env = lmdb::env::create();
+  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+  std::string gem_path = std::getenv("GEM_PATH");
+  std::string lmdb_data_file = gem_path+"/address_table.mdb";
+  env.open(lmdb_data_file.c_str(), 0, 0664);
+  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  int NOH = request->get_word("NOH");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  getmonOHSCAmainLocal(&la, NOH, ohMask);
+  rtxn.abort();
+}
+
+void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask){
+    std::string strKeyName;
+    std::string strRegBase;
+
+    for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
+        // If this Optohybrid is masked skip it
+        if(!((ohMask >> ohN) & 0x1)){
+            continue;
+        }
+
+        //Set regBase
+        strRegBase = stdsprintf("GEM_AMC.OH.OH%i.FPGA.ADC.CTRL.",ohN);
+
+        //Log Message
+        LOGGER->log_message(LogManager::INFO, stdsprintf("Reading Sysmon Values for OH%i",ohN));
+
+        //Issue reset??
+        //writeReg(la, strRegBase+"RESET", 0x1);
+
+        //Read Alarm conditions & counters - OVERTEMP
+        strKeyName = stdsprintf("OH%i.OVERTEMP",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "OVERTEMP"));
+
+        strKeyName = stdsprintf("OH%i.CNT_OVERTEMP",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_OVERTEMP"));
+
+        //Read Alarm conditions & counters - VCCAUX_ALARM
+        strKeyName = stdsprintf("OH%i.VCCAUX_ALARM",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCAUX_ALARM"));
+
+        strKeyName = stdsprintf("OH%i.CNT_VCCAUX_ALARM",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCAUX_ALARM"));
+
+        //Read Alarm conditions & counters - VCCINT_ALARM
+        strKeyName = stdsprintf("OH%i.VCCINT_ALARM",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCINT_ALARM"));
+
+        strKeyName = stdsprintf("OH%i.CNT_VCCINT_ALARM",ohN);
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCINT_ALARM"));
+
+        //Enable Sysmon ADC Read
+        writeReg(la, strRegBase + "ENABLE", 0x1);
+
+        //Read Sysmon Values - Core Temperature
+        writeReg(la, strRegBase + "ADR_IN", 0x0);
+        strKeyName = stdsprintf("OH%i.FPGA_CORE_TEMP");
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
+
+        //Read Sysmon Values - Core Voltage
+        writeReg(la, strRegBase + "ADR_IN", 0x1);
+        strKeyName = stdsprintf("OH%i.FPGA_CORE_1V0");
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
+
+        //Read Sysmon Values - I/O Voltage
+        writeReg(la, strRegBase + "ADR_IN", 0x2);
+        strKeyName = stdsprintf("OH%i.FPGA_CORE_2V5_IO");
+        la->response->set_word(strKeyName,readReg(la, strRegBase + "DATA_OUT"));
+
+        //Disable Sysmon ADC Read
+        writeReg(la, strRegBase + "ENABLE", 0x0);
+    } //End Loop over all optohybrids
+} //End getmonOHSysmonLocal()
+
+void getmonOHSysmon(const RPCMsg *request, RPCMsg *response){
+  auto env = lmdb::env::create();
+  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+  std::string gem_path = std::getenv("GEM_PATH");
+  std::string lmdb_data_file = gem_path+"/address_table.mdb";
+  env.open(lmdb_data_file.c_str(), 0, 0664);
+  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  int NOH = request->get_word("NOH");
+
+  int ohMask = 0xfff;
+  if(request->get_key_exists("ohMask")){
+    ohMask = request->get_word("ohMask");
+  }
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  getmonOHSysmonLocal(&la, NOH, ohMask);
+  rtxn.abort();
+} //End getmonOHSysmon()
+
+extern "C" {
+    const char *module_version_key = "daq_monitor v1.0.1";
+    int module_activity_color = 4;
+    void module_init(ModuleManager *modmgr) {
+        if (memsvc_open(&memsvc) != 0) {
+            LOGGER->log_message(LogManager::ERROR, stdsprintf("Unable to connect to memory service: %s", memsvc_get_last_error(memsvc)));
+            LOGGER->log_message(LogManager::ERROR, "Unable to load module");
+            return; // Do not register our functions, we depend on memsvc.
+        }
+        modmgr->register_method("daq_monitor", "getmonTTCmain", getmonTTCmain);
+        modmgr->register_method("daq_monitor", "getmonTRIGGERmain", getmonTRIGGERmain);
+        modmgr->register_method("daq_monitor", "getmonTRIGGEROHmain", getmonTRIGGEROHmain);
+        modmgr->register_method("daq_monitor", "getmonDAQmain", getmonDAQmain);
+        modmgr->register_method("daq_monitor", "getmonDAQOHmain", getmonDAQOHmain);
+        modmgr->register_method("daq_monitor", "getmonOHmain", getmonOHmain);
+        modmgr->register_method("daq_monitor", "getmonOHSCAmain", getmonOHSCAmain);
+        modmgr->register_method("daq_monitor", "getmonOHSysmon", getmonOHSysmon);
+    }
+}

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -1,5 +1,5 @@
-/*! \file amc.cpp
- *  \brief AMC methods for RPC modules
+/*! \file daq_monitor.cpp
+ *  \brief Contains functions for hardware monitoring
  *  \author Mykhailo Dalchenko <mykhailo.dalchenko@cern.ch>
  *  \author Brian Dorney <brian.l.dorney@cern.ch>
  */

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -353,7 +353,7 @@ void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask){
+void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask, bool doReset){
     std::string strKeyName;
     std::string strRegBase;
 
@@ -370,7 +370,9 @@ void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask){
         LOGGER->log_message(LogManager::INFO, stdsprintf("Reading Sysmon Values for OH%i",ohN));
 
         //Issue reset??
-        //writeReg(la, strRegBase+"RESET", 0x1);
+        if(doReset){
+            writeReg(la, strRegBase+"RESET", 0x1);
+        }
 
         //Read Alarm conditions & counters - OVERTEMP
         strKeyName = stdsprintf("OH%i.OVERTEMP",ohN);
@@ -431,8 +433,10 @@ void getmonOHSysmon(const RPCMsg *request, RPCMsg *response){
     ohMask = request->get_word("ohMask");
   }
 
+  bool doReset = request->get_word("doReset");
+
   struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-  getmonOHSysmonLocal(&la, NOH, ohMask);
+  getmonOHSysmonLocal(&la, NOH, ohMask, doReset);
   rtxn.abort();
 } //End getmonOHSysmon()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provided a local and non-local versions of function `getmonOHSysmon()` which monitors exposed sysmon registers in OH FW with direct register access rather than using JTAG path (bad).  This function will read the following error conditions:

```
eagle26 > kw GEM_AMC.OH.OH2.FPGA.ADC.CTRL
0x65084000 None         GEM_AMC.OH.OH2.FPGA.ADC.CTRL
0x65084000 r    GEM_AMC.OH.OH2.FPGA.ADC.CTRL.OVERTEMP                   0x00000000
0x65084000 r    GEM_AMC.OH.OH2.FPGA.ADC.CTRL.VCCAUX_ALARM               0x00000000
0x65084000 r    GEM_AMC.OH.OH2.FPGA.ADC.CTRL.VCCINT_ALARM               0x00000000
```

And their number of occurrences:

```
0x6508401c r    GEM_AMC.OH.OH2.FPGA.ADC.CTRL.CNT_OVERTEMP               0x00000000
0x6508401c r    GEM_AMC.OH.OH2.FPGA.ADC.CTRL.CNT_VCCAUX_ALARM           0x00000000
0x6508401c r    GEM_AMC.OH.OH2.FPGA.ADC.CTRL.CNT_VCCINT_ALARM           0x00000000
```

Along with reading the FPGA core temperature, voltage, and I/O voltage.

### Supporting Changes
#### Creating Dedicated Monitoring Library: `daq_monitor.so`
After discussion with @mexanick I've broken `include/amc.h` and corresponding `*.cpp` file into two files:

- `include/daq_monitor.h`, and
- `include/amc.h`.

In the former case all monitoring functions from the old `amc.h` are now located here.

Changes to `Makefile` have been included.

#### Providing `ohMask` parameter for all monitoring functions
We may find in the future that monitoring is required on an AMC in which the number of valid OH's is not sequential, e.g. OH7 may be non-operable and this would need to be masked for whatever reason.  In this case I've provided all monitoring functions the ability to have an `ohMask`.  This mask follows the convention of the current `sca.py` tool, e.g. a 1 in the N^th bit means use the N^th OH.

Additionally to maintain backwards compatibility all monitoring functions will first check if the `ohMask` key exists in the RPC request.  If it does, it will be set using the `get_word` method, if the key does not exist a default value of `0xfff` will be set.  This will ensure that all OH's are considered.  This should maintain current functionality.

### Documentation
All function documentation has been preserved in header file.  For new function `getmonOHSysmon()`, local and non-local versions, please see function documentation in `include/daq_monitor.h`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

Breaking change because any method in `xhal/cmsgemos` that was previously looking for monitoring functions in `amc.so` will now need to look in `daq_monitor.so`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Trying to access sysmon information of FPGA using JTAG path is not reliable and causes problems.  Here dedicated register reads are used.

In the future ability to mask an OH from monitoring may be desireable.  Functionality is included here.

Finally wanted to compartmentalise libraries, e.g. providing monitoring in dedicated monitoring library and amc functionality in dedicated amc library.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In progress.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
