### PR TITLE
remove all requests for the 'ohVfatMaskArray' key

### DIFF
--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -119,9 +119,9 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
             continue;
         }
 
-	//Get VFAT Mask
-	uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
-	
+        //Get VFAT Mask
+        uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
+        
         LOGGER->log_message(LogManager::INFO, stdsprintf("Programming VFAT3 ADC Monitoring on OH%i for Selection %i",ohN,dacSelect));
         configureVFAT3DacMonitorLocal(&la, ohN, vfatMask, dacSelect);
     } //End Loop over all Optohybrids
@@ -309,9 +309,9 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
 
         LOGGER->log_message(LogManager::INFO, stdsprintf("Reading VFAT3 ADC Values for all chips on OH%i",ohN));
 
-	//Get VFAT Mask
-	uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
-	
+        //Get VFAT Mask
+        uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
+        
         //Get all ADC values
         readVFAT3ADCLocal(&la, adcData, ohN, useExtRefADC, vfatMask);
 

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -12,7 +12,6 @@
 #include "vfat3.h"
 #include "amc.h"
 
-
 uint32_t vfatSyncCheckLocal(localArgs * la, uint32_t ohN)
 {
     uint32_t goodVFATs = 0;

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -109,8 +109,6 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
     auto dbi = lmdb::dbi::open(rtxn, nullptr);
 
     uint32_t ohMask = request->get_word("ohMask");
-    uint32_t ohVfatMaskArray[12];
-    request->get_word_array("ohVfatMaskArray",ohVfatMaskArray);
     uint32_t dacSelect = request->get_word("dacSelect");
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
@@ -120,8 +118,11 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
             continue;
         }
 
+	//Get VFAT Mask
+	uint32_t vfatMask = getOHVFATMaskLocal(la, ohN);
+	
         LOGGER->log_message(LogManager::INFO, stdsprintf("Programming VFAT3 ADC Monitoring on OH%i for Selection %i",ohN,dacSelect));
-        configureVFAT3DacMonitorLocal(&la, ohN, ohVfatMaskArray[ohN], dacSelect);
+        configureVFAT3DacMonitorLocal(&la, ohN, vfatMask, dacSelect);
     } //End Loop over all Optohybrids
 
     return;
@@ -294,8 +295,6 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
     auto dbi = lmdb::dbi::open(rtxn, nullptr);
 
     uint32_t ohMask = request->get_word("ohMask");
-    uint32_t ohVfatMaskArray[12];
-    request->get_word_array("ohVfatMaskArray",ohVfatMaskArray);
     bool useExtRefADC = request->get_word("useExtRefADC");
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
@@ -309,8 +308,11 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
 
         LOGGER->log_message(LogManager::INFO, stdsprintf("Reading VFAT3 ADC Values for all chips on OH%i",ohN));
 
+	//Get VFAT Mask
+	uint32_t vfatMask = getOHVFATMaskLocal(la, ohN);
+	
         //Get all ADC values
-        readVFAT3ADCLocal(&la, adcData, ohN, useExtRefADC, ohVfatMaskArray[ohN]);
+        readVFAT3ADCLocal(&la, adcData, ohN, useExtRefADC, vfatMask);
 
         //Copy all ADC values
         std::copy(adcData, adcData+24, adcDataAll+(24*ohN));

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -10,6 +10,8 @@
 #include "optohybrid.h"
 #include <thread>
 #include "vfat3.h"
+#include "amc.h"
+
 
 uint32_t vfatSyncCheckLocal(localArgs * la, uint32_t ohN)
 {
@@ -119,7 +121,7 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
         }
 
 	//Get VFAT Mask
-	uint32_t vfatMask = getOHVFATMaskLocal(la, ohN);
+	uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
 	
         LOGGER->log_message(LogManager::INFO, stdsprintf("Programming VFAT3 ADC Monitoring on OH%i for Selection %i",ohN,dacSelect));
         configureVFAT3DacMonitorLocal(&la, ohN, vfatMask, dacSelect);
@@ -309,7 +311,7 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
         LOGGER->log_message(LogManager::INFO, stdsprintf("Reading VFAT3 ADC Values for all chips on OH%i",ohN));
 
 	//Get VFAT Mask
-	uint32_t vfatMask = getOHVFATMaskLocal(la, ohN);
+	uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
 	
         //Get all ADC values
         readVFAT3ADCLocal(&la, adcData, ohN, useExtRefADC, vfatMask);


### PR DESCRIPTION
As requested in https://github.com/cms-gem-daq-project/ctp7_modules/issues/48, I have removed all instances in this repository where a "ohVfatMaskArray" key is requested in an rpc call.

## Description
Instead of getting the mask array from the rpc call, I get it from the getOHVFATMaskLocal whenever it is needed. There were two functions where this occurred and was changed:

1) readVFAT3ADCMultiLink in vfat3.cc
2) configureVFAT3DacMonitorMultiLink in vfat3.cc

Note: https://github.com/cms-gem-daq-project/ctp7_modules/pull/47 which was recently merged already implemented this change in the function dacScanMultiLink in calibration_routines.cpp

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This pull request is intended to add the feature requested in https://github.com/cms-gem-daq-project/ctp7_modules/issues/48. 

## How Has This Been Tested?
I have compiled the changes and tested them on eagle64 as described in http://cmsonline.cern.ch/cms-elog/1066648

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
