### PR TITLE
read the number of OHs from the AMC register and perform checks on the NOH rpc key

### DIFF
--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -87,10 +87,16 @@ void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
 
-    int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    if (request->get_key_exists("NOH")){
+      if (request->get_word("NOH") <= NOH)
+        NOH = request->get_word("NOH");
+      else
+        LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
+    }
     
     uint32_t ohVfatMaskArray[12];
-    for(int ohN=0; ohN<NOH; ++ohN){
+    for(unsigned int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
             ohVfatMaskArray[ohN] = 0xffffff;

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -89,10 +89,10 @@ void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
 
     unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (request->get_key_exists("NOH")){
-      if (request->get_word("NOH") <= NOH)
-        NOH = request->get_word("NOH");
-      else
-        LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
+        if (request->get_word("NOH") <= NOH)
+            NOH = request->get_word("NOH");
+        else
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
     }
     
     uint32_t ohVfatMaskArray[12];

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -92,7 +92,7 @@ void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
         if (NOH_requested <= NOH)
             NOH = NOH_requested;
         else
-            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",NOH_requested,NOH));
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register value (%i), NOH request will be disregarded",NOH_requested,NOH));
     }
     
     uint32_t ohVfatMaskArray[12];

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -86,13 +86,13 @@ void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
     }
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-
     unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (request->get_key_exists("NOH")){
-        if (request->get_word("NOH") <= NOH)
-            NOH = request->get_word("NOH");
+        unsigned int NOH_requested = request->get_word("NOH");
+        if (NOH_requested <= NOH)
+            NOH = NOH_requested;
         else
-            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",NOH_requested,NOH));
     }
     
     uint32_t ohVfatMaskArray[12];

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -87,8 +87,10 @@ void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
 
+    int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    
     uint32_t ohVfatMaskArray[12];
-    for(int ohN=0; ohN<12; ++ohN){
+    for(int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
             ohVfatMaskArray[ohN] = 0xffffff;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1536,7 +1536,7 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
         if (NOH_requested <= NOH)
             NOH = NOH_requested;
         else
-            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",NOH_requested,NOH));
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register value (%i), NOH request will be disregarded",NOH_requested,NOH));
     }
     
     std::vector<uint32_t> dacScanResultsAll;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1530,8 +1530,10 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
 
+    int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    
     std::vector<uint32_t> dacScanResultsAll;
-    for(int ohN=0; ohN<12; ++ohN){
+    for(int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
             continue;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1532,10 +1532,11 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
 
     unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (request->get_key_exists("NOH")){
-        if (request->get_word("NOH") <= NOH)
-            NOH = request->get_word("NOH");
+        unsigned int NOH_requested = request->get_word("NOH");
+        if (NOH_requested <= NOH)
+            NOH = NOH_requested;
         else
-            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",NOH_requested,NOH));
     }
     
     std::vector<uint32_t> dacScanResultsAll;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1532,10 +1532,10 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
 
     unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (request->get_key_exists("NOH")){
-      if (request->get_word("NOH") <= NOH)
-        NOH = request->get_word("NOH");
-      else
-        LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
+        if (request->get_word("NOH") <= NOH)
+            NOH = request->get_word("NOH");
+        else
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
     }
     
     std::vector<uint32_t> dacScanResultsAll;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1530,10 +1530,16 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
 
-    int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    if (request->get_key_exists("NOH")){
+      if (request->get_word("NOH") <= NOH)
+        NOH = request->get_word("NOH");
+      else
+        LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
+    }
     
     std::vector<uint32_t> dacScanResultsAll;
-    for(int ohN=0; ohN<NOH; ++ohN){
+    for(unsigned int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
             continue;

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -34,6 +34,7 @@ void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
 
 void getmonTRIGGERmainLocal(localArgs * la, int NOH, int ohMask)
 {
+
   std::string t1,t2;
   la->response->set_word("OR_TRIGGER_RATE",readReg(la,"GEM_AMC.TRIGGER.STATUS.OR_TRIGGER_RATE"));
   for (int ohN = 0; ohN < NOH; ohN++){
@@ -56,14 +57,22 @@ void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
   env.open(lmdb_data_file.c_str(), 0, 0664);
   auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
   auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
 
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+  if (request->get_key_exists("NOH")){
+    unsigned int NOH_requested = request->get_word("NOH");
+    if (NOH_requested <= NOH)
+      NOH = NOH_requested;
+    else
+      LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i), NOH request will be disregarded",NOH_requested,NOH));
+  }
+  
   int ohMask = 0xfff;
   if(request->get_key_exists("ohMask")){
     ohMask = request->get_word("ohMask");
   }
 
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   getmonTRIGGERmainLocal(&la, NOH, ohMask);
   rtxn.abort();
 }
@@ -112,14 +121,22 @@ void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
   env.open(lmdb_data_file.c_str(), 0, 0664);
   auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
   auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};  
+  unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+  if (request->get_key_exists("NOH")){
+    unsigned int NOH_requested = request->get_word("NOH");
+    if (NOH_requested <= NOH)
+      NOH = NOH_requested;
+    else
+      LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i), NOH request will be disregarded",NOH_requested,NOH));
+  }
 
   int ohMask = 0xfff;
   if(request->get_key_exists("ohMask")){
     ohMask = request->get_word("ohMask");
   }
 
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   getmonTRIGGEROHmainLocal(&la, NOH, ohMask);
   rtxn.abort();
 }
@@ -189,14 +206,22 @@ void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
   env.open(lmdb_data_file.c_str(), 0, 0664);
   auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
   auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};  
+  unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+  if (request->get_key_exists("NOH")){
+    unsigned int NOH_requested = request->get_word("NOH");
+    if (NOH_requested <= NOH)
+      NOH = NOH_requested;
+    else
+      LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i), NOH request will be disregarded",NOH_requested,NOH));
+  }
 
   int ohMask = 0xfff;
   if(request->get_key_exists("ohMask")){
     ohMask = request->get_word("ohMask");
   }
 
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   getmonDAQOHmainLocal(&la, NOH, ohMask);
   rtxn.abort();
 }
@@ -242,14 +267,22 @@ void getmonOHmain(const RPCMsg *request, RPCMsg *response)
   env.open(lmdb_data_file.c_str(), 0, 0664);
   auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
   auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};  
+  unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+  if (request->get_key_exists("NOH")){
+    unsigned int NOH_requested = request->get_word("NOH");
+    if (NOH_requested <= NOH)
+      NOH = NOH_requested;
+    else
+      LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i), NOH request will be disregarded",NOH_requested,NOH));
+  }
 
   int ohMask = 0xfff;
   if(request->get_key_exists("ohMask")){
     ohMask = request->get_word("ohMask");
   }
 
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   getmonOHmainLocal(&la, NOH, ohMask);
   rtxn.abort();
 }
@@ -341,14 +374,22 @@ void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
   env.open(lmdb_data_file.c_str(), 0, 0664);
   auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
   auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};  
+  unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+  if (request->get_key_exists("NOH")){
+    unsigned int NOH_requested = request->get_word("NOH");
+    if (NOH_requested <= NOH)
+      NOH = NOH_requested;
+    else
+      LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i), NOH request will be disregarded",NOH_requested,NOH));
+  }
 
   int ohMask = 0xfff;
   if(request->get_key_exists("ohMask")){
     ohMask = request->get_word("ohMask");
   }
 
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   getmonOHSCAmainLocal(&la, NOH, ohMask);
   rtxn.abort();
 }
@@ -427,7 +468,16 @@ void getmonOHSysmon(const RPCMsg *request, RPCMsg *response){
   env.open(lmdb_data_file.c_str(), 0, 0664);
   auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
   auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  int NOH = request->get_word("NOH");
+
+  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};  
+  unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+  if (request->get_key_exists("NOH")){
+    unsigned int NOH_requested = request->get_word("NOH");
+    if (NOH_requested <= NOH)
+      NOH = NOH_requested;
+    else
+      LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i), NOH request will be disregarded",NOH_requested,NOH));
+  }
 
   int ohMask = 0xfff;
   if(request->get_key_exists("ohMask")){
@@ -436,7 +486,6 @@ void getmonOHSysmon(const RPCMsg *request, RPCMsg *response){
 
   bool doReset = request->get_word("doReset");
 
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   getmonOHSysmonLocal(&la, NOH, ohMask, doReset);
   rtxn.abort();
 } //End getmonOHSysmon()

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -34,7 +34,6 @@ void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
 
 void getmonTRIGGERmainLocal(localArgs * la, int NOH, int ohMask)
 {
-
   std::string t1,t2;
   la->response->set_word("OR_TRIGGER_RATE",readReg(la,"GEM_AMC.TRIGGER.STATUS.OR_TRIGGER_RATE"));
   for (int ohN = 0; ohN < NOH; ohN++){

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -305,7 +305,6 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
     request->get_word_array("ohVfatMaskArray",ohVfatMaskArray);
     bool useExtRefADC = request->get_word("useExtRefADC");
 
-
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (request->get_key_exists("NOH")){

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -114,8 +114,14 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
     uint32_t dacSelect = request->get_word("dacSelect");
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-    int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
-    for(int ohN=0; ohN<NOH; ++ohN){
+    unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    if (request->get_key_exists("NOH")){
+      if (request->get_word("NOH") <= NOH)
+        NOH = request->get_word("NOH");
+      else
+        LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
+    }
+    for(unsigned int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
             continue;
@@ -301,10 +307,16 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
 
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-    int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    if (request->get_key_exists("NOH")){
+      if (request->get_word("NOH") <= NOH)
+        NOH = request->get_word("NOH");
+      else
+        LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
+    }
     uint32_t adcData[24] = {0};
     uint32_t adcDataAll[12*24] = {0};
-    for(int ohN=0; ohN<NOH; ++ohN){
+    for(unsigned int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
             continue;

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -116,10 +116,10 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (request->get_key_exists("NOH")){
-      if (request->get_word("NOH") <= NOH)
-        NOH = request->get_word("NOH");
-      else
-        LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
+        if (request->get_word("NOH") <= NOH)
+            NOH = request->get_word("NOH");
+        else
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
     }
     for(unsigned int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
@@ -309,10 +309,10 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (request->get_key_exists("NOH")){
-      if (request->get_word("NOH") <= NOH)
-        NOH = request->get_word("NOH");
-      else
-        LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
+        if (request->get_word("NOH") <= NOH)
+            NOH = request->get_word("NOH");
+        else
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
     }
     uint32_t adcData[24] = {0};
     uint32_t adcDataAll[12*24] = {0};

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -116,10 +116,11 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (request->get_key_exists("NOH")){
-        if (request->get_word("NOH") <= NOH)
-            NOH = request->get_word("NOH");
+        unsigned int NOH_requested = request->get_word("NOH");
+        if (NOH_requested <= NOH)
+            NOH = NOH_requested;
         else
-            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",NOH_requested,NOH));
     }
     for(unsigned int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
@@ -308,11 +309,12 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (request->get_key_exists("NOH")){
-        if (request->get_word("NOH") <= NOH)
-            NOH = request->get_word("NOH");
+        unsigned int NOH_requested = request->get_word("NOH");
+        if (NOH_requested <= NOH)
+            NOH = NOH_requested;
         else
-            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",request->get_word("NOH"),NOH));
-    }
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",NOH_requested,NOH));
+    }    
     uint32_t adcData[24] = {0};
     uint32_t adcDataAll[12*24] = {0};
     for(unsigned int ohN=0; ohN<NOH; ++ohN){

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -114,7 +114,8 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
     uint32_t dacSelect = request->get_word("dacSelect");
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-    for(int ohN=0; ohN<12; ++ohN){
+    int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    for(int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
             continue;
@@ -298,10 +299,12 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
     request->get_word_array("ohVfatMaskArray",ohVfatMaskArray);
     bool useExtRefADC = request->get_word("useExtRefADC");
 
+
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+    int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     uint32_t adcData[24] = {0};
     uint32_t adcDataAll[12*24] = {0};
-    for(int ohN=0; ohN<12; ++ohN){
+    for(int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
             continue;

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -120,7 +120,7 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
         if (NOH_requested <= NOH)
             NOH = NOH_requested;
         else
-            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",NOH_requested,NOH));
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register value (%i), NOH request will be disregarded",NOH_requested,NOH));
     }
     for(unsigned int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
@@ -313,7 +313,7 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
         if (NOH_requested <= NOH)
             NOH = NOH_requested;
         else
-            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH (%i), NOH request will be disregarded",NOH_requested,NOH));
+            LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register value (%i), NOH request will be disregarded",NOH_requested,NOH));
     }    
     uint32_t adcData[24] = {0};
     uint32_t adcDataAll[12*24] = {0};


### PR DESCRIPTION
Currently, the number of OHs is hardcoded as 12 in some places and it is read from the RPC request in other places. This pull request makes use of the NUM_OF_OH AMC register to avoid the hardcoding and perform a check on the number of OHs from in the RPC request.

## Description
The first 4 of the following functions (in amc.cpp, in calibration_routines.cpp, and vfat3.cpp) were previously using hardcoded number of OHs. The next 6 of the following functions (in daq_monitor.cpp) already used the number of OHs from the RPC request. I have changed all of these functions to: use the number of OHs from the RPC request if that exists and is less than or equal to the value of the NUM_OF_OH register, and otherwise to use the NUM_OF_OH register.

1) getOHVFATMaskMultiLink in amc.cpp
2) dacScanMultiLink in calibration_routines.cpp
3) configureVFAT3DacMonitorMultiLink in vfat3.cpp
4) readVFAT3ADCMultiLink in vfat3.cpp
5) getmonTRIGGERmain in daq_monitor.cpp
6) getmonTRIGGEROHmain in daq_monitor.cpp
7) getmonDAQOHmain in daq_monitor.cpp
8) getmonOHmain in daq_monitor.cpp
9) getmonOHSCAmain in daq_monitor.cpp
10) getmonOHSysmon in daq_monitor.cpp

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
There may be a different number of links on an OH, as explained in https://github.com/cms-gem-daq-project/ctp7_modules/issues/49. Instead of hardcoding the number or passing the number as a parameter to the rpc call, the number can be easily read from the NUM_OF_OH AMC register. In some cases the user may want to fewer than the total number of OHs, so passing the number as a parameter should be supported in that case.

## How Has This Been Tested?
I have compiled the changes and tested them on eagle64 as described in http://cmsonline.cern.ch/cms-elog/1066648

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
