### PR TITLE
Making use of unused in bits in dataword of DAC Scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ TARGET_LIBS=lib/memory.so
 TARGET_LIBS+=lib/optical.so
 TARGET_LIBS+=lib/utils.so
 TARGET_LIBS+=lib/extras.so
-TARGET_LIBS+=lib/daq_monitor.so
 TARGET_LIBS+=lib/amc.so
+TARGET_LIBS+=lib/daq_monitor.so
 TARGET_LIBS+=lib/vfat3.so
 TARGET_LIBS+=lib/optohybrid.so
 TARGET_LIBS+=lib/calibration_routines.so
@@ -47,11 +47,11 @@ lib/utils.so: src/utils.cpp
 lib/extras.so: src/extras.cpp
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,extras.so -o $@ $< -lwisci2c -lxhal -llmdb
 
-lib/daq_monitor.so: src/daq_monitor.cpp
-	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,daq_monitor.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so
-
 lib/amc.so: src/amc.cpp
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,amc.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so
+
+lib/daq_monitor.so: src/daq_monitor.cpp
+	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,daq_monitor.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so -l:amc.so
 
 lib/vfat3.so: src/vfat3.cpp 
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,vfat3.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so -l:amc.so

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -170,7 +170,7 @@ std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acq
             }
 
             //Store the sbit
-            tempSBits.push_back( (l1ADelay << 14) + (clusterSize << 11) + sbitAddress);
+            tempSBits.push_back( ((l1ADelay & 0x1fff) << 14) + ((clusterSize & 0x7) << 11) + (sbitAddress & 0x7ff) );
         } //End Loop over clusters
 
         if(anyValid){

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1392,7 +1392,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
     map_dacSelect[36] = std::make_tuple("CFG_THR_ZCC_DAC", 0, 0xff);
     //map_dacSelect[37] = std::make_tuple("NOREG_VTSENSEINT", 0, 0); //Internal temperature sensor
     //map_dacSelect[38] = std::make_tuple("NOREG_VTSENSEEXT", 0, 0); //External temperature sensor (only on HV3b_V3(4) hybrids)
-    map_dacSelect[39] = std::make_tuple("CFG_ADC_VREF", 0, 0x3);
+    map_dacSelect[39] = std::make_tuple("CFG_VREF_ADC", 0, 0x3);
     //map_dacSelect[40] = std::make_tuple("CFG_", 0,);
     //map_dacSelect[41] = std::make_tuple("CFG_", 0,);
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1061,7 +1061,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, uint32_
                 int vfatObserved = 7-int(sbitAddress/192)+int((sbitAddress%192)/64)*8;
                 int sbitObserved = sbitAddress % 64;
 
-                outData[idx] = (clusterSize << 27) + (isValid << 26) + (vfatObserved << 21) + (vfatN << 16) + (sbitObserved << 8) + chan;
+                outData[idx] = ((clusterSize & 0x7 ) << 27) + ((isValid & 0x1) << 26) + ((vfatObserved & 0x1f) << 21) + ((vfatN & 0x1f) << 16) + ((sbitObserved & 0xff) << 8) + (chan & 0xff);
 
                 if(isValid){
                     LOGGER->log_message(
@@ -1471,7 +1471,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
 
             //Store value
             int idx = vfatN*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
-            vec_dacScanData[idx] = (ohN << 23) + (vfatN << 18) + (adcVal << 8) + dacVal;
+            vec_dacScanData[idx] = ((ohN & 0xf) << 23) + ((vfatN & 0x1f) << 18) + ((adcVal & 0x3ff) << 8) + (dacVal & 0xff);
         } //End Loop over VFATs
     } //End Loop over DAC values
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1349,7 +1349,7 @@ void checkSbitRateWithCalPulse(const RPCMsg *request, RPCMsg *response){
  *  \param dacStep step size to scan the dac in
  *  \param mask VFAT mask to use, a value of 1 in the N^th bit indicates the N^th VFAT is masked
  *  \param useExtRefADC if (true) false use the (externally) internally referenced ADC on the VFAT3 for monitoring
- *  \return Returns a std::vector<uint32_t> object of size 24*(dacMax-dacMin+1)/dacStep where dacMax and dacMin are described in the VFAT3 manual.  For each element bits [7:0] are the dacValue and bits [17:8] are the ADC readback value in either current or voltage units depending on dacSelect (again, see VFAT3 manual).
+ *  \return Returns a std::vector<uint32_t> object of size 24*(dacMax-dacMin+1)/dacStep where dacMax and dacMin are described in the VFAT3 manual.  For each element bits [7:0] are the dacValue, bits [17:8] are the ADC readback value in either current or voltage units depending on dacSelect (again, see VFAT3 manual), bits [22:18] are the VFAT position, and bits [26:23] are the optohybrid number.
  */
 std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSelect, uint32_t dacStep=1, uint32_t mask=0xFF000000, bool useExtRefADC=false){
     //Ensure VFAT3 Hardware
@@ -1471,7 +1471,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
 
             //Store value
             int idx = vfatN*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
-            vec_dacScanData[idx] = (adcVal << 8) + dacVal;
+            vec_dacScanData[idx] = (ohN << 23) + (vfatN << 18) + (adcVal << 8) + dacVal;
         } //End Loop over VFATs
     } //End Loop over DAC values
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1546,16 +1546,22 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
         }
 
         //Get vfatmask for this OH
+        LOGGER->log_message(LogManager::INFO, stdsprintf("Getting VFAT Mask for OH%i", ohN));
         uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
 
         //Get dac scan results for this optohybrid
+        LOGGER->log_message(LogManager::INFO, stdsprintf("Performing DAC Scan for OH%i", ohN));
         std::vector<uint32_t> dacScanResults = dacScanLocal(&la, ohN, dacSelect, dacStep, vfatMask, useExtRefADC);
 
         //Copy the results into the final container
-        std::copy(dacScanResults.begin(), dacScanResults.end(), dacScanResultsAll.end());
+        LOGGER->log_message(LogManager::INFO, stdsprintf("Storing results of DAC scan for OH%i", ohN));
+        std::copy(dacScanResults.begin(), dacScanResults.end(), std::back_inserter(dacScanResultsAll));
+
+        LOGGER->log_message(LogManager::INFO, stdsprintf("Finished DAC scan for OH%i", ohN));
     } //End Loop over all Optohybrids
 
     response->set_word_array("dacScanResultsAll",dacScanResultsAll);
+    LOGGER->log_message(LogManager::INFO, stdsprintf("Finished DAC scans for OH Mask 0x%x", ohMask));
 
     return;
 } //End dacScanMultiLink(...)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since each DAC of the VFAT has a different size, and in the case of the multilink scan not every OH may be scanned, I've modified the output dataword for the dac scan such that each word includes the VFAT position and the OH number.

This makes determining the origin of the word much easier.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Change is non breaking, previously bits [32:18] in each word where unused.  Bits [32:27] are still left empty.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See comments above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See: https://github.com/cms-gem-daq-project/vfatqc-python-scripts/pull/203

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
