### PR TITLE
New Feature: getmonOHSysmonLocal() can now read v2b sysmon values

### DIFF
--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -4,6 +4,7 @@
  *  \author Brian Dorney <brian.l.dorney@cern.ch>
  */
 
+#include "amc.h"
 #include "daq_monitor.h"
 #include <string>
 #include "utils.h"
@@ -357,66 +358,96 @@ void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask, bool doReset){
     std::string strKeyName;
     std::string strRegBase;
 
-    for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
-        // If this Optohybrid is masked skip it
-        if(!((ohMask >> ohN) & 0x1)){
-            continue;
-        }
+    if (fw_version_check("getmonOHSysmon", la) == 3){
+        for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
+            // If this Optohybrid is masked skip it
+            if(!((ohMask >> ohN) & 0x1)){
+                continue;
+            }
 
-        //Set regBase
-        strRegBase = stdsprintf("GEM_AMC.OH.OH%i.FPGA.ADC.CTRL.",ohN);
+            //Set regBase
+            strRegBase = stdsprintf("GEM_AMC.OH.OH%i.FPGA.ADC.CTRL.",ohN);
 
-        //Log Message
-        LOGGER->log_message(LogManager::INFO, stdsprintf("Reading Sysmon Values for OH%i",ohN));
+            //Log Message
+            LOGGER->log_message(LogManager::INFO, stdsprintf("Reading Sysmon Values for OH%i",ohN));
 
-        //Issue reset??
-        if(doReset){
-            LOGGER->log_message(LogManager::INFO, stdsprintf("Reseting CNT_OVERTEMP, CNT_VCCAUX_ALARM and CNT_VCCINT_ALARM for OH%i",ohN));
-            writeReg(la, strRegBase+"RESET", 0x1);
-        }
+            //Issue reset??
+            if(doReset){
+                LOGGER->log_message(LogManager::INFO, stdsprintf("Reseting CNT_OVERTEMP, CNT_VCCAUX_ALARM and CNT_VCCINT_ALARM for OH%i",ohN));
+                writeReg(la, strRegBase+"RESET", 0x1);
+            }
 
-        //Read Alarm conditions & counters - OVERTEMP
-        strKeyName = stdsprintf("OH%i.OVERTEMP",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "OVERTEMP"));
+            //Read Alarm conditions & counters - OVERTEMP
+            strKeyName = stdsprintf("OH%i.OVERTEMP",ohN);
+            la->response->set_word(strKeyName,readReg(la, strRegBase + "OVERTEMP"));
 
-        strKeyName = stdsprintf("OH%i.CNT_OVERTEMP",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_OVERTEMP"));
+            strKeyName = stdsprintf("OH%i.CNT_OVERTEMP",ohN);
+            la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_OVERTEMP"));
 
-        //Read Alarm conditions & counters - VCCAUX_ALARM
-        strKeyName = stdsprintf("OH%i.VCCAUX_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCAUX_ALARM"));
+            //Read Alarm conditions & counters - VCCAUX_ALARM
+            strKeyName = stdsprintf("OH%i.VCCAUX_ALARM",ohN);
+            la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCAUX_ALARM"));
 
-        strKeyName = stdsprintf("OH%i.CNT_VCCAUX_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCAUX_ALARM"));
+            strKeyName = stdsprintf("OH%i.CNT_VCCAUX_ALARM",ohN);
+            la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCAUX_ALARM"));
 
-        //Read Alarm conditions & counters - VCCINT_ALARM
-        strKeyName = stdsprintf("OH%i.VCCINT_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCINT_ALARM"));
+            //Read Alarm conditions & counters - VCCINT_ALARM
+            strKeyName = stdsprintf("OH%i.VCCINT_ALARM",ohN);
+            la->response->set_word(strKeyName,readReg(la, strRegBase + "VCCINT_ALARM"));
 
-        strKeyName = stdsprintf("OH%i.CNT_VCCINT_ALARM",ohN);
-        la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCINT_ALARM"));
+            strKeyName = stdsprintf("OH%i.CNT_VCCINT_ALARM",ohN);
+            la->response->set_word(strKeyName,readReg(la, strRegBase + "CNT_VCCINT_ALARM"));
 
-        //Enable Sysmon ADC Read
-        writeReg(la, strRegBase + "ENABLE", 0x1);
+            //Enable Sysmon ADC Read
+            writeReg(la, strRegBase + "ENABLE", 0x1);
 
-        //Read Sysmon Values - Core Temperature
-        writeReg(la, strRegBase + "ADR_IN", 0x0);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_TEMP",ohN);
-        la->response->set_word(strKeyName, ((readReg(la, strRegBase + "DATA_OUT") >> 6) & 0x3ff));
+            //Read Sysmon Values - Core Temperature
+            writeReg(la, strRegBase + "ADR_IN", 0x0);
+            strKeyName = stdsprintf("OH%i.FPGA_CORE_TEMP",ohN);
+            la->response->set_word(strKeyName, ((readReg(la, strRegBase + "DATA_OUT") >> 6) & 0x3ff));
 
-        //Read Sysmon Values - Core Voltage
-        writeReg(la, strRegBase + "ADR_IN", 0x1);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_1V0",ohN);
-        la->response->set_word(strKeyName, ((readReg(la, strRegBase + "DATA_OUT") >> 6) & 0x3ff));
+            //Read Sysmon Values - Core Voltage
+            writeReg(la, strRegBase + "ADR_IN", 0x1);
+            strKeyName = stdsprintf("OH%i.FPGA_CORE_1V0",ohN);
+            la->response->set_word(strKeyName, ((readReg(la, strRegBase + "DATA_OUT") >> 6) & 0x3ff));
 
-        //Read Sysmon Values - I/O Voltage
-        writeReg(la, strRegBase + "ADR_IN", 0x2);
-        strKeyName = stdsprintf("OH%i.FPGA_CORE_2V5_IO",ohN);
-        la->response->set_word(strKeyName, ((readReg(la, strRegBase + "DATA_OUT") >> 6) & 0x3ff));
+            //Read Sysmon Values - I/O Voltage
+            writeReg(la, strRegBase + "ADR_IN", 0x2);
+            strKeyName = stdsprintf("OH%i.FPGA_CORE_2V5_IO",ohN);
+            la->response->set_word(strKeyName, ((readReg(la, strRegBase + "DATA_OUT") >> 6) & 0x3ff));
 
-        //Disable Sysmon ADC Read
-        writeReg(la, strRegBase + "ENABLE", 0x0);
-    } //End Loop over all optohybrids
+            //Disable Sysmon ADC Read
+            writeReg(la, strRegBase + "ENABLE", 0x0);
+        } //End Loop over all optohybrids
+    } //End Case: v3 Electronics
+    else{ //Case: v2b Electronics
+        for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
+            // If this Optohybrid is masked skip it
+            if(!((ohMask >> ohN) & 0x1)){
+                continue;
+            }
+
+            //Set regBase
+            strRegBase = stdsprintf("GEM_AMC.OH.OH%i.ADC.",ohN);
+
+            //Log Message
+            LOGGER->log_message(LogManager::INFO, stdsprintf("Reading Sysmon Values for OH%i",ohN));
+
+            //Read Sysmon Values - Core Temperature
+            strKeyName = stdsprintf("OH%i.FPGA_CORE_TEMP",ohN);
+            la->response->set_word(strKeyName, ((readReg(la, strRegBase + "TEMP") >> 6) & 0x3ff));
+
+            //Read Sysmon Values - Core Voltage
+            strKeyName = stdsprintf("OH%i.FPGA_CORE_1V0",ohN);
+            la->response->set_word(strKeyName, ((readReg(la, strRegBase + "VCCINT") >> 6) & 0x3ff));
+
+            //Read Sysmon Values - I/O Voltage
+            strKeyName = stdsprintf("OH%i.FPGA_CORE_2V5_IO",ohN);
+            la->response->set_word(strKeyName, ((readReg(la, strRegBase + "VCCAUX") >> 6) & 0x3ff));
+        } //End Loop all optohybrids
+    } //End Case: v2b Electronics
+
+    return;
 } //End getmonOHSysmonLocal()
 
 void getmonOHSysmon(const RPCMsg *request, RPCMsg *response){

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -258,6 +258,12 @@ void getmonOHmain(const RPCMsg *request, RPCMsg *response)
 void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask){
     std::string strRegName, strKeyName;
 
+    //Get original monitoring mask
+    uint32_t initSCAMonOffMask = readReg(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
+
+    //Turn on monitoring for requested links
+    writeReg(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", (~ohMask) & 0x3fc);
+
     for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
@@ -329,6 +335,9 @@ void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask){
         strKeyName = stdsprintf("OH%i.VTRX_RSSI1",ohN);
         la->response->set_word(strKeyName, readReg(la, strRegName));
     } //End Loop over all optohybrids
+
+    //Return monitoring to original value
+    writeReg(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", initSCAMonOffMask);
 
     return;
 } //End getmonOHSCAmainLocal(...)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `getmonOHSysmonLocal(...)` function can now read OHv2b sysmon values.  The RPC response keys for v2b or v3 are identical.  However there does not appear to be the same implementation in the OHv2b address table (e.g. alarm and alarm counters for temperature and voltage); or I least could not find them in the ADC node.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Wanted a method at P5 for OHv2b sysmon parameter monitoring in daqmonitoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Asking @mexanick to test when he implements in `cmsgemos`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
