### PR TITLE
[WIP] add three new structs to pass a large number of arguments cleanly

### DIFF
--- a/include/calibration_routines.h
+++ b/include/calibration_routines.h
@@ -101,7 +101,7 @@ void dacMonConfLocal(localArgs * la, ParamScan *scanParams);
  *  \param ohN Optical link
  *  \param enable See detailed mehod description
  */
-void ttcGenToggleLocal(localArgs * la, ParamScan *scanParams, ParamTtcGen *ttcParams);
+void ttcGenToggleLocal(localArgs * la, ParamScan *scanParams, ParamTTCGen *ttcParams);
 
 /*! \fn void ttcGenToggle(const RPCMsg *request, RPCMsg *response)
  *  \brief Toggles the TTC Generator
@@ -146,7 +146,7 @@ void ttcGenToggle(const RPCMsg *request, RPCMsg *response);
  *  \param nPulses Number of calibration pulses to generate
  *  \param enable If true (false) ignore (take) ttc commands from backplane for this AMC (affects all links)
  */
-void ttcGenConfLocal(localArgs * la, ParamScan *scanParams, ParamTtcGen *ttcParams);
+void ttcGenConfLocal(localArgs * la, ParamScan *scanParams, ParamTTCGen *ttcParams);
 
 /*! \fn void ttcGenConf(const RPCMsg *request, RPCMsg *response)
  *  \brief Configures TTC generator
@@ -279,7 +279,7 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response);
  *  \param L1Ainterval How often to repeat signals (only for enable = true)
  *  \param pulseDelay delay between CalPulse and L1A
  */
-void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, ParamScan *scanParams, ParamTtcGen *ttcParams);
+void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, ParamScan *scanParams, ParamTTCGen *ttcParams);
 
 /*! \fn void checkSbitMappingWithCalPulse(const RPCMsg *request, RPCMsg *response)
  *  \brief Checks the sbit mapping using the calibration pulse. See the local callable methods documentation for details
@@ -304,7 +304,7 @@ void checkSbitMappingWithCalPulse(const RPCMsg *request, RPCMsg *response);
  *  \param pulseRate rate of calpulses to be sent in Hz
  *  \param pulseDelay delay between CalPulse and L1A
  */
-void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, uint32_t *outDataFPGAClusterCntRate, uint32_t *outDataVFATSBits, ParamCalPulse *calParams, ParamScan *scanParams, ParamTtcGen *ttcParams);
+void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, uint32_t *outDataFPGAClusterCntRate, uint32_t *outDataVFATSBits, ParamCalPulse *calParams, ParamScan *scanParams, ParamTTCGen *ttcParams);
 
 /*! \fn void checkSbitRateWithCalPulse(const RPCMsg *request, RPCMsg *response)
  *  \brief Checks the sbit rate using the calibration pulse. See the local callable methods documentation for details

--- a/include/calibration_routines.h
+++ b/include/calibration_routines.h
@@ -89,7 +89,7 @@ bool confCalPulseLocal(localArgs *la, ParamCalPulse *calParams, ParamScan *scanP
  *  \param ohN Optical link number
  *  \param ch Channel of interest
  */
-void dacMonConfLocal(localArgs * la, ParamScan *scanParams);
+void dacMonConfLocal(localArgs * la, uint32_t ohN, uint32_t ch);
 
 /*! \fn void ttcGenToggleLocal(localArgs * la, uint32_t ohN, bool enable)
  *  \brief Toggles the TTC Generator. Local callable version of ttcGenToggle
@@ -101,7 +101,7 @@ void dacMonConfLocal(localArgs * la, ParamScan *scanParams);
  *  \param ohN Optical link
  *  \param enable See detailed mehod description
  */
-void ttcGenToggleLocal(localArgs * la, ParamScan *scanParams, ParamTTCGen *ttcParams);
+void ttcGenToggleLocal(localArgs * la, uint32_t ohN, bool enable);
 
 /*! \fn void ttcGenToggle(const RPCMsg *request, RPCMsg *response)
  *  \brief Toggles the TTC Generator
@@ -146,7 +146,7 @@ void ttcGenToggle(const RPCMsg *request, RPCMsg *response);
  *  \param nPulses Number of calibration pulses to generate
  *  \param enable If true (false) ignore (take) ttc commands from backplane for this AMC (affects all links)
  */
-void ttcGenConfLocal(localArgs * la, ParamScan *scanParams, ParamTTCGen *ttcParams);
+void ttcGenConfLocal(localArgs * la, uint32_t ohN, ParamTTCGen *ttcParams);
 
 /*! \fn void ttcGenConf(const RPCMsg *request, RPCMsg *response)
  *  \brief Configures TTC generator
@@ -194,7 +194,7 @@ void ttcGenConf(const RPCMsg *request, RPCMsg *response);
  *  \param useUltra Set to 1 in order to use the ultra scan
  *  \param useExtTrig Set to 1 in order to use the backplane triggers
  */
-void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, ParamScan *scanParams);
+void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, ParamScan *scanParams, bool useExtTrig);
 
 /*! \fn void genScan(const RPCMsg *request, RPCMsg *response)
  *  \brief Generic calibration routine

--- a/include/calibration_routines.h
+++ b/include/calibration_routines.h
@@ -81,7 +81,7 @@ void applyChanMask(std::unordered_map<uint32_t, uint32_t> map_chanOrigMask, loca
  *  \param currentPulse Selects whether to use current or volage pulse
  *  \param calScaleFactor Scale factor for the calibration pulse height (00 = 25%, 01 = 50%, 10 = 75%, 11 = 100%)
  */
-bool confCalPulseLocal(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t ch, bool toggleOn, bool currentPulse, uint32_t calScaleFactor);
+bool confCalPulseLocal(localArgs *la, ParamCalPulse *calParams, ParamScan *scanParams);
 
 /*! \fn void dacMonConfLocal(localArgs * la, uint32_t ohN, uint32_t ch)
  *  \brief Configures DAQ monitor. Local version only
@@ -89,7 +89,7 @@ bool confCalPulseLocal(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t ch, 
  *  \param ohN Optical link number
  *  \param ch Channel of interest
  */
-void dacMonConfLocal(localArgs * la, uint32_t ohN, uint32_t ch);
+void dacMonConfLocal(localArgs * la, ParamScan *scanParams);
 
 /*! \fn void ttcGenToggleLocal(localArgs * la, uint32_t ohN, bool enable)
  *  \brief Toggles the TTC Generator. Local callable version of ttcGenToggle
@@ -101,7 +101,7 @@ void dacMonConfLocal(localArgs * la, uint32_t ohN, uint32_t ch);
  *  \param ohN Optical link
  *  \param enable See detailed mehod description
  */
-void ttcGenToggleLocal(localArgs * la, uint32_t ohN, bool enable);
+void ttcGenToggleLocal(localArgs * la, ParamScan *scanParams, ParamTtcGen *ttcParams);
 
 /*! \fn void ttcGenToggle(const RPCMsg *request, RPCMsg *response)
  *  \brief Toggles the TTC Generator
@@ -146,7 +146,7 @@ void ttcGenToggle(const RPCMsg *request, RPCMsg *response);
  *  \param nPulses Number of calibration pulses to generate
  *  \param enable If true (false) ignore (take) ttc commands from backplane for this AMC (affects all links)
  */
-void ttcGenConfLocal(localArgs * la, uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay, uint32_t L1Ainterval, uint32_t nPulses, bool enable);
+void ttcGenConfLocal(localArgs * la, ParamScan *scanParams, ParamTtcGen *ttcParams);
 
 /*! \fn void ttcGenConf(const RPCMsg *request, RPCMsg *response)
  *  \brief Configures TTC generator
@@ -194,7 +194,7 @@ void ttcGenConf(const RPCMsg *request, RPCMsg *response);
  *  \param useUltra Set to 1 in order to use the ultra scan
  *  \param useExtTrig Set to 1 in order to use the backplane triggers
  */
-void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask, uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg, bool useUltra, bool useExtTrig);
+void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, ParamScan *scanParams);
 
 /*! \fn void genScan(const RPCMsg *request, RPCMsg *response)
  *  \brief Generic calibration routine
@@ -228,7 +228,7 @@ void genScan(const RPCMsg *request, RPCMsg *response);
  *  \param scanReg DAC register to scan over name
  *  \waitTime Measurement duration per point in milliseconds
  */
-void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRate, uint32_t ohN, uint32_t maskOh, bool invertVFATPos, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg, uint32_t waitTime);
+void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRate, ParamScan *scanParams, bool invertVFATPos);
 
 /*! \fn void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ohN, uint32_t vfatmask, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg)
  *  \brief Parallel SBIT rate scan. Local version of sbitRateScan
@@ -253,7 +253,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
  *  \param dacStep Scan variable change step
  *  \param scanReg DAC register to scan over name
  */
-void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ohN, uint32_t vfatmask, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg);
+void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall,ParamScan *scanParams);
 
 /*! \fn void sbitRateScan(const RPCMsg *request, RPCMsg *response)
  *  \brief SBIT rate scan. See the local callable methods documentation for details
@@ -279,7 +279,7 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response);
  *  \param L1Ainterval How often to repeat signals (only for enable = true)
  *  \param pulseDelay delay between CalPulse and L1A
  */
-void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t vfatN, uint32_t mask, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t nevts, uint32_t L1Ainterval, uint32_t pulseDelay);
+void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, ParamScan *scanParams, ParamTtcGen *ttcParams);
 
 /*! \fn void checkSbitMappingWithCalPulse(const RPCMsg *request, RPCMsg *response)
  *  \brief Checks the sbit mapping using the calibration pulse. See the local callable methods documentation for details
@@ -304,7 +304,7 @@ void checkSbitMappingWithCalPulse(const RPCMsg *request, RPCMsg *response);
  *  \param pulseRate rate of calpulses to be sent in Hz
  *  \param pulseDelay delay between CalPulse and L1A
  */
-void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, uint32_t *outDataFPGAClusterCntRate, uint32_t *outDataVFATSBits, uint32_t ohN, uint32_t vfatN, uint32_t mask, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t waitTime, uint32_t pulseRate, uint32_t pulseDelay);
+void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, uint32_t *outDataFPGAClusterCntRate, uint32_t *outDataVFATSBits, ParamCalPulse *calParams, ParamScan *scanParams, ParamTtcGen *ttcParams);
 
 /*! \fn void checkSbitRateWithCalPulse(const RPCMsg *request, RPCMsg *response)
  *  \brief Checks the sbit rate using the calibration pulse. See the local callable methods documentation for details
@@ -323,7 +323,7 @@ void checkSbitRateWithCalPulse(const RPCMsg *request, RPCMsg *response);
  *  \param useExtRefADC if (true) false use the (externally) internally referenced ADC on the VFAT3 for monitoring
  *  \return Returns a std::vector<uint32_t> object of size 24*(dacMax-dacMin+1)/dacStep where dacMax and dacMin are described in the VFAT3 manual.  For each element bits [7:0] are the dacValue, bits [17:8] are the ADC readback value in either current or voltage units depending on dacSelect (again, see VFAT3 manual), bits [22:18] are the VFAT position, and bits [26:23] are the optohybrid number.
  */
-std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSelect, uint32_t dacStep=1, uint32_t mask=0xFF000000, bool useExtRefADC=false);
+std::vector<uint32_t> dacScanLocal(localArgs *la, ParamScan *scanParams, bool useExtRefADC=false);
 
 /*! \fn void dacScan(const RPCMsg *request, RPCMsg *response)
  *  \brief allows the host machine to perform a dacScan for all unmasked VFATs on a given optohybrid, see Local version for details.

--- a/include/optohybrid.h
+++ b/include/optohybrid.h
@@ -78,7 +78,7 @@ void broadcastRead(const RPCMsg *request, RPCMsg *response);
  *  \param dacMax Maximal value of scan variable
  *  \param dacStep Scan variable change step
  */
-void configureScanModuleLocal(localArgs * la, uint32_t ohN, uint32_t vfatN, uint32_t scanmode, bool useUltra, uint32_t mask, uint32_t ch, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep);
+void configureScanModuleLocal(localArgs * la, uint32_t scanmode, ParamScan *scanParams);
 
 /*! \fn void configureScanModule(const RPCMsg *request, RPCMsg *response)
  *  \brief Configures V2b FW scan module
@@ -103,7 +103,7 @@ void configureVFATs(const RPCMsg *request, RPCMsg *response);
  *  \param dacMax Maximal value of scan variable
  *  \param dacStep Scan variable change step
  */
-void getUltraScanResultsLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep);
+void getUltraScanResultsLocal(localArgs * la, uint32_t *outData, ParamScan *scanParams);
 
 /*! \fn void getUltraScanResults(const RPCMsg *request, RPCMsg *response)
  *  \brief Returns results of an ultra scan routine

--- a/include/utils.h
+++ b/include/utils.h
@@ -65,10 +65,10 @@ struct ParamScan{
     bool useUltra;   //Set to 1 in order to use the ultra scan
     bool useExtTrig; //Set to 1 in order to use the backplane triggers
 
-    uint32_t dacMax;    //Maximum dac value
-    uint32_t dacMin;    //Minimum dac value
+    uint32_t max;    //Maximum dac value
+    uint32_t min;    //Minimum dac value
     uint32_t dacSelect; //DAC to use for Monitoring
-    uint32_t dacStep;   //step size for dac
+    uint32_t step;   //step size for dac
     uint32_t nevts;     //Number of events
     uint32_t waitTime;  //unit of time; uints depend on function
 
@@ -81,9 +81,9 @@ struct ParamScan{
         useUltra = true;
         useExtTrig = false;
 
-        dacMax=254;
-        dacMin=0;
-        dacStep=1;
+        max=254;
+        min=0;
+        step=1;
         nevts=100;
     }
 }; //End ParamScan

--- a/include/utils.h
+++ b/include/utils.h
@@ -55,11 +55,9 @@ struct ParamCalPulse{
  */
 struct ParamScan{
     //Hardware selection
-    uint32_t ohN;       //optical link number
-    uint32_t ohMask;    //OH mask
-    uint32_t vfatN;     //VFAT number
-    uint32_t vfatMask;  //VFAT mask
-    uint32_t chan;      //channel of interest
+    uint32_t oh;       //optical link number or optical link mask
+    uint32_t vfat;     //VFAT number or VFAT mask
+    uint32_t chan;      //channel number
 
     //Params
     bool useUltra;   //Set to 1 in order to use the ultra scan
@@ -75,8 +73,8 @@ struct ParamScan{
     std::string scanReg;     //Register to scan against
 
     ParamScan(){
-        vfatMask = 0x0;
-        ohMask = 0xfff;
+        vfat = 0;
+        oh = 0;
 
         useUltra = true;
         useExtTrig = false;

--- a/include/utils.h
+++ b/include/utils.h
@@ -23,6 +23,9 @@
 
 memsvc_handle_t memsvc; /// \var global memory service handle required for registers read/write operations
 
+/*! \struct ParamScan
+ *  Contains arguments related to calibration pulses
+ */
 struct ParamCalPulse{
     bool enable; //true (false) turn on (off) calpulse
     bool isCurrent; //true (false) is current injection (voltage pulse)
@@ -47,17 +50,20 @@ struct ParamCalPulse{
     }
 }; //End ParamCalPulse
 
+/*! \struct ParamScan
+ *  Contains arguments related to scans
+ */
 struct ParamScan{
     //Hardware selection
-    uint32_t ohN;
-    uint32_t ohMask;
-    uint32_t vfatN;
-    uint32_t vfatMask;
+    uint32_t ohN;       //optical link number
+    uint32_t ohMask;    //OH mask
+    uint32_t vfatN;     //VFAT number
+    uint32_t vfatMask;  //VFAT mask
     uint32_t chan;      //channel of interest
 
     //Params
-    bool useUltra;
-    bool useExtTrig;
+    bool useUltra;   //Set to 1 in order to use the ultra scan
+    bool useExtTrig; //Set to 1 in order to use the backplane triggers
 
     uint32_t dacMax;    //Maximum dac value
     uint32_t dacMin;    //Minimum dac value
@@ -82,15 +88,18 @@ struct ParamScan{
     }
 }; //End ParamScan
 
+/*! \struct ParamTtcGen
+ *  Contains arguments related to ttc generation
+ */
 struct ParamTtcGen{
-    bool enable;
+    bool enable; //If true (false) ignore (take) ttc commands from backplane for this AMC (affects all links)
 
-    uint32_t L1Ainterval;
-    uint32_t mode;
-    uint32_t nPulses;
-    uint32_t pulseDelay;
-    uint32_t pulseRate;
-    uint32_t type;
+    uint32_t L1Ainterval; //How often to repeat signals
+    uint32_t mode; //T1 controller mode
+    uint32_t nPulses; //Number of calibration pulses to generate
+    uint32_t pulseDelay; //Delay between CalPulse and L1A
+    uint32_t pulseRate; //rate of calpulses to be sent in Hz
+    uint32_t type; //Type of T1 signal to send
 
     ParamTtcGen(){
         enable = false;

--- a/include/utils.h
+++ b/include/utils.h
@@ -55,7 +55,7 @@ struct ParamCalPulse{
  */
 struct ParamScan{
     //Hardware selection
-    uint32_t oh;       //optical link number or optical link mask
+    uint32_t oh;       //OH index or OH mask
     uint32_t vfat;     //VFAT number or VFAT mask
     uint32_t chan;      //channel number
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -88,10 +88,10 @@ struct ParamScan{
     }
 }; //End ParamScan
 
-/*! \struct ParamTtcGen
+/*! \struct ParamTTCGen
  *  Contains arguments related to ttc generation
  */
-struct ParamTtcGen{
+struct ParamTTCGen{
     bool enable; //If true (false) ignore (take) ttc commands from backplane for this AMC (affects all links)
 
     uint32_t L1Ainterval; //How often to repeat signals
@@ -101,7 +101,7 @@ struct ParamTtcGen{
     uint32_t pulseRate; //rate of calpulses to be sent in Hz
     uint32_t type; //Type of T1 signal to send
 
-    ParamTtcGen(){
+    ParamTTCGen(){
         enable = false;
 
         L1Ainterval = 250;
@@ -119,7 +119,7 @@ struct ParamTtcGen{
 
         return pulseRate;
     }
-}; //End ParamTtcGen
+}; //End ParamTTCGen
 
 /*! \struct localArgs
  *  Contains arguments required to execute the method locally

--- a/include/utils.h
+++ b/include/utils.h
@@ -23,19 +23,19 @@
 
 memsvc_handle_t memsvc; /// \var global memory service handle required for registers read/write operations
 
-/*! \struct ParamScan
- *  Contains arguments related to calibration pulses
+/*! \struct ParamCalPulse
+ *  Contains arguments related to calibration pulses. Helps to make functions that take a large number of these arguments more managable.
  */
 struct ParamCalPulse{
-    bool enable; //true (false) turn on (off) calpulse
-    bool isCurrent; //true (false) is current injection (voltage pulse)
+    bool enable; /*!< true (false) turn on (off) calpulse */
+    bool isCurrent; /*!< true (false) is current injection (voltage pulse) */
 
-    uint32_t duration; //duration in BX's (CFG_CAL_DUR)
-    uint32_t extVoltStep; //External voltage step 0->disable; 1->enable (CFG_CAL_EXT)
-    uint32_t height; //height of calpulse (CFG_CAL_DAC)
-    uint32_t phase; //phase of calpulse (CFG_CAL_PHI)
-    uint32_t polarity; //polarity of calpulse 0->pos; 1->neg (CFG_CAL_SEL_POL)
-    uint32_t scaleFactor; //current pulse scale factor (CFG_CAL_FS)
+    uint32_t duration; /*!< duration in BX's (CFG_CAL_DUR) */
+    uint32_t extVoltStep; /*!< External voltage step 0->disable; 1->enable (CFG_CAL_EXT) */
+    uint32_t height; /*!< height of calpulse (CFG_CAL_DAC) */
+    uint32_t phase; /*!< phase of calpulse (CFG_CAL_PHI) */
+    uint32_t polarity; /*!< polarity of calpulse 0->pos; 1->neg (CFG_CAL_SEL_POL) */
+    uint32_t scaleFactor; /*!< current pulse scale factor (CFG_CAL_FS) */
 
     ParamCalPulse(){
         enable = false;
@@ -51,24 +51,24 @@ struct ParamCalPulse{
 }; //End ParamCalPulse
 
 /*! \struct ParamScan
- *  Contains arguments related to scans
+ *  Contains arguments related to scans. Helps to make functions that take a large number of these arguments more managable.
  */
 struct ParamScan{
     //Hardware selection
-    uint32_t oh;       //OH index or OH mask
-    uint32_t vfat;     //VFAT number or VFAT mask
-    uint32_t chan;      //channel number
+    uint32_t oh;       /*!< OH index or OH mask */
+    uint32_t vfat;     /*!< VFAT number or VFAT mask */
+    uint32_t chan;      /*!< channel number */
 
     //Params
-    bool useUltra;   //Set to 1 in order to use the ultra scan
+    bool useUltra;   /*!< Set to 1 in order to use the ultra scan */
 
-    uint32_t max;    //Maximum dac value
-    uint32_t min;    //Minimum dac value
-    uint32_t step;   //step size for dac
-    uint32_t nevts;     //Number of events
-    uint32_t waitTime;  //unit of time; uints depend on function
+    uint32_t max;    /*!< Maximum dac value */
+    uint32_t min;    /*!< Minimum dac value */
+    uint32_t step;   /*!< step size for dac */
+    uint32_t nevts;     /*!< Number of events */
+    uint32_t waitTime;  /*!< unit of time; uints depend on function */
 
-    std::string scanReg;     //Register to scan against
+    std::string scanReg;     /*!< Register to scan against */
 
     ParamScan(){
         vfat = 0;
@@ -84,17 +84,17 @@ struct ParamScan{
 }; //End ParamScan
 
 /*! \struct ParamTTCGen
- *  Contains arguments related to ttc generation
+ *  Contains arguments related to ttc generation. Helps to make functions that take a large number of these arguments more managable.
  */
 struct ParamTTCGen{
-    bool enable; //If true (false) ignore (take) ttc commands from backplane for this AMC (affects all links)
+    bool enable; /*!< If true (false) ignore (take) ttc commands from backplane for this AMC (affects all links) */
 
-    uint32_t interval; //How often to repeat signals
-    uint32_t mode; //T1 controller mode
-    uint32_t nPulses; //Number of calibration pulses to generate
-    uint32_t delay; //Delay between CalPulse and L1A
-    uint32_t pulseRate; //rate of calpulses to be sent in Hz
-    uint32_t type; //Type of T1 signal to send
+    uint32_t interval; /*!< How often to repeat signals */
+    uint32_t mode; /*!< T1 controller mode */
+    uint32_t nPulses; /*!< Number of calibration pulses to generate */
+    uint32_t delay; /*!< Delay between CalPulse and L1A */
+    uint32_t pulseRate; /*!< rate of calpulses to be sent in Hz */
+    uint32_t type; /*!< Type of T1 signal to send */
 
     ParamTTCGen(){
         enable = false;

--- a/include/utils.h
+++ b/include/utils.h
@@ -94,24 +94,24 @@ struct ParamScan{
 struct ParamTTCGen{
     bool enable; //If true (false) ignore (take) ttc commands from backplane for this AMC (affects all links)
 
-    uint32_t L1Ainterval; //How often to repeat signals
+    uint32_t interval; //How often to repeat signals
     uint32_t mode; //T1 controller mode
     uint32_t nPulses; //Number of calibration pulses to generate
-    uint32_t pulseDelay; //Delay between CalPulse and L1A
+    uint32_t delay; //Delay between CalPulse and L1A
     uint32_t pulseRate; //rate of calpulses to be sent in Hz
     uint32_t type; //Type of T1 signal to send
 
     ParamTTCGen(){
         enable = false;
 
-        L1Ainterval = 250;
-        pulseDelay = 40;
-        pulseRate = 40079000 / L1Ainterval;
+        interval = 250;
+        delay = 40;
+        pulseRate = 40079000 / interval;
     }
 
     uint32_t calcRate(){
-        if(L1Ainterval > 0){
-            pulseRate = 40079000 / L1Ainterval;
+        if(interval > 0){
+            pulseRate = 40079000 / interval;
         }
         else{
             pulseRate = 0;

--- a/include/utils.h
+++ b/include/utils.h
@@ -61,11 +61,9 @@ struct ParamScan{
 
     //Params
     bool useUltra;   //Set to 1 in order to use the ultra scan
-    bool useExtTrig; //Set to 1 in order to use the backplane triggers
 
     uint32_t max;    //Maximum dac value
     uint32_t min;    //Minimum dac value
-    uint32_t dacSelect; //DAC to use for Monitoring
     uint32_t step;   //step size for dac
     uint32_t nevts;     //Number of events
     uint32_t waitTime;  //unit of time; uints depend on function
@@ -77,7 +75,6 @@ struct ParamScan{
         oh = 0;
 
         useUltra = true;
-        useExtTrig = false;
 
         max=254;
         min=0;

--- a/include/utils.h
+++ b/include/utils.h
@@ -23,6 +23,95 @@
 
 memsvc_handle_t memsvc; /// \var global memory service handle required for registers read/write operations
 
+struct ParamCalPulse{
+    bool enable; //true (false) turn on (off) calpulse
+    bool isCurrent; //true (false) is current injection (voltage pulse)
+
+    uint32_t duration; //duration in BX's (CFG_CAL_DUR)
+    uint32_t extVoltStep; //External voltage step 0->disable; 1->enable (CFG_CAL_EXT)
+    uint32_t height; //height of calpulse (CFG_CAL_DAC)
+    uint32_t phase; //phase of calpulse (CFG_CAL_PHI)
+    uint32_t polarity; //polarity of calpulse 0->pos; 1->neg (CFG_CAL_SEL_POL)
+    uint32_t scaleFactor; //current pulse scale factor (CFG_CAL_FS)
+
+    ParamCalPulse(){
+        enable = false;
+        isCurrent = false;
+
+        duration = 0x1ff;
+        extVoltStep = 0x0;
+        height = 0x0;
+        phase = 0x0;
+        polarity = 0x0;
+        scaleFactor = 0x0;
+    }
+}; //End ParamCalPulse
+
+struct ParamScan{
+    //Hardware selection
+    uint32_t ohN;
+    uint32_t ohMask;
+    uint32_t vfatN;
+    uint32_t vfatMask;
+    uint32_t chan;      //channel of interest
+
+    //Params
+    bool useUltra;
+    bool useExtTrig;
+
+    uint32_t dacMax;    //Maximum dac value
+    uint32_t dacMin;    //Minimum dac value
+    uint32_t dacSelect; //DAC to use for Monitoring
+    uint32_t dacStep;   //step size for dac
+    uint32_t nevts;     //Number of events
+    uint32_t waitTime;  //unit of time; uints depend on function
+
+    std::string scanReg;     //Register to scan against
+
+    ParamScan(){
+        vfatMask = 0x0;
+        ohMask = 0xfff;
+
+        useUltra = true;
+        useExtTrig = false;
+
+        dacMax=254;
+        dacMin=0;
+        dacStep=1;
+        nevts=100;
+    }
+}; //End ParamScan
+
+struct ParamTtcGen{
+    bool enable;
+
+    uint32_t L1Ainterval;
+    uint32_t mode;
+    uint32_t nPulses;
+    uint32_t pulseDelay;
+    uint32_t pulseRate;
+    uint32_t type;
+
+    ParamTtcGen(){
+        enable = false;
+
+        L1Ainterval = 250;
+        pulseDelay = 40;
+        pulseRate = 40079000 / L1Ainterval;
+    }
+
+    uint32_t calcRate(){
+        if(L1Ainterval > 0){
+            pulseRate = 40079000 / L1Ainterval;
+        }
+        else{
+            pulseRate = 0;
+        }
+
+        return pulseRate;
+    }
+}; //End ParamTtcGen
+
 /*! \struct localArgs
  *  Contains arguments required to execute the method locally
  */

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -681,12 +681,12 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
 void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall,ParamScan *scanParams)
 {
     uint32_t ohN = scanParams->oh;
-    uint32_t vfatmask = scanParams->vfat;    
+    uint32_t vfatmask = scanParams->vfat;
     uint32_t ch = scanParams->chan;
     uint32_t dacMin = scanParams->min;
     uint32_t dacMax = scanParams->max;
     uint32_t dacStep = scanParams->step;
-    std::string scanReg = scanParams->scanReg ;
+    std::string scanReg = scanParams->scanReg;
 
     char regBuf[200];
     switch (fw_version_check("SBIT Rate Scan", la)){
@@ -700,7 +700,7 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
                 la->response->set_string("error",regBuf);
                 return;
             }
-                
+
             //If ch!=128 store the original channel mask settings
             //Then mask all other channels except for channel ch
             std::unordered_map<uint32_t, uint32_t> map_chanOrigMask[24]; //key -> reg addr; val -> reg value

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -129,7 +129,7 @@ void dacMonConfLocal(localArgs * la, ParamScan *scanParams)
     return;
 }
 
-void ttcGenToggleLocal(localArgs * la, ParamScan *scanParams, ParamTtcGen *ttcParams)
+void ttcGenToggleLocal(localArgs * la, ParamScan *scanParams, ParamTTCGen *ttcParams)
 {
 
     uint32_t ohN = scanParams->ohN;
@@ -187,7 +187,7 @@ void ttcGenToggle(const RPCMsg *request, RPCMsg *response)
     auto dbi = lmdb::dbi::open(rtxn, nullptr);
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-    ParamTtcGen ttcParams;
+    ParamTTCGen ttcParams;
     ParamScan scanParams;
 
     scanParams.ohN = request->get_word("ohN");
@@ -199,7 +199,7 @@ void ttcGenToggle(const RPCMsg *request, RPCMsg *response)
     return;
 } //End ttcGenToggle(...)
 
-void ttcGenConfLocal(localArgs * la, ParamScan *scanParams, ParamTtcGen *ttcParams)
+void ttcGenConfLocal(localArgs * la, ParamScan *scanParams, ParamTTCGen *ttcParams)
 {
     uint32_t ohN = scanParams->ohN;
 
@@ -294,7 +294,7 @@ void ttcGenConf(const RPCMsg *request, RPCMsg *response)
     auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
     auto dbi = lmdb::dbi::open(rtxn, nullptr);
 
-    ParamTtcGen ttcParams;
+    ParamTTCGen ttcParams;
     ParamScan scanParams;
 
     scanParams.ohN = request->get_word("ohN");
@@ -830,7 +830,7 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response)
     return;
 } //End sbitRateScan(...)
 
-void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, ParamScan *scanParams, ParamTtcGen *ttcParams) {
+void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, ParamScan *scanParams, ParamTTCGen *ttcParams) {
 
     bool useCalPulse = calParams->enable;
     bool currentPulse = calParams->isCurrent;
@@ -878,7 +878,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
     setChannelRegistersVFAT3SimpleLocal(la, ohN, mask, chanRegData_tmp);
 
     //Setup TTC Generator
-    ParamTtcGen ttcParams_modified(*ttcParams); 
+    ParamTTCGen ttcParams_modified(*ttcParams); 
     ttcParams_modified.mode = 0;
     ttcParams_modified.type = 0;
     ttcParams_modified.nPulses = nevts;
@@ -986,7 +986,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
     writeReg(la,stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_RUN",ohN, vfatN), 0x0);
     //} //End Loop over all VFATs
 
-    ParamTtcGen ttcParams_disabled;
+    ParamTTCGen ttcParams_disabled;
     ttcParams_disabled.enable=false;
         
     //turn off TTC Generator
@@ -1024,7 +1024,7 @@ void checkSbitMappingWithCalPulse(const RPCMsg *request, RPCMsg *response){
 
     ParamCalPulse calParams;
     ParamScan scanParams;
-    ParamTtcGen ttcParams;
+    ParamTTCGen ttcParams;
 
     scanParams.ohN = ohN;
     scanParams.vfatN = vfatN;
@@ -1046,7 +1046,7 @@ void checkSbitMappingWithCalPulse(const RPCMsg *request, RPCMsg *response){
     return;
 } //End checkSbitMappingWithCalPulse()
 
-void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, uint32_t *outDataFPGAClusterCntRate, uint32_t *outDataVFATSBits, ParamCalPulse *calParams, ParamScan *scanParams, ParamTtcGen *ttcParams){
+void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, uint32_t *outDataFPGAClusterCntRate, uint32_t *outDataVFATSBits, ParamCalPulse *calParams, ParamScan *scanParams, ParamTTCGen *ttcParams){
 
     uint32_t ohN = scanParams->ohN;
     uint32_t vfatN = scanParams->vfatN;
@@ -1168,7 +1168,7 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
         //Start the TTC Generator
         LOGGER->log_message(LogManager::INFO, stdsprintf("Configuring TTC Generator to use OH %i with pulse delay %i and L1Ainterval %i",ohN,pulseDelay,L1Ainterval));
 
-        ParamTtcGen ttcParams_modified(*ttcParams);
+        ParamTTCGen ttcParams_modified(*ttcParams);
         
         ttcParams_modified.mode = 0;
         ttcParams_modified.type = 0;
@@ -1215,7 +1215,7 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
     //turn off TTC Generator
     LOGGER->log_message(LogManager::INFO, "Disabling TTC Generator");
 
-    ParamTtcGen ttcParams_disabled;
+    ParamTTCGen ttcParams_disabled;
     ttcParams_disabled.enable=false;
     
     ttcGenToggleLocal(la, scanParams, &ttcParams_disabled);
@@ -1252,7 +1252,7 @@ void checkSbitRateWithCalPulse(const RPCMsg *request, RPCMsg *response){
 
     ParamCalPulse calParams; 
     ParamScan scanParams;
-    ParamTtcGen ttcParams;
+    ParamTTCGen ttcParams;
     
     calParams.enable = useCalPulse;
     calParams.isCurrent = currentPulse;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -38,8 +38,8 @@ void applyChanMask(std::unordered_map<uint32_t, uint32_t> map_chanOrigMask, loca
 
 bool confCalPulseLocal(localArgs *la, ParamCalPulse *calParams, ParamScan *scanParams){
 
-    uint32_t ohN = scanParams->ohN;
-    uint32_t mask = scanParams->vfatMask;
+    uint32_t ohN = scanParams->oh;
+    uint32_t mask = scanParams->vfat;
     uint32_t ch = scanParams->chan;
     
     bool toggleOn = calParams->enable;
@@ -96,7 +96,7 @@ bool confCalPulseLocal(localArgs *la, ParamCalPulse *calParams, ParamScan *scanP
 void dacMonConfLocal(localArgs * la, ParamScan *scanParams)
 {
 
-    uint32_t ohN = scanParams->ohN;
+    uint32_t ohN = scanParams->oh;
     uint32_t ch = scanParams->chan;
     
     //Check the firmware version
@@ -132,7 +132,7 @@ void dacMonConfLocal(localArgs * la, ParamScan *scanParams)
 void ttcGenToggleLocal(localArgs * la, ParamScan *scanParams, ParamTTCGen *ttcParams)
 {
 
-    uint32_t ohN = scanParams->ohN;
+    uint32_t ohN = scanParams->oh;
 
     bool enable = ttcParams->enable;
     
@@ -190,7 +190,7 @@ void ttcGenToggle(const RPCMsg *request, RPCMsg *response)
     ParamTTCGen ttcParams;
     ParamScan scanParams;
 
-    scanParams.ohN = request->get_word("ohN");
+    scanParams.oh = request->get_word("ohN");
     
     ttcParams.enable = request->get_word("enable");
 
@@ -201,7 +201,7 @@ void ttcGenToggle(const RPCMsg *request, RPCMsg *response)
 
 void ttcGenConfLocal(localArgs * la, ParamScan *scanParams, ParamTTCGen *ttcParams)
 {
-    uint32_t ohN = scanParams->ohN;
+    uint32_t ohN = scanParams->oh;
 
     uint32_t mode = ttcParams->mode;
     uint32_t type = ttcParams->type;
@@ -297,7 +297,7 @@ void ttcGenConf(const RPCMsg *request, RPCMsg *response)
     ParamTTCGen ttcParams;
     ParamScan scanParams;
 
-    scanParams.ohN = request->get_word("ohN");
+    scanParams.oh = request->get_word("ohN");
     
     ttcParams.mode = request->get_word("mode");
     ttcParams.type = request->get_word("type");
@@ -307,7 +307,7 @@ void ttcGenConf(const RPCMsg *request, RPCMsg *response)
     ttcParams.enable = request->get_word("enable");
     
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-    LOGGER->log_message(LogManager::INFO, stdsprintf("Calling ttcGenConfLocal with ohN : %i, mode : %i, type : %i, pulse delay : %i, L1A interval : %i, number of pulses : %i", scanParams.ohN,ttcParams.mode,ttcParams.type,ttcParams.delay,ttcParams.interval,ttcParams.nPulses));
+    LOGGER->log_message(LogManager::INFO, stdsprintf("Calling ttcGenConfLocal with ohN : %i, mode : %i, type : %i, pulse delay : %i, L1A interval : %i, number of pulses : %i", scanParams.oh,ttcParams.mode,ttcParams.type,ttcParams.delay,ttcParams.interval,ttcParams.nPulses));
     ttcGenConfLocal(&la, &scanParams, &ttcParams);    
 
     return;
@@ -321,9 +321,9 @@ void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, Pa
     
     bool useExtTrig = scanParams->useExtTrig;
     bool useUltra = scanParams->useUltra; 
-    uint32_t ohN = scanParams->ohN;
+    uint32_t ohN = scanParams->oh;
     uint32_t nevts = scanParams->nevts;
-    uint32_t mask = scanParams->vfatMask;
+    uint32_t mask = scanParams->vfat;
     uint32_t ch = scanParams->chan;
     uint32_t dacMin = scanParams->min;
     uint32_t dacMax = scanParams->max;
@@ -489,7 +489,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, Pa
                 //If we are not performing an ultraScan, take the first non-masked VFAT
                 for(int vfat=0; vfat<24; ++vfat){
                     if((notmask >> vfat) & 0x1){
-                        scanParams_modified.vfatN = vfat; 
+                        scanParams_modified.vfat = vfat; 
                         break;
                     }
                 }
@@ -556,8 +556,8 @@ void genScan(const RPCMsg *request, RPCMsg *response)
     ParamScan scanParams;
     ParamCalPulse calParams;
 
-    scanParams.ohN = request->get_word("ohN");
-    scanParams.vfatMask = request->get_word("mask");
+    scanParams.oh = request->get_word("ohN");
+    scanParams.vfat = request->get_word("mask");
     scanParams.chan = request->get_word("ch");
     scanParams.nevts = request->get_word("nevts");
     scanParams.min = request->get_word("dacMin");
@@ -586,8 +586,8 @@ void genScan(const RPCMsg *request, RPCMsg *response)
 void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRate, ParamScan *scanParams, bool invertVFATPos)
 {
 
-    uint32_t ohN = scanParams->ohN;
-    uint32_t maskOh = scanParams->ohMask;
+    uint32_t ohN = scanParams->oh;
+    uint32_t maskOh = scanParams->vfat;
     uint32_t ch = scanParams->chan;
     uint32_t dacMin = scanParams->min;
     uint32_t dacMax = scanParams->max;
@@ -692,8 +692,8 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
 
 void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall,ParamScan *scanParams)
 {
-    uint32_t ohN = scanParams->ohN;
-    uint32_t vfatmask = scanParams->vfatMask;
+    uint32_t ohN = scanParams->oh;
+    uint32_t vfatmask = scanParams->vfat;    
     uint32_t ch = scanParams->chan;
     uint32_t dacMin = scanParams->min;
     uint32_t dacMax = scanParams->max;
@@ -712,7 +712,7 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
                 la->response->set_string("error",regBuf);
                 return;
             }
-
+                
             //If ch!=128 store the original channel mask settings
             //Then mask all other channels except for channel ch
             std::unordered_map<uint32_t, uint32_t> map_chanOrigMask[24]; //key -> reg addr; val -> reg value
@@ -799,8 +799,8 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response)
 
     ParamScan scanParams;
 
-    scanParams.ohN = request->get_word("ohN");
-    scanParams.ohMask = request->get_word("maskOh");
+    scanParams.oh = request->get_word("ohN");
+    scanParams.vfat = request->get_word("maskOh");
     scanParams.chan = request->get_word("ch");
     scanParams.min = request->get_word("dacMin");
     scanParams.max = request->get_word("dacMax");
@@ -836,15 +836,11 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
     bool currentPulse = calParams->isCurrent;
     uint32_t calScaleFactor = calParams->scaleFactor;
     
-    uint32_t ohN = scanParams->ohN;
-    uint32_t vfatN = scanParams->vfatN;
-    uint32_t mask = scanParams->vfatMask;
+    uint32_t ohN = scanParams->oh;
+    uint32_t vfatN = scanParams->vfat;
     uint32_t nevts = scanParams->nevts;
 
     uint32_t pulseDelay = ttcParams->delay;
-
-    //Determine the inverse of the vfatmask
-    uint32_t notmask = ~mask & 0xFFFFFF;
 
     char regBuf[200];
     if( fw_version_check("checkSbitMappingWithCalPulse", la) < 3){
@@ -855,12 +851,8 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
     }
 
     uint32_t goodVFATs = vfatSyncCheckLocal(la, ohN);
-    if( (notmask & goodVFATs) != notmask){
-        sprintf(regBuf,"One of the unmasked VFATs is not Synced. goodVFATs: %x\tnotmask: %x",goodVFATs,notmask);
-        la->response->set_string("error",regBuf);
-        return;
-    }
-
+    uint32_t mask = ~goodVFATs & 0xFFFFFF;
+    
     if (currentPulse && calScaleFactor > 3){
         sprintf(regBuf,"Bad value for CFG_CAL_FS: %x, Possible values are {0b00, 0b01, 0b10, 0b11}. Exiting.",calScaleFactor);
         la->response->set_string("error",regBuf);
@@ -904,7 +896,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
         addrSbitCluster[iCluster] = getAddress(la, regBuf);
     }
 
-    if(!((notmask >> vfatN) & 0x1)){
+    if(!((goodVFATs >> vfatN) & 0x1)){
         la->response->set_string("error",stdsprintf("The vfat of interest %i should not be part of the vfats to be masked: %x",vfatN, mask));
         return;
     }
@@ -920,7 +912,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
         writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.MASK",ohN,vfatN,chan), 0x0);
 
         ParamScan scanParams_modified(*scanParams);
-        scanParams_modified.vfatMask = ~((0x1)<<vfatN) & 0xFFFFFF;
+        scanParams_modified.vfat = ~((0x1)<<vfatN) & 0xFFFFFF;
         scanParams_modified.chan = chan;
         
         //Turn on the calpulse for this channel
@@ -1010,47 +1002,35 @@ void checkSbitMappingWithCalPulse(const RPCMsg *request, RPCMsg *response){
     auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
     auto dbi = lmdb::dbi::open(rtxn, nullptr);
 
-    uint32_t ohN = request->get_word("ohN");
-    uint32_t vfatN = request->get_word("vfatN");
-    uint32_t mask = request->get_word("mask");
-    bool useCalPulse = request->get_word("useCalPulse");
-    bool currentPulse = request->get_word("currentPulse");
-    uint32_t calScaleFactor = request->get_word("calScaleFactor");
-    uint32_t nevts = request->get_word("nevts");
-    uint32_t L1Ainterval = request->get_word("L1Ainterval");
-    uint32_t pulseDelay = request->get_word("pulseDelay");
-
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
 
     ParamCalPulse calParams;
     ParamScan scanParams;
     ParamTTCGen ttcParams;
 
-    scanParams.ohN = ohN;
-    scanParams.vfatN = vfatN;
-    scanParams.vfatMask = mask;
-    scanParams.nevts = nevts;
+    scanParams.oh = request->get_word("ohN");
+    scanParams.vfat = request->get_word("vfatN");
+    scanParams.nevts = request->get_word("nevts");
 
-    calParams.enable = useCalPulse;
-    calParams.isCurrent = currentPulse;
-    calParams.scaleFactor = calScaleFactor;
+    calParams.enable = request->get_word("useCalPulse");
+    calParams.isCurrent = request->get_word("currentPulse");
+    calParams.scaleFactor = request->get_word("calScaleFactor");
 
-    ttcParams.interval = L1Ainterval;
-    ttcParams.delay = pulseDelay;
+    ttcParams.interval = request->get_word("L1Ainterval");
+    ttcParams.delay = request->get_word("pulseDelay");
     
-    uint32_t outData[128*8*nevts];
+    uint32_t outData[128*8*scanParams.nevts];
     checkSbitMappingWithCalPulseLocal(&la, outData, &calParams, &scanParams, &ttcParams);
 
-    response->set_word_array("data",outData,128*8*nevts);
+    response->set_word_array("data",outData,128*8*scanParams.nevts);
 
     return;
 } //End checkSbitMappingWithCalPulse()
 
 void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, uint32_t *outDataFPGAClusterCntRate, uint32_t *outDataVFATSBits, ParamCalPulse *calParams, ParamScan *scanParams, ParamTTCGen *ttcParams){
 
-    uint32_t ohN = scanParams->ohN;
-    uint32_t vfatN = scanParams->vfatN;
-    uint32_t mask = scanParams->vfatMask;
+    uint32_t ohN = scanParams->oh;
+    uint32_t vfatN = scanParams->vfat;
     uint32_t waitTime = scanParams->waitTime;
 
     bool useCalPulse = calParams->enable;
@@ -1060,9 +1040,6 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
     uint32_t pulseRate = ttcParams->pulseRate;
     uint32_t pulseDelay = ttcParams->delay;
     
-    //Determine the inverse of the vfatmask
-    uint32_t notmask = ~mask & 0xFFFFFF;
-
     char regBuf[200];
     if( fw_version_check("checkSbitRateWithCalPulse", la) < 3){
         LOGGER->log_message(LogManager::ERROR, "checkSbitRateWithCalPulse is only supported in V3 electronics");
@@ -1072,12 +1049,8 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
     }
 
     uint32_t goodVFATs = vfatSyncCheckLocal(la, ohN);
-    if( (notmask & goodVFATs) != notmask){
-        sprintf(regBuf,"One of the unmasked VFATs is not Synced. goodVFATs: %x\tnotmask: %x",goodVFATs,notmask);
-        la->response->set_string("error",regBuf);
-        return;
-    }
-
+    uint32_t mask = ~goodVFATs & 0xFFFFFF;
+    
     if (currentPulse && calScaleFactor > 3){
         sprintf(regBuf,"Bad value for CFG_CAL_FS: %x, Possible values are {0b00, 0b01, 0b10, 0b11}. Exiting.",calScaleFactor);
         la->response->set_string("error",regBuf);
@@ -1130,7 +1103,7 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
     writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.FPGA.TRIG.CNT.SBIT_CNT_PERSIST",ohN), 0x0); //reset all counters after SBIT_CNT_TIME_MAX
     writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.FPGA.TRIG.CNT.SBIT_CNT_TIME_MAX",ohN), uint32_t(0x02638e98*waitTime/1000.) ); //count for a number of BX's specified by waitTime
 
-    if(!((notmask >> vfatN) & 0x1)){
+    if(!((goodVFATs >> vfatN) & 0x1)){
         la->response->set_string("error",stdsprintf("The vfat of interest %i should not be part of the vfats to be masked: %x",vfatN, mask));
         return;
     }
@@ -1152,7 +1125,7 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
         //Turn on the calpulse for this channel
         LOGGER->log_message(LogManager::INFO, stdsprintf("Enabling calpulse for channel %i on vfat %i of OH %i", chan, vfatN, ohN));
         ParamScan scanParams_modified(*scanParams);
-        scanParams_modified.vfatMask = ~((0x1)<<vfatN) & 0xFFFFFF;
+        scanParams_modified.vfat = ~((0x1)<<vfatN) & 0xFFFFFF;
         scanParams_modified.chan = chan;
         if (confCalPulseLocal(la, calParams, &scanParams_modified) == false){
             la->response->set_string("error",stdsprintf("Unable to configure calpulse %b for ohN %i mask %x chan %i", useCalPulse, ohN, ~((0x1)<<vfatN) & 0xFFFFFF, chan));
@@ -1240,31 +1213,20 @@ void checkSbitRateWithCalPulse(const RPCMsg *request, RPCMsg *response){
     auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
     auto dbi = lmdb::dbi::open(rtxn, nullptr);
 
-    uint32_t ohN = request->get_word("ohN");
-    uint32_t vfatN = request->get_word("vfatN");
-    uint32_t mask = request->get_word("mask");
-    bool useCalPulse = request->get_word("useCalPulse");
-    bool currentPulse = request->get_word("currentPulse");
-    uint32_t calScaleFactor = request->get_word("calScaleFactor");
-    uint32_t waitTime = request->get_word("waitTime");
-    uint32_t pulseRate = request->get_word("pulseRate");
-    uint32_t pulseDelay = request->get_word("pulseDelay");
-
     ParamCalPulse calParams; 
     ParamScan scanParams;
     ParamTTCGen ttcParams;
     
-    calParams.enable = useCalPulse;
-    calParams.isCurrent = currentPulse;
-    calParams.scaleFactor = calScaleFactor;
+    calParams.enable = request->get_word("useCalPulse");
+    calParams.isCurrent = request->get_word("currentPulse");
+    calParams.scaleFactor = request->get_word("calScaleFactor");
     
-    scanParams.ohN = ohN;
-    scanParams.vfatN = vfatN;
-    scanParams.vfatMask = mask;
-    scanParams.waitTime = waitTime;
+    scanParams.oh = request->get_word("ohN");
+    scanParams.vfat = request->get_word("vfatN");
+    scanParams.waitTime = request->get_word("waitTime");
     
-    ttcParams.pulseRate = pulseRate;
-    ttcParams.delay = pulseDelay;
+    ttcParams.pulseRate = request->get_word("pulseRate");
+    ttcParams.delay = request->get_word("pulseDelay");
     
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     uint32_t outDataCTP7Rate[128];
@@ -1282,10 +1244,10 @@ void checkSbitRateWithCalPulse(const RPCMsg *request, RPCMsg *response){
 std::vector<uint32_t> dacScanLocal(localArgs *la, ParamScan *scanParams, bool useExtRefADC)
 {
 
-    uint32_t ohN = scanParams->ohN;
+    uint32_t ohN = scanParams->oh;
     uint32_t dacSelect = scanParams->dacSelect;
     uint32_t dacStep = scanParams->step;
-    uint32_t mask = scanParams->vfatMask;
+    uint32_t mask = scanParams->vfat;
 
     //Ensure VFAT3 Hardware
     if(fw_version_check("dacScanLocal", la) < 3){
@@ -1439,10 +1401,10 @@ void dacScan(const RPCMsg *request, RPCMsg *response){
 
     ParamScan scanParams;
 
-    scanParams.ohN = ohN;
+    scanParams.oh = ohN;
     scanParams.dacSelect = dacSelect;
     scanParams.step = dacStep;
-    scanParams.vfatMask = mask;
+    scanParams.vfat = mask;
     
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     std::vector<uint32_t> dacScanResults = dacScanLocal(&la, &scanParams, useExtRefADC);
@@ -1495,10 +1457,10 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
 
         ParamScan scanParams;
 
-        scanParams.ohN = ohN;
+        scanParams.oh = ohN;
         scanParams.dacSelect = dacSelect;
         scanParams.step = dacStep;
-        scanParams.vfatMask = vfatMask;
+        scanParams.vfat = vfatMask;
         
         //Get dac scan results for this optohybrid
         LOGGER->log_message(LogManager::INFO, stdsprintf("Performing DAC Scan for OH%i", ohN));
@@ -1552,8 +1514,8 @@ void genChannelScan(const RPCMsg *request, RPCMsg *response)
         ParamScan scanParams;
         ParamCalPulse calParams;
 
-        scanParams.ohN = ohN;
-        scanParams.vfatMask = mask;
+        scanParams.oh = ohN;
+        scanParams.vfat = mask;
         scanParams.chan = ch;
         scanParams.nevts = nevts;
         scanParams.min = dacMin;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1502,7 +1502,7 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
         
         //Get dac scan results for this optohybrid
         LOGGER->log_message(LogManager::INFO, stdsprintf("Performing DAC Scan for OH%i", ohN));
-        dacScanResults = dacScanLocal(&la, &scanParams, useExtRefADC);        
+        dacScanResults = dacScanLocal(&la, &scanParams, useExtRefADC);
 
         //Copy the results into the final container
         LOGGER->log_message(LogManager::INFO, stdsprintf("Storing results of DAC scan for OH%i", ohN));

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -922,6 +922,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
         ParamScan scanParams_modified(*scanParams);
         
         scanParams_modified.vfatMask = ~((0x1)<<vfatN) & 0xFFFFFF;
+        scanParams_modified.chan = chan;
         
         //Turn on the calpulse for this channel
         if (confCalPulseLocal(la, calParams, &scanParams_modified) == false){

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -205,8 +205,8 @@ void ttcGenConfLocal(localArgs * la, ParamScan *scanParams, ParamTTCGen *ttcPara
 
     uint32_t mode = ttcParams->mode;
     uint32_t type = ttcParams->type;
-    uint32_t pulseDelay = ttcParams->pulseDelay;
-    uint32_t L1Ainterval = ttcParams->L1Ainterval;
+    uint32_t pulseDelay = ttcParams->delay;
+    uint32_t L1Ainterval = ttcParams->interval;
     uint32_t nPulses = ttcParams->nPulses;
     
     //Check firmware version
@@ -301,13 +301,13 @@ void ttcGenConf(const RPCMsg *request, RPCMsg *response)
     
     ttcParams.mode = request->get_word("mode");
     ttcParams.type = request->get_word("type");
-    ttcParams.pulseDelay = request->get_word("pulseDelay");
-    ttcParams.L1Ainterval = request->get_word("L1Ainterval");
+    ttcParams.delay = request->get_word("pulseDelay");
+    ttcParams.interval = request->get_word("L1Ainterval");
     ttcParams.nPulses = request->get_word("nPulses");
     ttcParams.enable = request->get_word("enable");
     
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-    LOGGER->log_message(LogManager::INFO, stdsprintf("Calling ttcGenConfLocal with ohN : %i, mode : %i, type : %i, pulse delay : %i, L1A interval : %i, number of pulses : %i", scanParams.ohN,ttcParams.mode,ttcParams.type,ttcParams.pulseDelay,ttcParams.L1Ainterval,ttcParams.nPulses));
+    LOGGER->log_message(LogManager::INFO, stdsprintf("Calling ttcGenConfLocal with ohN : %i, mode : %i, type : %i, pulse delay : %i, L1A interval : %i, number of pulses : %i", scanParams.ohN,ttcParams.mode,ttcParams.type,ttcParams.delay,ttcParams.interval,ttcParams.nPulses));
     ttcGenConfLocal(&la, &scanParams, &ttcParams);    
 
     return;
@@ -841,7 +841,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
     uint32_t mask = scanParams->vfatMask;
     uint32_t nevts = scanParams->nevts;
 
-    uint32_t pulseDelay = ttcParams->pulseDelay;
+    uint32_t pulseDelay = ttcParams->delay;
 
     //Determine the inverse of the vfatmask
     uint32_t notmask = ~mask & 0xFFFFFF;
@@ -1035,8 +1035,8 @@ void checkSbitMappingWithCalPulse(const RPCMsg *request, RPCMsg *response){
     calParams.isCurrent = currentPulse;
     calParams.scaleFactor = calScaleFactor;
 
-    ttcParams.L1Ainterval = L1Ainterval;
-    ttcParams.pulseDelay = pulseDelay;
+    ttcParams.interval = L1Ainterval;
+    ttcParams.delay = pulseDelay;
     
     uint32_t outData[128*8*nevts];
     checkSbitMappingWithCalPulseLocal(&la, outData, &calParams, &scanParams, &ttcParams);
@@ -1058,7 +1058,7 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
     uint32_t calScaleFactor = calParams->scaleFactor;
 
     uint32_t pulseRate = ttcParams->pulseRate;
-    uint32_t pulseDelay = ttcParams->pulseDelay;
+    uint32_t pulseDelay = ttcParams->delay;
     
     //Determine the inverse of the vfatmask
     uint32_t notmask = ~mask & 0xFFFFFF;
@@ -1264,7 +1264,7 @@ void checkSbitRateWithCalPulse(const RPCMsg *request, RPCMsg *response){
     scanParams.waitTime = waitTime;
     
     ttcParams.pulseRate = pulseRate;
-    ttcParams.pulseDelay = pulseDelay;
+    ttcParams.delay = pulseDelay;
     
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     uint32_t outDataCTP7Rate[128];

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -829,7 +829,8 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
     uint32_t nevts = scanParams->nevts;
 
     uint32_t pulseDelay = ttcParams->delay;
-
+    //uint32_t L1Ainterval = ttcParams->interval //not used in this function, but passed to ttcGenConfLocal through ttcParams
+    
     //Determine the inverse of the vfatmask
     uint32_t notmask = ~mask & 0xFFFFFF;
     

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -920,7 +920,6 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
         writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.MASK",ohN,vfatN,chan), 0x0);
 
         ParamScan scanParams_modified(*scanParams);
-        
         scanParams_modified.vfatMask = ~((0x1)<<vfatN) & 0xFFFFFF;
         scanParams_modified.chan = chan;
         
@@ -970,12 +969,11 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
             } //End Loop over clusters
         } //End Pulses for this channel
 
-        ParamCalPulse calParams_modified(*calParams);
-        
-        calParams_modified.enable = false;
+        ParamCalPulse calParams_disabled(*calParams);
+        calParams_disabled.enable = false;
         
         //Turn off the calpulse for this channel
-        if (confCalPulseLocal(la, &calParams_modified, scanParams) == false){
+        if (confCalPulseLocal(la, &calParams_disabled, &scanParams_modified) == false){
             la->response->set_string("error",stdsprintf("Unable to configure calpulse OFF for ohN %i mask %x chan %i", ohN, ~((0x1)<<vfatN) & 0xFFFFFF, chan));
             return; //Calibration pulse is not configured correctly
         }
@@ -1198,9 +1196,9 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
 
         //Turn off the calpulse for this channel
         LOGGER->log_message(LogManager::INFO, stdsprintf("Disabling calpulse for channel %i on vfat %i of OH %i", chan, vfatN, ohN));
-        ParamCalPulse calParams_modified(*calParams);
-        calParams_modified.enable = false;
-        if (confCalPulseLocal(la, &calParams_modified, &scanParams_modified) == false){
+        ParamCalPulse calParams_disabled(*calParams);
+        calParams_disabled.enable = false;
+        if (confCalPulseLocal(la, &calParams_disabled,&scanParams_modified) == false){
             la->response->set_string("error",stdsprintf("Unable to configure calpulse OFF for ohN %i mask %x chan %i", ohN, ~((0x1)<<vfatN) & 0xFFFFFF, chan));
             return; //Calibration pulse is not configured correctly
         }
@@ -1381,7 +1379,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, ParamScan *scanParams, bool us
 
     //Scan the DAC
 
-    uint32_t nReads=100;
+    int32_t nReads=100;
     for(uint32_t dacVal=dacMin; dacVal<=dacMax; dacVal += dacStep){ //Loop over DAC values
         for(int vfatN=0; vfatN<24; ++vfatN){ //Loop over VFATs
             //Skip masked VFATs

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -352,7 +352,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse calParams, Par
             if(useCalPulse){
                 calParams.enable = true; 
                 if (confCalPulseLocal(la, calParams, scanParams) == false){
-                    la->response->set_string("error",stdsprintf("Unable to configure calpulse ON for ohN %i mask %x chan %i", ohN, vfatMask, ch));
+                    la->response->set_string("error",stdsprintf("Unable to configure calpulse ON for ohN %i mask %x chan %i", ohN, mask, ch));
                     return; //Calibration pulse is not configured correctly
                 }
             } //End use calibration pulse
@@ -441,7 +441,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse calParams, Par
             if(useCalPulse){
                 calParams.enable = false; 
                 if (confCalPulseLocal(la, calParams, scanParams) == false){
-                    la->response->set_string("error",stdsprintf("Unable to configure calpulse OFF for ohN %i mask %x chan %i", ohN, vfatMask, ch));
+                    la->response->set_string("error",stdsprintf("Unable to configure calpulse OFF for ohN %i mask %x chan %i", ohN, mask, ch));
                     return; //Calibration pulse is not configured correctly
                 }
             }
@@ -489,7 +489,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse calParams, Par
                 }
             }
 
-            configureScanModuleLocal(la, ohN, vfatN, scanmode, useUltra, vfatMask, ch, nevts, dacMin, dacMax, dacStep);
+            configureScanModuleLocal(la, ohN, vfatN, scanmode, useUltra, mask, ch, nevts, dacMin, dacMax, dacStep);
 
             //Print scan configuration
             printScanConfigurationLocal(la, ohN, useUltra);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -189,6 +189,7 @@ void ttcGenToggle(const RPCMsg *request, RPCMsg *response)
 void ttcGenConfLocal(localArgs * la, ParamScan scanParams, ParamTtcGen ttcParams)
 {
     uint32_t ohN = scanParams.ohN;
+
     uint32_t mode = ttcParams.mode;
     uint32_t type = ttcParams.type;
     uint32_t pulseDelay = ttcParams.pulseDelay;
@@ -310,7 +311,10 @@ void ttcGenConf(const RPCMsg *request, RPCMsg *response)
 
 void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse calParams, ParamScan scanParams)
 {
-
+    bool useCalPulse = calParams.enable;
+    bool currentPulse = calParams.isCurrent;
+    bool calScaleFactor = calParams.scaleFactor;
+    
     bool useExtTrig = scanParams.useExtTrig;
     bool useUltra = scanParams.useUltra; 
     uint32_t ohN = scanParams.ohN ;
@@ -322,10 +326,6 @@ void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse calParams, Par
     uint32_t dacStep = scanParams.dacStep;
     std::string scanReg = scanParams.scanReg;
 
-    bool useCalPulse = calParams.enable;
-    bool currentPulse = calParams.isCurrent;
-    bool calScaleFactor = calParams.scaleFactor;
-    
     //Determine the inverse of the vfatmask
     uint32_t notmask = ~mask & 0xFFFFFF;
 
@@ -608,7 +608,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     switch (fw_version_check("SBIT Rate Scan", la)){
         case 3:
         {
-            //Hard code possible maskOh values and how they map to vfatN
+            //Hard code possible mask values and how they map to vfatN
             std::unordered_map<uint32_t,uint32_t> map_maskOh2vfatN;
             map_maskOh2vfatN[0xfffffe] = 0;
             map_maskOh2vfatN[0xfffffd] = 1;
@@ -635,7 +635,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
             map_maskOh2vfatN[0xbfffff] = 22;
             map_maskOh2vfatN[0x7fffff] = 23;
 
-            //Determine vfatN based on input maskOh
+            //Determine vfatN based on input mask
             auto vfatNptr = map_maskOh2vfatN.find(maskOh);
             if( vfatNptr == map_maskOh2vfatN.end() ){
                 sprintf(regBuf,"Input maskOh: %x not recgonized. Please make sure all but one VFAT is unmasked and then try again", maskOh);
@@ -849,13 +849,15 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response)
 
 void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCalPulse calParams, ParamScan scanParams, ParamTtcGen ttcParams) {
 
+    bool useCalPulse = calParams.enable;
+    bool currentPulse = calParams.isCurrent;
+    uint32_t calScaleFactor = calParams.scaleFactor;
+    
     uint32_t ohN = scanParams.ohN;
     uint32_t vfatN = scanParams.vfatN;
     uint32_t mask = scanParams.vfatMask;
     uint32_t nevts = scanParams.nevts;
-    bool useCalPulse = calParams.enable;
-    bool currentPulse = calParams.isCurrent;
-    uint32_t calScaleFactor = calParams.scaleFactor;
+
     uint32_t pulseDelay = ttcParams.pulseDelay;
 
     //Determine the inverse of the vfatmask

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -484,18 +484,18 @@ void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, Pa
             }
 
             //Configure scan module
-            uint32_t vfatN = 0;
+            ParamScan scanParams_modified(*scanParams);
             if (!useUltra){
                 //If we are not performing an ultraScan, take the first non-masked VFAT
                 for(int vfat=0; vfat<24; ++vfat){
                     if((notmask >> vfat) & 0x1){
-                        vfatN=vfat;
+                        scanParams_modified.vfatN = vfat; 
                         break;
                     }
                 }
             }
-
-            configureScanModuleLocal(la, ohN, vfatN, scanmode, useUltra, mask, ch, nevts, dacMin, dacMax, dacStep);
+            
+            configureScanModuleLocal(la, scanmode, &scanParams_modified);
 
             //Print scan configuration
             printScanConfigurationLocal(la, ohN, useUltra);
@@ -531,7 +531,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse *calParams, Pa
             }
 
             //Get scan results
-            getUltraScanResultsLocal(la, outData, ohN, nevts, dacMin, dacMax, dacStep);
+            getUltraScanResultsLocal(la, outData, scanParams);
             break;
         }//End v2b electronics behavior
         default:

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -693,7 +693,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
 void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall,ParamScan *scanParams)
 {
     uint32_t ohN = scanParams->ohN;
-    uint32_t vfatmask = scanParams->ohN;
+    uint32_t vfatmask = scanParams->vfatMask;
     uint32_t ch = scanParams->chan;
     uint32_t dacMin = scanParams->min;
     uint32_t dacMax = scanParams->max;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -39,15 +39,15 @@ void applyChanMask(std::unordered_map<uint32_t, uint32_t> map_chanOrigMask, loca
 bool confCalPulseLocal(localArgs *la, ParamCalPulse calParams, ParamScan scanParams){
 
     uint32_t ohN = scanParams.ohN;
-    uint32_t vfatMask = scanParams.vfatMask;
+    uint32_t mask = scanParams.vfatMask;
     uint32_t ch = scanParams.chan;
     
     bool toggleOn = calParams.enable;
-    bool isCurrentPulse = calParams.isCurrent;
+    bool currentPulse = calParams.isCurrent;
     uint32_t calScaleFactor = calParams.scaleFactor;
     
     //Determine the inverse of the vfatmask
-    uint32_t notmask = ~vfatMask & 0xFFFFFF;
+    uint32_t notmask = ~mask & 0xFFFFFF;
 
     char regBuf[200];
     if(ch >= 128 && toggleOn == true){ //Case: Bad Config, asked for OR of all channels
@@ -71,7 +71,7 @@ bool confCalPulseLocal(localArgs *la, ParamCalPulse calParams, ParamScan scanPar
                 sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.VFAT_CHANNELS.CHANNEL%i.CALPULSE_ENABLE", ohN, vfatN, ch);
                 if(toggleOn == true){ //Case: turn calpulse on
                     writeReg(la, regBuf, 0x1);
-                    if(isCurrentPulse){ //Case: cal mode current injection
+                    if(currentPulse){ //Case: cal mode current injection
                         writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_CAL_MODE", ohN, vfatN), 0x2);
 
                         //Set cal current pulse scale factor. Q = CAL DUR[s] * CAL DAC * 10nA * CAL FS[%] (00 = 25%, 01 = 50%, 10 = 75%, 11 = 100%)
@@ -315,7 +315,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse calParams, Par
     bool useUltra = scanParams.useUltra; 
     uint32_t ohN = scanParams.ohN ;
     uint32_t nevts = scanParams.nevts ;
-    uint32_t vfatMask = scanParams.vfatMask;
+    uint32_t mask = scanParams.vfatMask;
     uint32_t ch = scanParams.chan;
     uint32_t dacMin = scanParams.dacMin;
     uint32_t dacMax = scanParams.dacMax;
@@ -323,11 +323,11 @@ void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse calParams, Par
     std::string scanReg = scanParams.scanReg;
 
     bool useCalPulse = calParams.enable;
-    bool isCurrentPulse = calParams.isCurrent;
+    bool currentPulse = calParams.isCurrent;
     bool calScaleFactor = calParams.scaleFactor;
     
     //Determine the inverse of the vfatmask
-    uint32_t notmask = ~vfatMask & 0xFFFFFF;
+    uint32_t notmask = ~mask & 0xFFFFFF;
 
     //Check firmware version
     switch(fw_version_check("genScanLocal", la)) {
@@ -342,7 +342,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, ParamCalPulse calParams, Par
                 return;
             }
 
-            if (isCurrentPulse && calScaleFactor > 3){
+            if (currentPulse && calScaleFactor > 3){
                 sprintf(regBuf,"Bad value for CFG_CAL_FS: %x, Possible values are {0b00, 0b01, 0b10, 0b11}. Exiting.",calScaleFactor);
                 la->response->set_string("error",regBuf);
                 return;
@@ -854,7 +854,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
     uint32_t mask = scanParams.vfatMask;
     uint32_t nevts = scanParams.nevts;
     bool useCalPulse = calParams.enable;
-    bool isCurrentPulse = calParams.isCurrent;
+    bool currentPulse = calParams.isCurrent;
     uint32_t calScaleFactor = calParams.scaleFactor;
     uint32_t pulseDelay = ttcParams.pulseDelay;
 
@@ -876,7 +876,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, ParamCa
         return;
     }
 
-    if (isCurrentPulse && calScaleFactor > 3){
+    if (currentPulse && calScaleFactor > 3){
         sprintf(regBuf,"Bad value for CFG_CAL_FS: %x, Possible values are {0b00, 0b01, 0b10, 0b11}. Exiting.",calScaleFactor);
         la->response->set_string("error",regBuf);
         return;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1154,6 +1154,7 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
         LOGGER->log_message(LogManager::INFO, stdsprintf("Enabling calpulse for channel %i on vfat %i of OH %i", chan, vfatN, ohN));
         ParamScan scanParams_modified(*scanParams);
         scanParams_modified.vfatMask = ~((0x1)<<vfatN) & 0xFFFFFF;
+        scanParams_modified.chan = chan;
         if (confCalPulseLocal(la, calParams, &scanParams_modified) == false){
             la->response->set_string("error",stdsprintf("Unable to configure calpulse %b for ohN %i mask %x chan %i", useCalPulse, ohN, ~((0x1)<<vfatN) & 0xFFFFFF, chan));
             return; //Calibration pulse is not configured correctly

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1279,7 +1279,7 @@ void checkSbitRateWithCalPulse(const RPCMsg *request, RPCMsg *response){
     return;
 } //End checkSbitRateWithCalPulse()
 
-std::vector<uint32_t> dacScanLocal(localArgs *la, ParamScan *scanParams, bool useExtRefADC=false)
+std::vector<uint32_t> dacScanLocal(localArgs *la, ParamScan *scanParams, bool useExtRefADC)
 {
 
     uint32_t ohN = scanParams->ohN;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -284,10 +284,9 @@ void ttcGenConf(const RPCMsg *request, RPCMsg *response)
     auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
     auto dbi = lmdb::dbi::open(rtxn, nullptr);
 
-    ParamTTCGen ttcParams;
-    ParamScan scanParams;
+    uint32_t oh = request->get_word("ohN");
 
-    scanParams.oh = request->get_word("ohN");
+    ParamTTCGen ttcParams;
     
     ttcParams.mode = request->get_word("mode");
     ttcParams.type = request->get_word("type");
@@ -297,8 +296,8 @@ void ttcGenConf(const RPCMsg *request, RPCMsg *response)
     ttcParams.enable = request->get_word("enable");
     
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-    LOGGER->log_message(LogManager::INFO, stdsprintf("Calling ttcGenConfLocal with ohN : %i, mode : %i, type : %i, pulse delay : %i, L1A interval : %i, number of pulses : %i", scanParams.oh,ttcParams.mode,ttcParams.type,ttcParams.delay,ttcParams.interval,ttcParams.nPulses));
-    ttcGenConfLocal(&la, &scanParams, &ttcParams);    
+    LOGGER->log_message(LogManager::INFO, stdsprintf("Calling ttcGenConfLocal with ohN : %i, mode : %i, type : %i, pulse delay : %i, L1A interval : %i, number of pulses : %i", oh,ttcParams.mode,ttcParams.type,ttcParams.delay,ttcParams.interval,ttcParams.nPulses));
+    ttcGenConfLocal(&la, oh, &ttcParams);    
 
     return;
 }

--- a/src/optohybrid.cpp
+++ b/src/optohybrid.cpp
@@ -254,9 +254,9 @@ void configureScanModuleLocal(localArgs * la, uint32_t scanmode, ParamScan *scan
     uint32_t mask = scanParams->vfatMask;
     uint32_t ch = scanParams->chan;
     uint32_t nevts = scanParams->nevts;
-    uint32_t dacMin = scanParams->dacMin;
-    uint32_t dacMax = scanParams->dacMax;
-    uint32_t dacStep = scanParams->dacStep;
+    uint32_t dacMin = scanParams->min;
+    uint32_t dacMax = scanParams->max;
+    uint32_t dacStep = scanParams->step;
 
     /*
      *     Configure the firmware scan controller
@@ -341,9 +341,9 @@ void configureScanModule(const RPCMsg *request, RPCMsg *response){
 
     scanParams.chan = request->get_word("ch");
     scanParams.nevts = request->get_word("nevts");
-    scanParams.dacMin = request->get_word("dacMin");
-    scanParams.dacMax = request->get_word("dacMax");
-    scanParams.dacStep = request->get_word("dacStep");
+    scanParams.min = request->get_word("dacMin");
+    scanParams.max = request->get_word("dacMax");
+    scanParams.step = request->get_word("dacStep");
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     configureScanModuleLocal(&la, scanmode, &scanParams);
@@ -475,9 +475,9 @@ void getUltraScanResultsLocal(localArgs * la, uint32_t *outData, ParamScan *scan
 {
     uint32_t ohN = scanParams->ohN;
     uint32_t nevts = scanParams->nevts;
-    uint32_t dacMin = scanParams->dacMin;
-    uint32_t dacMax = scanParams->dacMax;
-    uint32_t dacStep = scanParams->dacStep;
+    uint32_t dacMin = scanParams->min;
+    uint32_t dacMax = scanParams->max;
+    uint32_t dacStep = scanParams->step;
     
     std::stringstream sstream;
     sstream<<ohN;
@@ -551,15 +551,15 @@ void getUltraScanResults(const RPCMsg *request, RPCMsg *response){
     ParamScan scanParams;
     scanParams.ohN = request->get_word("ohN");
     scanParams.nevts = request->get_word("nevts");
-    scanParams.dacMin = request->get_word("dacMin");
-    scanParams.dacMax = request->get_word("dacMax");
-    scanParams.dacStep = request->get_word("dacStep");
+    scanParams.min = request->get_word("dacMin");
+    scanParams.max = request->get_word("dacMax");
+    scanParams.step = request->get_word("dacStep");
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-    uint32_t outData[24*(scanParams.dacMax-scanParams.dacMin+1)/scanParams.dacStep];
+    uint32_t outData[24*(scanParams.max-scanParams.min+1)/scanParams.step];
 
     getUltraScanResultsLocal(&la, outData, &scanParams);
-    response->set_word_array("data",outData,24*(scanParams.dacMax-scanParams.dacMin+1)/scanParams.dacStep);
+    response->set_word_array("data",outData,24*(scanParams.max-scanParams.min+1)/scanParams.step);
 
     return;
 } //End getUltraScanResults(...)

--- a/src/optohybrid.cpp
+++ b/src/optohybrid.cpp
@@ -355,6 +355,7 @@ void configureScanModule(const RPCMsg *request, RPCMsg *response){
     ps.dacStep = dacStep;
     ps.ohN = ohN;
     ps.vfatN = vfatN;
+    ps.vfatMask = mask;
     ps.useUltra = useUltra;
     
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};

--- a/src/optohybrid.cpp
+++ b/src/optohybrid.cpp
@@ -248,10 +248,9 @@ void configureVFATs(const RPCMsg *request, RPCMsg *response) {
 
 void configureScanModuleLocal(localArgs * la, uint32_t scanmode, ParamScan *scanParams)
 {
-    uint32_t ohN = scanParams->ohN;
-    uint32_t vfatN = scanParams->vfatN;
+    uint32_t ohN = scanParams->oh;
     bool useUltra = scanParams->useUltra;
-    uint32_t mask = scanParams->vfatMask;
+    uint32_t vfat = scanParams->vfat; //if using ultra, this should be a VFAT mask; if not using ultra, this should be a VFAT number
     uint32_t ch = scanParams->chan;
     uint32_t nevts = scanParams->nevts;
     uint32_t dacMin = scanParams->min;
@@ -290,10 +289,10 @@ void configureScanModuleLocal(localArgs * la, uint32_t scanmode, ParamScan *scan
     // write scan parameters
     writeReg(la, scanBase + ".MODE", scanmode);
     if (useUltra){
-        writeReg(la, scanBase + ".MASK", mask);
+        writeReg(la, scanBase + ".MASK", vfat);
     }
     else{
-        writeReg(la, scanBase + ".CHIP", vfatN);
+        writeReg(la, scanBase + ".CHIP", vfat);
     }
     writeReg(la, scanBase + ".CHAN", ch);
     writeReg(la, scanBase + ".NTRIGS", nevts);
@@ -327,16 +326,16 @@ void configureScanModule(const RPCMsg *request, RPCMsg *response){
     ParamScan scanParams;
     
     //Get OH and scanmode
-    scanParams.ohN = request->get_word("ohN");
+    scanParams.oh = request->get_word("ohN");
     uint32_t scanmode = request->get_word("scanmode");
 
     //Setup ultra mode, mask, and/or vfat number
     if (request->get_key_exists("useUltra")){
         scanParams.useUltra = true;
-        scanParams.vfatMask = request->get_word("mask");
+        scanParams.vfat = request->get_word("mask");
     }
     else{
-        scanParams.vfatN = request->get_word("vfatN");
+        scanParams.vfat = request->get_word("vfatN");
     }
 
     scanParams.chan = request->get_word("ch");
@@ -473,7 +472,7 @@ void startScanModule(const RPCMsg *request, RPCMsg *response){
 
 void getUltraScanResultsLocal(localArgs * la, uint32_t *outData, ParamScan *scanParams)
 {
-    uint32_t ohN = scanParams->ohN;
+    uint32_t ohN = scanParams->oh;
     uint32_t nevts = scanParams->nevts;
     uint32_t dacMin = scanParams->min;
     uint32_t dacMax = scanParams->max;
@@ -549,7 +548,7 @@ void getUltraScanResults(const RPCMsg *request, RPCMsg *response){
     auto dbi = lmdb::dbi::open(rtxn, nullptr);
 
     ParamScan scanParams;
-    scanParams.ohN = request->get_word("ohN");
+    scanParams.oh = request->get_word("ohN");
     scanParams.nevts = request->get_word("nevts");
     scanParams.min = request->get_word("dacMin");
     scanParams.max = request->get_word("dacMax");


### PR DESCRIPTION
Some of the functions in calibration_routines.cpp and optohybrid.cpp now take a large number of arguments. There is also large overlap between the arguments that the different functions take. We can use structs to more elegantly pass these arguments.

## Description
Three new structs have been defined in `include/utils.h` for calpulse-related arguments, scan-related arguments, and ttcgen-related arguments:

```
struct ParamCalPulse{
    bool enable; //true (false) turn on (off) calpulse
    bool isCurrent; //true (false) is current injection (voltage pulse)

    uint32_t duration; //duration in BX's (CFG_CAL_DUR)
    uint32_t extVoltStep; //External voltage step 0->disable; 1->enable (CFG_CAL_EXT)
    uint32_t height; //height of calpulse (CFG_CAL_DAC)
    uint32_t phase; //phase of calpulse (CFG_CAL_PHI)
    uint32_t polarity; //polarity of calpulse 0->pos; 1->neg (CFG_CAL_SEL_POL)
    uint32_t scaleFactor; //current pulse scale factor (CFG_CAL_FS)

    ParamCalPulse(){
        enable = false;
        isCurrent = false;

        duration = 0x1ff;
        extVoltStep = 0x0;
        height = 0x0;
        phase = 0x0;
        polarity = 0x0;
        scaleFactor = 0x0;
    }
}; //End ParamCalPulse

struct ParamScan{
    //Hardware selection
    uint32_t ohN;
    uint32_t ohMask;
    uint32_t vfatN;
    uint32_t vfatMask;
    uint32_t chan;      //channel of interest

    //Params
    bool useUltra;
    bool useExtTrig;

    uint32_t dacMax;    //Maximum dac value
    uint32_t dacMin;    //Minimum dac value
    uint32_t dacSelect; //DAC to use for Monitoring
    uint32_t dacStep;   //step size for dac
    uint32_t nevts;     //Number of events
    uint32_t waitTime;  //unit of time; uints depend on function

    std::string scanReg;     //Register to scan against

    ParamScan(){
        vfatMask = 0x0;
        ohMask = 0xfff;

        useUltra = true;
        useExtTrig = false;

        dacMax=254;
        dacMin=0;
        dacStep=1;
        nevts=100;
    }
}; //End ParamScan

struct ParamTtcGen{
    bool enable;

    uint32_t L1Ainterval;
    uint32_t mode;
    uint32_t nPulses;
    uint32_t pulseDelay;
    uint32_t pulseRate;
    uint32_t type;

    ParamTtcGen(){
        enable = false;

        L1Ainterval = 250;
        pulseDelay = 40;
        pulseRate = 40079000 / L1Ainterval;
    }

    uint32_t calcRate(){
        if(L1Ainterval > 0){
            pulseRate = 40079000 / L1Ainterval;
        }
        else{
            pulseRate = 0;
        }

        return pulseRate;
    }
}; //End ParamTtcGen
```
The following 9 functions have been modified to take these structs:

`confCalPulseLocal` in `src/calibration_routines.cpp`
`ttcGenConfLocal` in `src/calibration_routines.cpp`
`genScanLocal` in `src/calibration_routines.cpp`
`sbitRateScanLocal` in `src/calibration_routines.cpp`
`sbitRateScanParallelLocal` in `src/calibration_routines.cpp`
`checkSbitMappingWithCalPulseLocal` in `src/calibration_routines.cpp`
`checkSbitRateWithCalPulseLocal` in `src/calibration_routines.cpp`
`dacScanLocal` in `src/calibration_routines.cpp`
`configureScanModuleLocal` in `src/optohybrid.cpp`
`getUltraScanResultsLocal` in `src/optohybrid.cpp`

All of the places where these functions are called have been modified to pass these structs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This change was requested in https://github.com/cms-gem-daq-project/ctp7_modules/issues/62

## How Has This Been Tested?
All of the scans that are affected by this update have been run on the coffin setup with and without this update, and no statistically significant changes are apparent: http://cmsonline.cern.ch/cms-elog/1077762

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
