### PR TITLE
Update calibration_routines.cpp

### DIFF
--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1474,10 +1474,9 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
                 continue;
             } //End Case: VFAT is masked, skip
             else{ //Case: VFAT is not masked
-                //Set DAC value
+            //Set DAC value
                 std::string strDacReg = stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.",ohN,vfatN) + regName;
                 writeReg(la, strDacReg, dacVal);
-
                 for(int i=0; i<100; ++i){ //Read 100 times and take avg value
                 //Read the ADC
                     Temp = readRawAddress(adcAddr[vfatN], la->response);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1478,12 +1478,12 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
                 std::string strDacReg = stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.",ohN,vfatN) + regName;
                 writeReg(la, strDacReg, dacVal);
 
-    		for(int i=0; i<100; ++i){ //Read 100 times and take avg value
-                    //Read the ADC
+                for(int i=0; i<100; ++i){ //Read 100 times and take avg value
+                //Read the ADC
                     Temp = readRawAddress(adcAddr[vfatN], la->response);
-		            adcVal = adcVal + Temp;
-		}
-		adcVal = adcVal/100;
+                    adcVal = adcVal + Temp;
+                }
+                adcVal = adcVal/100;
                 //Store value
                 int idx = vfatN*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
                 vec_dacScanData[idx] = ((ohN & 0xf) << 23) + ((vfatN & 0x1f) << 18) + ((adcVal & 0x3ff) << 8) + (dacVal & 0xff);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1478,7 +1478,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
                 std::string strDacReg = stdsprintf("GEM_AMC.OH.OH%i.GEB.VFAT%i.",ohN,vfatN) + regName;
                 writeReg(la, strDacReg, dacVal);
                 for(int i=0; i<100; ++i){ //Read 100 times and take avg value
-                //Read the ADC
+                    //Read the ADC
                     Temp = readRawAddress(adcAddr[vfatN], la->response);
                     adcVal = adcVal + Temp;
                 }


### PR DESCRIPTION
Update calibration_routines.cpp: dacScanLocal now gives averaged values of DAC, DAC number 4 added

## Description
<!--- Describe your changes in detail -->
- in dacScanLocal, the ADC values are now read 100 times and the averaged (the single read method gave fluctuations)
- in dacScanLocal, the map_dacSelect[] referred to current measurement now contains entries 4, 13, 32, 40. DACscan is working for dacselect=4 which corresponds to CFG_BIAS_PRE_I_BSF

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
The DAC scan has been tested on eagle60 link0 for DAC CFG_BIAS_PRE_I_BLCC (dacSelect = 03) and now returns stable values: see elog: http://cmsonline.cern.ch/cms-elog/1072401

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
