### PR TITLE
New Feature: Phase Align Function

### DIFF
--- a/include/amc.h
+++ b/include/amc.h
@@ -11,20 +11,20 @@
 #include "utils.h"
 #include <unistd.h>
 
-/*! \fn uint32_t checkPllLockLocal(localArgs * la, uint32_t readAttempts)
+/*! \fn uint32_t checkPLLLockLocal(localArgs * la, uint32_t readAttempts)
  *  \brief Resets the PLL and checks if it relocks
  *  \param la Local arguments structure
  *  \param readAttempts Specifies the number of times to reset the PLL and check for a relock
  *  \return Returns the number of times the PLL relocked
  */
-uint32_t checkPllLockLocal(localArgs * la, int readAttempts);
+uint32_t checkPLLLockLocal(localArgs * la, int readAttempts);
 
-/*! \fn void checkPllLock(const RPCMsg *request, RPCMsg *response)
+/*! \fn void checkPLLLock(const RPCMsg *request, RPCMsg *response)
  *  \brief Resets the PLL and checks if it relocks, see local method for details
  *  \param request RPC request message
  *  \param response RPC response message
  */
-void checkPllLock(const RPCMsg *request, RPCMsg *response);
+void checkPLLLock(const RPCMsg *request, RPCMsg *response);
 
 /*! \fn unsigned int fw_version_check(const char* caller_name, localArgs *la)
  *  \brief Returns AMC FW version

--- a/include/amc.h
+++ b/include/amc.h
@@ -11,6 +11,21 @@
 #include "utils.h"
 #include <unistd.h>
 
+/*! \fn uint32_t checkPllLockLocal(localArgs * la, uint32_t readAttempts)
+ *  \brief Resets the PLL and checks if it relocks
+ *  \param la Local arguments structure
+ *  \param readAttempts Specifies the number of times to reset the PLL and check for a relock
+ *  \return Returns the number of times the PLL relocked
+ */
+uint32_t checkPllLockLocal(localArgs * la, int readAttempts);
+
+/*! \fn void checkPllLock(const RPCMsg *request, RPCMsg *response)
+ *  \brief Resets the PLL and checks if it relocks, see local method for details
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void checkPllLock(const RPCMsg *request, RPCMsg *response);
+
 /*! \fn unsigned int fw_version_check(const char* caller_name, localArgs *la)
  *  \brief Returns AMC FW version
  *  in case FW version is not 1.X or 3.X sets an error string in response
@@ -56,11 +71,29 @@ void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response);
  */
 std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acquireTime, bool *maxNetworkSizeReached);
 
-/*! \fn sbitReadOut(const RPCMsg *request, RPCMsg *response)
+/*! \fn void sbitReadOut(const RPCMsg *request, RPCMsg *response)
  *  \brief readout sbits using the SBIT Monitor.  See the local callable methods documentation for details.
  *  \param request RPC response message
  *  \param response RPC response message
  */
 void sbitReadOut(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void ttcMMCMPhaseShiftLocal(localArgs *la, bool shiftOutOfLockFirst, bool useBC0Locked, bool doScan)
+ *  \brief Performs the locking procedure performs up to 3840 shifts (full width of one good + bad region).
+ *  \details If shiftOutOfLockFirst is true, then the procedure will first shift into a bad region (not an edge), find the next good lock status, shift halfway through the region.  1920 for BC0_LOCKED, 1000 for PLL_LOCKED.
+ *  \details If shiftOutOfLockFirst is false, then the procedure will find X consecutive "good" locks for X = 200 (50) for BC0_LOCKED (PLL_LOCKED).  It will then reverse direction and shift backwards halfway.  If a bad lock is encountered it will reset and try again.  Otherwise it will take the phase at the back half point
+ *  \param la Local arguments structure
+ *  \param shiftOutOfLockFirst controls whether the procedure will force a relock
+ *  \useBC0Locked controls whether the procedure will use the BC0_LOCKED or the PLL_LOCKED register.  Note for GEM_AMC FW > 1.13.0 BC0_LOCKED doesn't work.
+ *  \param doScan tells the procedure to run through the full possibility of phases several times, and just logs the place where it found a lock
+ */
+void ttcMMCMPhaseShiftLocal(localArgs *la, bool shiftOutOfLockFirst, bool useBC0Locked, bool doScan);
+
+/*! \fn void ttcMMCMPhaseShift(const RPCMsg *request, RPCMsg *response)
+ *  \brief phase alignment algorithm for ttc phase on uTCA backplane.  See the local callable methods documentation for details.
+ *  \param request RPC response message
+ *  \param response RPC response message
+ */
+void ttcMMCMPhaseShift(const RPCMsg *request, RPCMsg *response);
 
 #endif

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -267,18 +267,18 @@ void ttcMMCMPhaseShiftLocal(localArgs *la, bool shiftOutOfLockFirst, bool useBC0
     std::string strTTCCtrlBaseNode = "GEM_AMC.TTC.CTRL.";
     std::vector<std::pair<std::string, uint32_t> > vec_ttcCtrlRegs;
 
-    vec_ttcCtrlRegs["DISABLE_PHASE_ALIGNMENT"]       = 0x1;
-    vec_ttcCtrlRegs["PA_DISABLE_GTH_PHASE_TRACKING"] = 0x1;
-    vec_ttcCtrlRegs["PA_MANUAL_OVERRIDE"]            = 0x1;
-    vec_ttcCtrlRegs["PA_MANUAL_SHIFT_DIR"]           = 0x1;
-    vec_ttcCtrlRegs["PA_GTH_MANUAL_OVERRIDE"]        = 0x1;
-    vec_ttcCtrlRegs["PA_GTH_MANUAL_SHIFT_DIR"]       = 0x0;
-    vec_ttcCtrlRegs["PA_GTH_MANUAL_SHIFT_STEP"]      = 0x1;
-    vec_ttcCtrlRegs["PA_GTH_MANUAL_SEL_OVERRIDE"]    = 0x1;
-    vec_ttcCtrlRegs["PA_GTH_MANUAL_COMBINED"]        = 0x1;
-    vec_ttcCtrlRegs["GTH_TXDLYBYPASS"]               = 0x1;
-    vec_ttcCtrlRegs["PA_MANUAL_PLL_RESET"]           = 0x1;
-    vec_ttcCtrlRegs["CNT_RESET"]                     = 0x1;
+    vec_ttcCtrlRegs.push_back(std::make_pair("DISABLE_PHASE_ALIGNMENT"       , 0x1));
+    vec_ttcCtrlRegs.push_back(std::make_pair("PA_DISABLE_GTH_PHASE_TRACKING" , 0x1));
+    vec_ttcCtrlRegs.push_back(std::make_pair("PA_MANUAL_OVERRIDE"            , 0x1));
+    vec_ttcCtrlRegs.push_back(std::make_pair("PA_MANUAL_SHIFT_DIR"           , 0x1));
+    vec_ttcCtrlRegs.push_back(std::make_pair("PA_GTH_MANUAL_OVERRIDE"        , 0x1));
+    vec_ttcCtrlRegs.push_back(std::make_pair("PA_GTH_MANUAL_SHIFT_DIR"       , 0x0));
+    vec_ttcCtrlRegs.push_back(std::make_pair("PA_GTH_MANUAL_SHIFT_STEP"      , 0x1));
+    vec_ttcCtrlRegs.push_back(std::make_pair("PA_GTH_MANUAL_SEL_OVERRIDE"    , 0x1));
+    vec_ttcCtrlRegs.push_back(std::make_pair("PA_GTH_MANUAL_COMBINED"        , 0x1));
+    vec_ttcCtrlRegs.push_back(std::make_pair("GTH_TXDLYBYPASS"               , 0x1));
+    vec_ttcCtrlRegs.push_back(std::make_pair("PA_MANUAL_PLL_RESET"           , 0x1));
+    vec_ttcCtrlRegs.push_back(std::make_pair("CNT_RESET"                     , 0x1));
 
     // write & readback of aforementioned registers
     uint32_t readback;

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <time.h>
 #include <thread>
+#include <utility>
 #include "utils.h"
 #include <vector>
 
@@ -264,24 +265,24 @@ void ttcMMCMPhaseShiftLocal(localArgs *la, bool shiftOutOfLockFirst, bool useBC0
     LOGGER->log_message(LogManager::INFO,"starting phase shifting procedure");
 
     std::string strTTCCtrlBaseNode = "GEM_AMC.TTC.CTRL.";
-    std::unordered_map<std::string, uint32_t> map_ttcCtrlRegs;
+    std::vector<std::pair<std::string, uint32_t> > vec_ttcCtrlRegs;
 
-    map_ttcCtrlRegs["DISABLE_PHASE_ALIGNMENT"]       = 0x1;
-    map_ttcCtrlRegs["PA_DISABLE_GTH_PHASE_TRACKING"] = 0x1;
-    map_ttcCtrlRegs["PA_MANUAL_OVERRIDE"]            = 0x1;
-    map_ttcCtrlRegs["PA_MANUAL_SHIFT_DIR"]           = 0x1;
-    map_ttcCtrlRegs["PA_GTH_MANUAL_OVERRIDE"]        = 0x1;
-    map_ttcCtrlRegs["PA_GTH_MANUAL_SHIFT_DIR"]       = 0x0;
-    map_ttcCtrlRegs["PA_GTH_MANUAL_SHIFT_STEP"]      = 0x1;
-    map_ttcCtrlRegs["PA_GTH_MANUAL_SEL_OVERRIDE"]    = 0x1;
-    map_ttcCtrlRegs["PA_GTH_MANUAL_COMBINED"]        = 0x1;
-    map_ttcCtrlRegs["GTH_TXDLYBYPASS"]               = 0x1;
-    map_ttcCtrlRegs["PA_MANUAL_PLL_RESET"]           = 0x1;
-    map_ttcCtrlRegs["CNT_RESET"]                     = 0x1;
+    vec_ttcCtrlRegs["DISABLE_PHASE_ALIGNMENT"]       = 0x1;
+    vec_ttcCtrlRegs["PA_DISABLE_GTH_PHASE_TRACKING"] = 0x1;
+    vec_ttcCtrlRegs["PA_MANUAL_OVERRIDE"]            = 0x1;
+    vec_ttcCtrlRegs["PA_MANUAL_SHIFT_DIR"]           = 0x1;
+    vec_ttcCtrlRegs["PA_GTH_MANUAL_OVERRIDE"]        = 0x1;
+    vec_ttcCtrlRegs["PA_GTH_MANUAL_SHIFT_DIR"]       = 0x0;
+    vec_ttcCtrlRegs["PA_GTH_MANUAL_SHIFT_STEP"]      = 0x1;
+    vec_ttcCtrlRegs["PA_GTH_MANUAL_SEL_OVERRIDE"]    = 0x1;
+    vec_ttcCtrlRegs["PA_GTH_MANUAL_COMBINED"]        = 0x1;
+    vec_ttcCtrlRegs["GTH_TXDLYBYPASS"]               = 0x1;
+    vec_ttcCtrlRegs["PA_MANUAL_PLL_RESET"]           = 0x1;
+    vec_ttcCtrlRegs["CNT_RESET"]                     = 0x1;
 
     // write & readback of aforementioned registers
     uint32_t readback;
-    for(auto ttcRegIter = map_ttcCtrlRegs.begin(); ttcRegIter != map_ttcCtrlRegs.end(); ++ttcRegIter){
+    for(auto ttcRegIter = vec_ttcCtrlRegs.begin(); ttcRegIter != vec_ttcCtrlRegs.end(); ++ttcRegIter){
         writeReg(la, strTTCCtrlBaseNode + (*ttcRegIter).first, (*ttcRegIter).second);
         std::this_thread::sleep_for(std::chrono::microseconds(250));
         readback = readReg(la, strTTCCtrlBaseNode + (*ttcRegIter).first);

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -13,6 +13,42 @@
 #include "utils.h"
 #include <vector>
 
+uint32_t checkPllLockLocal(localArgs * la, uint32_t readAttempts){
+    uint32_t lockCnt = 0;
+    for (uint32_t i = 0; i < readAttempts; ++i ) {
+        writeReg(la,"GEM_AMC.TTC.CTRL.PA_MANUAL_PLL_RESET", 0x1);
+
+        //wait 100us to allow the PLL to lock
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+
+        //Check if it's locked
+        if (readReg(la,"GEM_AMC.TTC.STATUS.CLK.PHASE_LOCKED") != 0){
+            lockCnt += 1;
+        }
+    }
+    return lockCnt;
+} //End checkPllLockLocal()
+
+void checkPllLock(const RPCMsg * request, RPCMsg * response){
+    auto env = lmdb::env::create();
+    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+    std::string gem_path = std::getenv("GEM_PATH");
+    std::string lmdb_data_file = gem_path+"/address_table.mdb";
+    env.open(lmdb_data_file.c_str(), 0, 0664);
+    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+
+    uint32_t readAttempts = request->get_word("readAttempts");
+    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+
+    uint32_t lockCnt = checkPllLockLocal(&la, readAttempts);
+    LOGGER->log_message(LogManager::INFO, stdsprintf("Checked PLL Locked Status %i times; Found PLL Locked %i times",readAttempts,lockCnt));
+
+    response->set_word("lockCnt",lockCnt);
+
+    return;
+} //End checkPllLock()
+
 unsigned int fw_version_check(const char* caller_name, localArgs *la)
 {
     int iFWVersion = readReg(la, "GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR");
@@ -94,7 +130,7 @@ void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response){
         else
             LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register value (%i), NOH request will be disregarded",NOH_requested,NOH));
     }
-    
+
     uint32_t ohVfatMaskArray[12];
     for(unsigned int ohN=0; ohN<NOH; ++ohN){
         // If this Optohybrid is masked skip it
@@ -222,6 +258,512 @@ void sbitReadOut(const RPCMsg *request, RPCMsg *response){
     return;
 } //End sbitReadOut()
 
+void ttcMMCMPhaseShiftLocal(localArgs *la, bool shiftOutOfLockFirst, bool useBC0Locked, bool doScan){
+    const int PLL_LOCK_READ_ATTEMPTS  = 10;
+
+    LOGGER->log_message(LogManager::INFO,"starting phase shifting procedure");
+
+    std::string strTtcCtrlBaseNode = "GEM_AMC.TTC.CTRL.";
+    std::unordered_map<std::string, uint32_t> map_ttcCtrlRegs;
+
+    map_ttcCtrlRegs["DISABLE_PHASE_ALIGNMENT"]       = 0x1;
+    map_ttcCtrlRegs["PA_DISABLE_GTH_PHASE_TRACKING"] = 0x1;
+    map_ttcCtrlRegs["PA_MANUAL_OVERRIDE"]            = 0x1;
+    map_ttcCtrlRegs["PA_MANUAL_SHIFT_DIR"]           = 0x1;
+    map_ttcCtrlRegs["PA_GTH_MANUAL_OVERRIDE"]        = 0x1;
+    map_ttcCtrlRegs["PA_GTH_MANUAL_SHIFT_DIR"]       = 0x0;
+    map_ttcCtrlRegs["PA_GTH_MANUAL_SHIFT_STEP"]      = 0x1;
+    map_ttcCtrlRegs["PA_GTH_MANUAL_SEL_OVERRIDE"]    = 0x1;
+    map_ttcCtrlRegs["PA_GTH_MANUAL_COMBINED"]        = 0x1;
+    map_ttcCtrlRegs["GTH_TXDLYBYPASS"]               = 0x1;
+    map_ttcCtrlRegs["PA_MANUAL_PLL_RESET"]           = 0x1;
+    map_ttcCtrlRegs["CNT_RESET"]                     = 0x1;
+
+    // write & readback of aforementioned registers
+    uint32_t readback;
+    for(auto ttcRegIter = map_ttcCtrlRegs.begin(); ttcRegIter != map_ttcCtrlRegs.end(); ++ttcRegIter){
+        writeReg(la, strTtcCtrlBaseNode + (*ttcRegIter).first, (*ttcRegIter).second);
+        std::this_thread::sleep_for(std::chrono::microseconds(250));
+        readback = readReg(la, strTtcCtrlBaseNode + (*ttcRegIter).first);
+        if( readback != (*ttcRegIter).second){
+            LOGGER->log_message(
+                    LogManager::ERROR,
+                    stdsprintf(
+                        "Readback of %s failed, value is %i, expected %i",
+                        (strTtcCtrlBaseNode + (*ttcRegIter).first).c_str(),
+                        readback,
+                        (*ttcRegIter).second)
+                    );
+            la->response->set_string("error",stdsprintf(
+                        "ttcMMCMPhaseShift: Readback of %s failed, value is %i, expected %i",
+                        (strTtcCtrlBaseNode + (*ttcRegIter).first).c_str(),
+                        readback,
+                        (*ttcRegIter).second)
+                    );
+            return;
+        }
+    }
+
+    if (readReg(la,strTtcCtrlBaseNode+"DISABLE_PHASE_ALIGNMENT") == 0x0) {
+        LOGGER->log_message(LogManager::ERROR,"automatic phase alignment is turned off!!");
+        la->response->set_string("error","ttcMMCMPhaseShift: automatic phase alignment is turned off!!");
+        return;
+    }
+
+    uint32_t readAttempts = 1;
+    int maxShift     = 7680+(7680/2);
+
+    if (!useBC0Locked) {
+      readAttempts = PLL_LOCK_READ_ATTEMPTS;
+    }
+    if (doScan) {
+      readAttempts = PLL_LOCK_READ_ATTEMPTS;
+      maxShift = 23040;
+    }
+    uint32_t mmcmShiftCnt = readReg(la,"GEM_AMC.TTC.STATUS.CLK.PA_MANUAL_SHIFT_CNT");
+    uint32_t gthShiftCnt  = readReg(la,"GEM_AMC.TTC.STATUS.CLK.PA_MANUAL_GTH_SHIFT_CNT");
+    int  pllLockCnt = checkPllLockLocal(la, readAttempts);
+    bool firstUnlockFound = false;
+    bool nextLockFound    = false;
+    bool bestLockFound    = false;
+    bool reversingForLock = false;
+    uint32_t phase = 0;
+    double phaseNs = 0.0;
+
+    bool mmcmShiftTable[] = {false, false, false, true, false, false, false,
+                             false, false, true, false, false, false, false,
+                             false, true, false, false, false, false, true,
+                             false, false, false, false, false, true, false,
+                             false, false, false, false, true, false, false,
+                             false, false, false, true, false, false};
+
+    int nGoodLocks       = 0;
+    int nShiftsSinceLock = 0;
+    int nBadLocks        = 0;
+    int totalShiftCount  = 0;
+
+    for (int i = 0; i < maxShift; ++i) {
+        writeReg(la, strTtcCtrlBaseNode + "CNT_RESET", 0x1);
+        writeReg(la, strTtcCtrlBaseNode + "PA_GTH_MANUAL_SHIFT_EN", 0x1);
+
+        if (!reversingForLock && (gthShiftCnt == 39)) {
+            LOGGER->log_message(LogManager::DEBUG,"normal GTH shift rollover 39->0");
+            gthShiftCnt = 0;
+        }
+        else if (reversingForLock && (gthShiftCnt == 0)){
+            LOGGER->log_message(LogManager::DEBUG,"rerversed GTH shift rollover 0->39");
+            gthShiftCnt = 39;
+        }
+        else {
+            if (reversingForLock) {
+                gthShiftCnt -= 1;
+            }
+            else {
+                gthShiftCnt += 1;
+            }
+        }
+
+        uint32_t tmpGthShiftCnt  = readReg(la,"GEM_AMC.TTC.STATUS.CLK.PA_MANUAL_GTH_SHIFT_CNT");
+        uint32_t tmpMmcmShiftCnt = readReg(la,"GEM_AMC.TTC.STATUS.CLK.PA_MANUAL_SHIFT_CNT");
+        LOGGER->log_message(LogManager::INFO,stdsprintf("tmpGthShiftCnt: %i, tmpMmcmShiftCnt %i",tmpGthShiftCnt, tmpMmcmShiftCnt));
+        while (gthShiftCnt != tmpGthShiftCnt) {
+            LOGGER->log_message(LogManager::WARNING,
+                    "Repeating a GTH PI shift because the shift count doesn't"
+                    " match the expected value."
+                    " Expected shift cnt = " + std::to_string(gthShiftCnt) +
+                    ", ctp7 returned "       + std::to_string(tmpGthShiftCnt));
+
+            writeReg(la, "GEM_AMC.TTC.CTRL.PA_GTH_MANUAL_SHIFT_EN", 0x1);
+            tmpGthShiftCnt = readReg(la,"GEM_AMC.TTC.STATUS.CLK.PA_MANUAL_GTH_SHIFT_CNT");
+            //FIX ME should this continue indefinitely...?
+        }
+
+        if (mmcmShiftTable[gthShiftCnt+1]) {
+            if (!reversingForLock && (mmcmShiftCnt == 0xffff)) {
+                mmcmShiftCnt = 0;
+            }
+            else if (reversingForLock && (mmcmShiftCnt == 0x0)) {
+                mmcmShiftCnt = 0xffff;
+            }
+            else {
+                if (reversingForLock) {
+                    mmcmShiftCnt -= 1;
+                } else {
+                    mmcmShiftCnt += 1;
+                }
+            }
+
+            tmpMmcmShiftCnt = readReg(la,"TTC.STATUS.CLK.PA_MANUAL_SHIFT_CNT");
+            if (mmcmShiftCnt != tmpMmcmShiftCnt){
+                LOGGER->log_message(LogManager::WARNING,
+                        "Reported MMCM shift count doesn't match the expected MMCM shift count."
+                        " Expected shift cnt = " + std::to_string(mmcmShiftCnt) +
+                        " , ctp7 returned "      + std::to_string(tmpMmcmShiftCnt));
+            }
+        }
+
+        pllLockCnt = checkPllLockLocal(la,readAttempts);
+        phase      = readReg(la,"GEM_AMC.TTC.STATUS.CLK.TTC_PM_PHASE_MEAN");
+        phaseNs    = phase * 0.01860119;
+        uint32_t gthPhase = readReg(la,"TTC.STATUS.CLK.GTH_PM_PHASE_MEAN");
+        double gthPhaseNs = gthPhase * 0.01860119;
+
+        uint32_t bc0Locked  = readReg(la,"GEM_AMC.TTC.STATUS.BC0.LOCKED");
+        //uint32_t bc0UnlkCnt = readReg(la,"GEM_AMC.TTC.STATUS.BC0.UNLOCK_CNT");
+        //uint32_t sglErrCnt  = readReg(la,"GEM_AMC.TTC.STATUS.TTC_SINGLE_ERROR_CNT");
+        //uint32_t dblErrCnt  = readReg(la,"GEM_AMC.TTC.STATUS.TTC_DOUBLE_ERROR_CNT");
+
+        LOGGER->log_message(LogManager::DEBUG,
+                "GTH shift #"             + std::to_string(i) +
+                ": mmcm shift cnt = "     + std::to_string(mmcmShiftCnt) +
+                ", mmcm phase counts = "  + std::to_string(phase) +
+                ", mmcm phase = "         + std::to_string(phaseNs) +
+                "ns, gth phase counts = " + std::to_string(gthPhase) +
+                ", gth phase = "          + std::to_string(gthPhaseNs) +
+                ", PLL lock count = "     + std::to_string(pllLockCnt));
+
+        if (useBC0Locked) {
+            if (!firstUnlockFound) {
+                bestLockFound = false;
+                if (bc0Locked == 0) {
+                    nBadLocks += 1;
+                    nGoodLocks = 0;
+                } else {
+                    nBadLocks   = 0;
+                    nGoodLocks += 1;
+                }
+
+                if (shiftOutOfLockFirst) {
+                    if (nBadLocks > 100) {
+                      firstUnlockFound = true;
+                      LOGGER->log_message(LogManager::INFO,
+                              "100 unlocks found after " + std::to_string(i+1) + " shifts:"
+                              " bad locks "              + std::to_string(nBadLocks) +
+                              ", good locks "            + std::to_string(nGoodLocks) +
+                              ", mmcm phase count = "    + std::to_string(phase) +
+                              ", mmcm phase ns = "       + std::to_string(phaseNs) + "ns");
+                    }
+                }
+                else {
+                    if (reversingForLock && (nBadLocks > 0)) {
+                        LOGGER->log_message(LogManager::DEBUG,
+                                "Bad BC0 lock found:"
+                                " phase count = " + std::to_string(phase) +
+                                ", phase ns = "   + std::to_string(phaseNs) + "ns"
+                                ", returning to normal search");
+                        writeReg(la,"GEM_AMC.TTC.CTRL.PA_MANUAL_SHIFT_DIR",1);
+                        writeReg(la,"GEM_AMC.TTC.CTRL.PA_GTH_MANUAL_SHIFT_DIR",0);
+                        bestLockFound    = false;
+                        reversingForLock = false;
+                        nGoodLocks       = 0;
+                    }
+                    else if (nGoodLocks == 200) {
+                        reversingForLock = true;
+                        LOGGER->log_message(LogManager::INFO,
+                                "200 consecutive good BC0 locks found:"
+                                " phase count = " + std::to_string(phase) +
+                                ", phase ns = "   + std::to_string(phaseNs) + "ns"
+                                ", reversing scan direction");
+                        writeReg(la,"GEM_AMC.TTC.CTRL.PA_MANUAL_SHIFT_DIR",0);
+                        writeReg(la,"GEM_AMC.TTC.CTRL.PA_GTH_MANUAL_SHIFT_DIR",1);
+                    }
+                    if (reversingForLock && (nGoodLocks == 300)) {
+                        LOGGER->log_message(LogManager::INFO,
+                                "Best lock found after reversing:"
+                                " phase count = " + std::to_string(phase) +
+                                ", phase ns = "   + std::to_string(phaseNs) + "ns.");
+                        bestLockFound    = true;
+                        if (doScan) {
+                            writeReg(la,"GEM_AMC.TTC.CTRL.PA_MANUAL_SHIFT_DIR",1);
+                            writeReg(la,"GEM_AMC.TTC.CTRL.PA_GTH_MANUAL_SHIFT_DIR",0);
+                            bestLockFound    = false;
+                            reversingForLock = false;
+                            nGoodLocks       = 0;
+                        }
+                        else {
+                            break;
+                        }
+                    }
+                }
+            }
+            else { // shift to first good BC0 locked
+                if (bc0Locked == 0) {
+                    if (nextLockFound) {
+                        LOGGER->log_message(LogManager::DEBUG,
+                                "Unexpected unlock after " + std::to_string(i+1) + " shifts:"
+                                " bad locks "              + std::to_string(nBadLocks) +
+                                ", good locks "            + std::to_string(nGoodLocks) +
+                                ", mmcm phase count = "    + std::to_string(phase) +
+                                ", mmcm phase ns = "       + std::to_string(phaseNs) + "ns");
+                    }
+                    nBadLocks += 1;
+                } else {
+                    if (!nextLockFound) {
+                        LOGGER->log_message(LogManager::INFO,
+                                "Found next lock after " + std::to_string(i+1) + " shifts:"
+                                " bad locks "            + std::to_string(nBadLocks) +
+                                ", good locks "          + std::to_string(nGoodLocks) +
+                                ", mmcm phase count = "  + std::to_string(phase) +
+                                ", mmcm phase ns = "     + std::to_string(phaseNs) + "ns");
+                        nextLockFound = true;
+                        nBadLocks   = 0;
+                    }
+                    nGoodLocks += 1;
+                }
+                if (nGoodLocks == 1920) {
+                    LOGGER->log_message(LogManager::INFO,
+                            "Finished 1920 shifts after first good lock: "
+                            "bad locks "   + std::to_string(nBadLocks) +
+                            " good locks " + std::to_string(nGoodLocks));
+                    bestLockFound = true;
+                    if (doScan) {
+                        nextLockFound    = false;
+                        firstUnlockFound = false;
+                        nGoodLocks       = 0;
+                        nBadLocks        = 0;
+                        nShiftsSinceLock = 0;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+        else if (true) { // using the PLL lock counter, but the method as for the BC0 lock
+            if (!firstUnlockFound) {
+                bestLockFound = false;
+                if (pllLockCnt < PLL_LOCK_READ_ATTEMPTS) {
+                    nBadLocks += 1;
+                    nGoodLocks = 0;
+                } else {
+                    nBadLocks   = 0;
+                    nGoodLocks += 1;
+                }
+                if (shiftOutOfLockFirst) {
+                    if (nBadLocks > 500) {
+                      firstUnlockFound = true;
+                      LOGGER->log_message(LogManager::DEBUG,
+                              "500 unlocks found after " + std::to_string(i+1) + " shifts:"
+                              " bad locks "              + std::to_string(nBadLocks) +
+                              ", good locks "            + std::to_string(nGoodLocks) +
+                              ", mmcm phase count = "    + std::to_string(phase) +
+                              ", mmcm phase ns = "       + std::to_string(phaseNs) + "ns");
+                    }
+                    else {
+                        if (reversingForLock && (nBadLocks > 0)) {
+                            LOGGER->log_message(LogManager::DEBUG,
+                                    "Bad BC0 lock found:"
+                                    " phase count = " + std::to_string(phase) +
+                                    ", phase ns = "   + std::to_string(phaseNs) + "ns"
+                                    ", returning to normal search");
+                            writeReg(la,"GEM_AMC.TTC.CTRL.PA_MANUAL_SHIFT_DIR",1);
+                            writeReg(la,"GEM_AMC.TTC.CTRL.PA_GTH_MANUAL_SHIFT_DIR",0);
+                            bestLockFound    = false;
+                            reversingForLock = false;
+                            nGoodLocks       = 0;
+                        }
+                        else if (nGoodLocks == 50) {
+                            reversingForLock = true;
+                            LOGGER->log_message(LogManager::INFO,
+                                    "50 consecutive good PLL locks found:"
+                                    " phase count = " + std::to_string(phase) +
+                                    ", phase ns = "   + std::to_string(phaseNs) + "ns"
+                                    ", reversing scan direction");
+                            writeReg(la,"GEM_AMC.TTC.CTRL.PA_MANUAL_SHIFT_DIR",0);
+                            writeReg(la,"GEM_AMC.TTC.CTRL.PA_GTH_MANUAL_SHIFT_DIR",1);
+                        }
+                        if (reversingForLock &&(nGoodLocks == 75)) {
+                            LOGGER->log_message(LogManager::INFO,
+                                    "Best lock found after reversing:"
+                                    " phase count = " + std::to_string(phase) +
+                                    ", phase ns = "   + std::to_string(phaseNs) + "ns.");
+                            bestLockFound = true;
+                            if (doScan) {
+                                writeReg(la,"GEM_AMC.TTC.CTRL.PA_MANUAL_SHIFT_DIR",1);
+                                writeReg(la,"GEM_AMC.TTC.CTRL.PA_GTH_MANUAL_SHIFT_DIR",0);
+                                bestLockFound    = false;
+                                reversingForLock = false;
+                                nGoodLocks       = 0;
+                            }
+                            else {
+                                break;
+                            }
+                        }
+                    }
+                }
+            } else { // shift to first good PLL locked
+                if (pllLockCnt < PLL_LOCK_READ_ATTEMPTS) {
+                    if (nextLockFound) {
+                        LOGGER->log_message(LogManager::WARNING,
+                                "Unexpected unlock after " + std::to_string(i+1) + " shifts:"
+                                " bad locks "              + std::to_string(nBadLocks) +
+                                ", good locks "            + std::to_string(nGoodLocks) +
+                                ", mmcm phase count = "    + std::to_string(phase) +
+                                ", mmcm phase ns = "       + std::to_string(phaseNs) + "ns");
+                        nBadLocks += 1;
+                    } else {
+                        if (!nextLockFound) {
+                            LOGGER->log_message(LogManager::INFO,
+                                    "Found next lock after " + std::to_string(i+1) + " shifts:"
+                                    " bad locks "            + std::to_string(nBadLocks) +
+                                    ", good locks "          + std::to_string(nGoodLocks) +
+                                    ", mmcm phase count = "  + std::to_string(phase) +
+                                    ", mmcm phase ns = "     + std::to_string(phaseNs) + "ns");
+                            nextLockFound = true;
+                            nBadLocks     = 0;
+                        }
+                        nGoodLocks += 1;
+                    }
+                    if (nShiftsSinceLock == 1000) {
+                        LOGGER->log_message(LogManager::INFO,
+                                "Finished 1000 shifts after first good lock:"
+                                " bad locks "   + std::to_string(nBadLocks) +
+                                ", good locks " + std::to_string(nGoodLocks));
+                        bestLockFound = true;
+                        if (doScan) {
+                            nextLockFound    = false;
+                            firstUnlockFound = false;
+                            nGoodLocks       = 0;
+                            nBadLocks        = 0;
+                            nShiftsSinceLock = 0;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            if (shiftOutOfLockFirst && (pllLockCnt < PLL_LOCK_READ_ATTEMPTS) && !firstUnlockFound) {
+                firstUnlockFound = true;
+                LOGGER->log_message(LogManager::WARNING,
+                        "Unlocked after "          + std::to_string(i+1) + "shifts:"
+                        " mmcm phase count = "     + std::to_string(phase) +
+                        ", mmcm phase ns = "       + std::to_string(phaseNs) + "ns"
+                        ", pllLockCnt = "          + std::to_string(pllLockCnt) +
+                        ", firstUnlockFound = "    + std::to_string(firstUnlockFound) +
+                        ", shiftOutOfLockFirst = " + std::to_string(shiftOutOfLockFirst) );
+            }
+
+            if (pllLockCnt == PLL_LOCK_READ_ATTEMPTS) {
+                if (!shiftOutOfLockFirst) {
+                    if (nGoodLocks == 50) {
+                        reversingForLock = true;
+                        LOGGER->log_message(LogManager::INFO,
+                                "200 consecutive good PLL locks found:"
+                                " phase count = " + std::to_string(phase) +
+                                ", phase ns = "   + std::to_string(phaseNs) + "ns"
+                                ", reversing scan direction");
+                        writeReg(la,"GEM_AMC.TTC.CTRL.PA_MANUAL_SHIFT_DIR",0);
+                        writeReg(la,"GEM_AMC.TTC.CTRL.PA_GTH_MANUAL_SHIFT_DIR",1);
+                    }
+                    if (reversingForLock && (nGoodLocks == 75)) {
+                        LOGGER->log_message(LogManager::INFO,
+                                "Best lock found after reversing:"
+                                " phase count = " + std::to_string(phase) +
+                                ", phase ns = "   + std::to_string(phaseNs) + "ns.");
+                        bestLockFound    = true;
+                        if (doScan) {
+                            writeReg(la,"GEM_AMC.TTC.CTRL.PA_MANUAL_SHIFT_DIR",1);
+                            writeReg(la,"GEM_AMC.TTC.CTRL.PA_GTH_MANUAL_SHIFT_DIR",0);
+                            bestLockFound    = false;
+                            reversingForLock = false;
+                            nGoodLocks       = 0;
+                            nShiftsSinceLock = 0;
+                        }
+                        else {
+                            break;
+                        }
+                    }
+                }
+                else if (firstUnlockFound || !shiftOutOfLockFirst) {
+                    if (!nextLockFound) {
+                        LOGGER->log_message(LogManager::DEBUG,
+                                "Found next lock after " + std::to_string(i+1)+ " shifts:"
+                                " bad locks "            + std::to_string(nBadLocks) +
+                                ", good locks "          + std::to_string(nGoodLocks) +
+                                ", mmcm phase count = "  + std::to_string(phase) +
+                                ", mmcm phase ns = "     + std::to_string(phaseNs) + "ns");
+                        nextLockFound = true;
+                    }
+                    if (nShiftsSinceLock > 500) {
+                        bestLockFound = true;
+                        if (!doScan)
+                            break;
+                        nextLockFound    = false;
+                        firstUnlockFound = false;
+                        bestLockFound    = false;
+                        nGoodLocks       = 0;
+                        nShiftsSinceLock = 0;
+                    }
+                }
+                else {
+                    nGoodLocks += 1;
+                }
+            }
+            else if (nextLockFound) {
+                if (nShiftsSinceLock > 500) {
+                    bestLockFound = true;
+                    if (!doScan)
+                        break;
+                    nextLockFound    = false;
+                    firstUnlockFound = false;
+                    bestLockFound    = false;
+                    nGoodLocks       = 0;
+                    nShiftsSinceLock = 0;
+                }
+            }
+            else {
+                bestLockFound = false;
+                nBadLocks += 1;
+            }
+        }
+        if (nextLockFound){
+            nShiftsSinceLock += 1;
+        }
+        if (reversingForLock){
+            totalShiftCount -= 1;
+        }
+        else{
+            totalShiftCount += 1;
+        }
+    }
+
+    if (bestLockFound) {
+        writeReg(la,"GEM_AMC.TTC.CTRL.MMCM_RESET", 0x1);
+        LOGGER->log_message(LogManager::INFO,
+                "Lock was found:"
+                " phase count " +std::to_string(phase) +
+                ", phase "      +std::to_string(phaseNs) + "ns");
+    }
+    else {
+        std::stringstream msg;
+        LOGGER->log_message(LogManager::ERROR,"Unable to find lock");
+        la->response->set_string("error","ttcMMCMPhaseShift: unable to find lock");
+    }
+
+    return;
+} //End ttcMMCMPhaseShiftLocal()
+
+void ttcMMCMPhaseShift(const RPCMsg *request, RPCMsg *response){
+    auto env = lmdb::env::create();
+    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+    std::string gem_path = std::getenv("GEM_PATH");
+    std::string lmdb_data_file = gem_path+"/address_table.mdb";
+    env.open(lmdb_data_file.c_str(), 0, 0664);
+    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+
+    bool shiftOutOfLockFirst = request->get_word("shiftOutOfLockFirst");
+    bool useBC0Locked = request->get_word("useBC0Locked");
+    bool doScan = request->get_word("doScan");
+
+    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+
+    ttcMMCMPhaseShiftLocal(&la, shiftOutOfLockFirst, useBC0Locked, doScan);
+
+    return;
+} //End ttcMMCMPhaseShift()
+
 extern "C" {
     const char *module_version_key = "amc v1.0.1";
     int module_activity_color = 4;
@@ -231,8 +773,10 @@ extern "C" {
             LOGGER->log_message(LogManager::ERROR, "Unable to load module");
             return; // Do not register our functions, we depend on memsvc.
         }
+        modmgr->register_method("amc", "checkPllLock", checkPllLock);
         modmgr->register_method("amc", "getOHVFATMask", getOHVFATMask);
         modmgr->register_method("amc", "getOHVFATMaskMultiLink", getOHVFATMaskMultiLink);
         modmgr->register_method("amc", "sbitReadOut", sbitReadOut);
+        modmgr->register_method("amc", "ttcMMCMPhaseShift", ttcMMCMPhaseShift);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses #65.  Migrated from `uhal` based methods in `cmsgemos`.

Provided local and nonlocal functions for `uhal` based equivalent functions in `cmsgemos`:

- `checkPllLock(...)`, and
- `ttcMMCMPhaseShift(...)`

The keys for the RPC request match input arguments.  No rpc response is returned by `ttcMMCMPhaseShift(...)` but for `checkPllLock(...)` the key `lockCnt` is inserted into the rpc response.

Note that `checkPllLock(...)` is provided for standalone functionality but `ttcMMCMPhaseShiftLocal(...)` calls `checkPllLockLocal(...)` preserving the functionality.  I am not sure if the uhal based `checkPllLock(...)` function is being used elsewhere in `cmsgemos` so I included a remote function just in case.

Also implemented the requested readback check in `ttcMMCMPhaseShiftLocal(...)`.  

Finally in the cases **where** exceptions **were** suggested in the comments I've set the `error` string in the RPC response.  The calling function from the DAQ machine should check for the presence of this key (e.g. `response->get_key_exists("error")`) and raise the appropriate exception or take the appropriate follow-up action.  Note that when the `"error"` key is set it definitely means the procedure *didn't* work or was not executed.

Not sure if additional keys should be inserted into the rpc response, e.g. in the case where `CMSGEMOS_WARN` logger was used one could thing that the `"warning"` key could be inserted into the rpc response but I'm not sure how `cmsgemos` is handling it...from the code snippet presented in #65 it seemed there was no exception being raised so if it's not necessary I'll just leave it as is.  

In all cases logging is now managed by logger in RPC land and will show up in the local/remote log file for the CTP7 (not the xdaq output which I suspect was previously being done). 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
#65 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested yet, would need `eagle34` in 904 to have a "good linux image" or would need some time during interfill period to try to test on `eagle61` in P5. @jsturdy 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
