### PR TITLE
 Implement RPC methods for configuring the GBTX's v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,8 @@ lib/optohybrid.so: src/optohybrid.cpp
 lib/calibration_routines.so: src/calibration_routines.cpp
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,calibration_routines.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so -l:optohybrid.so -l:vfat3.so -l:amc.so
 
-lib/gbt.so: src/gbt.cpp include/gbt.h include/moduleapi.h include/memhub.h include/utils.h
-	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,gbt.so -o $@ $< -l:memhub.so
+lib/gbt.so: src/gbt.cpp include/gbt.h include/gbt_constants.h include/moduleapi.h include/memhub.h include/utils.h lib/utils.so
+	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,gbt.so -o $@ $< -l:memhub.so -l:utils.so
 
 clean: cleanrpm
 	-rm -rf lib/*.so

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ TARGET_LIBS += lib/daq_monitor.so
 TARGET_LIBS += lib/vfat3.so
 TARGET_LIBS += lib/optohybrid.so
 TARGET_LIBS += lib/calibration_routines.so
+TARGET_LIBS += lib/gbt.so
 
 .PHONY: clean rpc prerpm
 
@@ -86,6 +87,9 @@ lib/optohybrid.so: src/optohybrid.cpp
 
 lib/calibration_routines.so: src/calibration_routines.cpp
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,calibration_routines.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so -l:optohybrid.so -l:vfat3.so -l:amc.so
+
+lib/gbt.so: src/gbt.cpp include/gbt.h include/moduleapi.h include/memhub.h include/utils.h
+	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,gbt.so -o $@ $< -l:memhub.so
 
 clean: cleanrpm
 	-rm -rf lib/*.so

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ lib/optohybrid.so: src/optohybrid.cpp
 lib/calibration_routines.so: src/calibration_routines.cpp
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,calibration_routines.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so -l:optohybrid.so -l:vfat3.so -l:amc.so
 
-lib/gbt.so: src/gbt.cpp include/gbt.h include/hw_constants.h include/moduleapi.h include/memhub.h include/utils.h lib/utils.so
+lib/gbt.so: src/gbt.cpp include/gbt.h include/hw_constants.h include/hw_constants_checks.h include/moduleapi.h include/memhub.h include/utils.h lib/utils.so
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,gbt.so -o $@ $< -l:memhub.so -l:utils.so
 
 clean: cleanrpm

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ IncludeDirs += ${BUILD_HOME}/xhal/xhalcore/include
 #IncludeDirs += /opt/cactus/include
 INC=$(IncludeDirs:%=-I%)
 
+CFLAGS += -DGEM_VARIANT="ge11"
+
 LDFLAGS+= -L${BUILD_HOME}/xhal/xhalarm/lib
 LDFLAGS+= -L${BUILD_HOME}/$(Package)/lib
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,11 @@ IncludeDirs += ${BUILD_HOME}/xhal/xhalcore/include
 #IncludeDirs += /opt/cactus/include
 INC=$(IncludeDirs:%=-I%)
 
-CFLAGS += -DGEM_VARIANT="ge11"
+ifndef GEM_VARIANT
+	GEM_VARIANT = ge11
+endif
+
+CFLAGS += -DGEM_VARIANT="${GEM_VARIANT}"
 
 LDFLAGS+= -L${BUILD_HOME}/xhal/xhalarm/lib
 LDFLAGS+= -L${BUILD_HOME}/$(Package)/lib

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ lib/optohybrid.so: src/optohybrid.cpp
 lib/calibration_routines.so: src/calibration_routines.cpp
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,calibration_routines.so -o $@ $< -lwisci2c -lxhal -llmdb -l:utils.so -l:extras.so -l:optohybrid.so -l:vfat3.so -l:amc.so
 
-lib/gbt.so: src/gbt.cpp include/gbt.h include/gbt_constants.h include/moduleapi.h include/memhub.h include/utils.h lib/utils.so
+lib/gbt.so: src/gbt.cpp include/gbt.h include/hw_constants.h include/moduleapi.h include/memhub.h include/utils.h lib/utils.so
 	$(CXX) $(CFLAGS) -std=c++1y -O3 -pthread $(INC) $(LDFLAGS) -fPIC -shared -Wl,-soname,gbt.so -o $@ $< -l:memhub.so -l:utils.so
 
 clean: cleanrpm

--- a/include/gbt.h
+++ b/include/gbt.h
@@ -1,0 +1,10 @@
+/*! \file
+ *  \brief RPC module for GBT methods
+ *  \author Laurent Pétré <lpetre@ulb.ac.be>
+ */
+
+#ifndef GBT_H
+#define GBT_H
+
+#endif
+

--- a/include/gbt.h
+++ b/include/gbt.h
@@ -10,6 +10,47 @@
 
 #include "utils.h"
 
+/*! \brief Scan the GBT phases of one OptoHybrid.
+ *  \param[in] request RPC response message
+ *  \param[out] response RPC response message
+ *
+ *  The method expects the following RPC keys :
+ *  - `word ohN` : OptoHybrid index number.
+ *  - `word N` : The number of times the scan must performed.
+ *  - `word phaseMin` : Lowest phase to scan (min = 0).
+ *  - `word phaseMax` : Highest phase to scan (max = 15).
+ *  - `word phaseStep` : Step to scan the phases.
+ *
+ *  The method returns the following RPC keys :
+ *  - `word_array results` : Array of word containing the results of the scans. See details of the `scanGBTPhase` function for a description of the words.
+ *  - `string error` : If an error occurs, this keys exists and contains the error message.
+ */
+void scanGBTPhases(const RPCMsg *request, RPCMsg *response);
+
+/*! \brief Local callable version of `scanGBTPhase`.
+ *  \param[in, out] la Local arguments structure.
+ *  \param[out] results A `std::vector` containing the results of the scan. See details for the items description.
+ *  \param[in] ohN OptoHybrid index number.
+ *  \param[in] N The number of times the scan must performed.
+ *  \param[in] phaseMin Lowest phase to scan (min = 0).
+ *  \param[in] phaseMax Highest phase to scan (max = 15).
+ *  \param[in] phaseStep Step to scan the phases.
+ *  \return Returns `false` in case of success; `true` in case of error. The precise error is logged and written to the `error` RPC key.
+ *
+ *  \detail
+ *
+ *  The scan seeks for valid RX phases for the VFAT's of one OptoHybrid. A phase is considered valid when `LINK_GOOD = 1`, `SYNC_ERR_CNT = 0` and `CFG_RUN != 0xdeaddead`. In order to improve the reliability of the scan, it is repeated `N` times.
+ *
+ *  Each item of the results vector is composed as follow :
+ *  - [31:28] : ohN
+ *  - [27:24] : phase
+ *  - [23:0] : result of the N scans (and) for the i^th VFAT. A `1` indicates a good phase while a `0` indicates a bad phase.
+ *
+ *  The length of the vector is determined by `phaseMin`, `phaseMax` and `phaseStep` : 
+ *  (`phaseMax` - `phaseMin` + 1)/`phaseStep`
+ */
+bool scanGBTPhasesLocal(localArgs *la, std::vector<uint32_t> &results, const uint32_t ohN, const uint32_t N = 1, const uint8_t phaseMin = gbt::phaseMin, const uint8_t phaseMax = gbt::phaseMax, const uint8_t phaseStep = 1);
+
 /*! \brief Write the GBT configuration of one OptoHybrid.
  *  \param[in] request RPC response message.
  *  \param[out] response RPC response message.

--- a/include/gbt.h
+++ b/include/gbt.h
@@ -6,7 +6,32 @@
 #ifndef GBT_H
 #define GBT_H
 
+#include "gbt_constants.h"
+
 #include "utils.h"
+
+/*! \brief Write the GBT configuration of one OptoHybrid.
+ *  \param[in] request RPC response message.
+ *  \param[out] response RPC response message.
+ *
+ *  The method expects the following RPC keys :
+ *  - `word ohN` : OptoHybrid index number.
+ *  - `word gbtN` : Index of the GBT to configure. There 3 GBT's per OptoHybrid in the GE1/1 chambers.
+ *  - `binarydata config` : Configuration blob of the GBT. This is a 366 element long vector of the registers to write. The registers are sorted from address 0 to address 365.
+ *
+ *  The method returns the following RPC keys :
+ *  - `string error` : If an error occurs, this keys exists and contains the error message.
+ */
+void writeGBTConfig(const RPCMsg *request, RPCMsg *response);
+
+/*! \brief Local callable version of `writeGBTConfig`
+ *  \param[in, out] la Local arguments structure.
+ *  \param[in] ohN OptoHybrid index number.
+ *  \param[in] gbtN Index of the GBT to write. There 3 GBT's per OptoHybrid in the GE1/1 chambers.
+ *  \param[in] config Configuration blob of the GBT. This is a 366 elements long array whose each element is the value of one register sorted from address 0 to address 365.
+ *  \return Returns `false` in case of success; `true` in case of error. The precise error is logged and written to the `error` RPC key.
+ */
+bool writeGBTConfigLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN, const gbt::config_t &config);
 
 /*! \brief This function writes a single register in the given GBT of the given OptoHybrid.
  *  \param[in, out] la Local arguments structure.

--- a/include/gbt.h
+++ b/include/gbt.h
@@ -49,7 +49,7 @@ void scanGBTPhases(const RPCMsg *request, RPCMsg *response);
  *  The length of the vector is determined by `phaseMin`, `phaseMax` and `phaseStep` : 
  *  (`phaseMax` - `phaseMin` + 1)/`phaseStep`
  */
-bool scanGBTPhasesLocal(localArgs *la, std::vector<uint32_t> &results, const uint32_t ohN, const uint32_t N = 1, const uint8_t phaseMin = gbt::phaseMin, const uint8_t phaseMax = gbt::phaseMax, const uint8_t phaseStep = 1);
+bool scanGBTPhasesLocal(localArgs *la, std::vector<uint32_t> &results, const uint32_t ohN, const uint32_t N = 1, const uint8_t phaseMin = gbt::PHASE_MIN, const uint8_t phaseMax = gbt::PHASE_MAX, const uint8_t phaseStep = 1);
 
 /*! \brief Write the GBT configuration of one OptoHybrid.
  *  \param[in] request RPC response message.

--- a/include/gbt.h
+++ b/include/gbt.h
@@ -22,14 +22,13 @@
  *  - `word phaseStep` : Step to scan the phases.
  *
  *  The method returns the following RPC keys :
- *  - `word_array results` : Array of word containing the results of the scans. See details of the `scanGBTPhase` function for a description of the words.
+ *  - `word_array OHX.VFATY` : Array of word containing the results of the scans. See details of the `scanGBTPhase` function for a description of the words.
  *  - `string error` : If an error occurs, this keys exists and contains the error message.
  */
 void scanGBTPhases(const RPCMsg *request, RPCMsg *response);
 
 /*! \brief Local callable version of `scanGBTPhase`.
  *  \param[in, out] la Local arguments structure.
- *  \param[out] results A `std::vector` containing the results of the scan. See details for the items description.
  *  \param[in] ohN OptoHybrid index number.
  *  \param[in] N The number of times the scan must performed.
  *  \param[in] phaseMin Lowest phase to scan (min = 0).
@@ -41,15 +40,12 @@ void scanGBTPhases(const RPCMsg *request, RPCMsg *response);
  *
  *  The scan seeks for valid RX phases for the VFAT's of one OptoHybrid. A phase is considered valid when `LINK_GOOD = 1`, `SYNC_ERR_CNT = 0` and `CFG_RUN != 0xdeaddead`. In order to improve the reliability of the scan, it is repeated `N` times.
  *
- *  Each item of the results vector is composed as follow :
- *  - [31:28] : ohN
- *  - [27:24] : phase
- *  - [23:0] : result of the N scans (and) for the i^th VFAT. A `1` indicates a good phase while a `0` indicates a bad phase.
+ *  The results are returned as RPC keys named `OHX.VFATY` where X is the index of the OptoHyrid and Y the index of the VFAT within this OptoHybrid.
+ *  Each key is a word array of 16 elements for the 16 possible phases ordered from phase 0 to phase 15.
+ *  Each word is the number of time the scan was "good" out of the total number of scan requested, N.
  *
- *  The length of the vector is determined by `phaseMin`, `phaseMax` and `phaseStep` : 
- *  (`phaseMax` - `phaseMin` + 1)/`phaseStep`
  */
-bool scanGBTPhasesLocal(localArgs *la, std::vector<uint32_t> &results, const uint32_t ohN, const uint32_t N = 1, const uint8_t phaseMin = gbt::PHASE_MIN, const uint8_t phaseMax = gbt::PHASE_MAX, const uint8_t phaseStep = 1);
+bool scanGBTPhasesLocal(localArgs *la, const uint32_t ohN, const uint32_t N = 1, const uint8_t phaseMin = gbt::PHASE_MIN, const uint8_t phaseMax = gbt::PHASE_MAX, const uint8_t phaseStep = 1);
 
 /*! \brief Write the GBT configuration of one OptoHybrid.
  *  \param[in] request RPC response message.

--- a/include/gbt.h
+++ b/include/gbt.h
@@ -33,6 +33,29 @@ void writeGBTConfig(const RPCMsg *request, RPCMsg *response);
  */
 bool writeGBTConfigLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN, const gbt::config_t &config);
 
+/*! \brief Write the phase of a single VFAT.
+ *  \param[in] request RPC response message.
+ *  \param[out] response RPC response message.
+ *
+ *  The method expects the following RPC keys :
+ *  - `word ohN` : OptoHybrid index number.
+ *  - `word vfatN` : Index of the VFAT to configure. There 24 VFAT's per OptoHybrid in the GE1/1 chambers.
+ *  - `word phase` : Phase value to write. The values span from 0 to 15.
+ *
+ *  The method returns the following RPC keys :
+ *  - `string error` : If an error occurs, this keys exists and contains the error message.
+ */
+void writeGBTPhase(const RPCMsg *request, RPCMsg *response);
+
+/*! \brief Local callable version of `writeGBTPhase`
+ *  \param[in, out] la Local arguments structure.
+ *  \param[in] ohN OptoHybrid index number.
+ *  \param[in] vfatN VFAT index of which the phase is changed.
+ *  \param[in] phase Phase value to write. Minimal phase is 0 and maximal phase is 15.
+ *  \return Returns `false` in case of success; `true` in case of error. The precise error is logged and written to the `error` RPC key.
+ */
+bool writeGBTPhaseLocal(localArgs *la, const uint32_t ohN, const uint32_t vfatN, const uint8_t phase);
+
 /*! \brief This function writes a single register in the given GBT of the given OptoHybrid.
  *  \param[in, out] la Local arguments structure.
  *  \param[in] ohN OptoHybrid index number. Warning : the value of this parameter is not checked because of the cost of a register access.

--- a/include/gbt.h
+++ b/include/gbt.h
@@ -6,5 +6,17 @@
 #ifndef GBT_H
 #define GBT_H
 
+#include "utils.h"
+
+/*! \brief This function writes a single register in the given GBT of the given OptoHybrid.
+ *  \param[in, out] la Local arguments structure.
+ *  \param[in] ohN OptoHybrid index number. Warning : the value of this parameter is not checked because of the cost of a register access.
+ *  \param[in] gbtN Index of the GBT to write. There 3 GBT's per OptoHybrid in the GE1/1 chambers.
+ *  \param[in] address GBT register address to write. The highest writable address is 365.
+ *  \param[in] value Value to write to the GBT register.
+ *  \return Returns `false` in case of success; `true` in case of error. The precise error is logged and written to the `error` RPC key.
+ */
+bool writeGBTRegLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN, const uint16_t address, const uint8_t value);
+
 #endif
 

--- a/include/gbt.h
+++ b/include/gbt.h
@@ -6,7 +6,7 @@
 #ifndef GBT_H
 #define GBT_H
 
-#include "gbt_constants.h"
+#include "hw_constants.h"
 
 #include "utils.h"
 

--- a/include/gbt_constants.h
+++ b/include/gbt_constants.h
@@ -1,0 +1,22 @@
+/*! \file
+ *  \brief Header containing the constants for the GBT module.
+ *  \author Laurent Pétré <lpetre@ulb.ac.be>
+ */
+
+#ifndef GBT_CONSTANTS_H
+#define GBT_CONSTANTS_H
+
+#include <stdint.h>
+
+namespace gbt{
+    /*! \brief The number of GBT's per OptoHybrid.
+     */
+    constexpr uint32_t gbtsPerOH = 3;
+
+    /*! \brief The size of the GBT configuration address space. The corresponding addresses span from 0 to 365.
+     */
+    constexpr uint16_t configSize = 366;
+}
+
+#endif
+

--- a/include/gbt_constants.h
+++ b/include/gbt_constants.h
@@ -7,6 +7,7 @@
 #define GBT_CONSTANTS_H
 
 #include <stdint.h>
+#include <array>
 
 namespace gbt{
     /*! \brief The number of GBT's per OptoHybrid.
@@ -16,6 +17,10 @@ namespace gbt{
     /*! \brief The size of the GBT configuration address space. The corresponding addresses span from 0 to 365.
      */
     constexpr uint16_t configSize = 366;
+
+    /*! \brief This type defines a GBT configuration blob.
+     */
+    typedef std::array<uint8_t, configSize> config_t;
 }
 
 #endif

--- a/include/gbt_constants.h
+++ b/include/gbt_constants.h
@@ -14,6 +14,10 @@ namespace gbt{
      */
     constexpr uint32_t gbtsPerOH = 3;
 
+    /*! \brief The number of VFAT's prt OptoHybrid.
+     */
+    constexpr uint32_t vfatsPerOH = 24;
+
     /*! \brief The size of the GBT configuration address space. The corresponding addresses span from 0 to 365.
      */
     constexpr uint16_t configSize = 366;
@@ -21,6 +25,36 @@ namespace gbt{
     /*! \brief This type defines a GBT configuration blob.
      */
     typedef std::array<uint8_t, configSize> config_t;
+
+    /*! \brief Minimal phase for the elink RX GBT phase.
+     */
+    constexpr uint8_t phaseMin = 0;
+
+    /*! \brief Maximal phase for the elink RX GBT phase.
+     */
+    constexpr uint8_t phaseMax = 15;
+
+    /*! \brief Mappings between elinks, GBT index and VFAT index.
+     */
+    namespace elinkMappings {
+        /*! \brief Mapping from VFAT index to GBT index.
+	 */
+        constexpr std::array<uint32_t, 24> vfatToGBT{
+            { 1, 1, 1, 1, 1, 1, 1, 0, 1, 2, 2, 2, 0, 0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 0 }
+        };
+
+        /*! \brief Mapping from VFAT index to the elink of its corresponding GBT.
+	 */
+        constexpr std::array<uint8_t, 24> vfatToElink{
+            { 5, 9, 2, 3, 1, 8, 6, 6, 4, 1, 5, 4, 3, 2, 1, 0, 7, 8, 6, 7, 2, 3, 9, 8 }
+        };
+
+        /*! \brief Mapping from elink index to the 3 registers addresses in the GBT.
+	 */
+        constexpr std::array<std::array<uint16_t, 3>, 10> elinkToRegisters{
+            { {69, 73, 77}, {67, 71, 75}, {93, 97, 101}, {91, 95, 99}, {117, 121, 125}, {115, 119, 123}, {141, 145, 149}, {139, 143, 147}, {165, 169, 173}, {163, 167, 171} }
+        };
+    }
 }
 
 #endif

--- a/include/hw_constants.h
+++ b/include/hw_constants.h
@@ -1,10 +1,10 @@
 /*! \file
- *  \brief Header containing the constants for the GBT module.
+ *  \brief Header containing the hardware related constants.
  *  \author Laurent Pétré <lpetre@ulb.ac.be>
  */
 
-#ifndef GBT_CONSTANTS_H
-#define GBT_CONSTANTS_H
+#ifndef HW_CONSTANTS_H
+#define HW_CONSTANTS_H
 
 #include <stdint.h>
 #include <array>

--- a/include/hw_constants.h
+++ b/include/hw_constants.h
@@ -21,7 +21,7 @@ namespace oh{
     namespace ge11{
         /*! \brief The number of VFAT's per OptoHybrid.
          */
-        constexpr uint32_t vfatsPerOH = 24;
+        constexpr uint32_t VFATS_PER_OH = 24;
     }
 
     using namespace GEM_VARIANT;
@@ -32,26 +32,26 @@ namespace oh{
 namespace gbt{
     /*! \brief The size of the GBT configuration address space. The corresponding addresses span from 0 to 365.
      */
-    constexpr uint16_t configSize = 366;
+    constexpr uint16_t CONFIG_SIZE = 366;
 
     /*! \brief This type defines a GBT configuration blob.
      */
-    typedef std::array<uint8_t, configSize> config_t;
+    typedef std::array<uint8_t, CONFIG_SIZE> config_t;
 
     /*! \brief Minimal phase for the elink RX GBT phase.
      */
-    constexpr uint8_t phaseMin = 0;
+    constexpr uint8_t PHASE_MIN = 0;
 
     /*! \brief Maximal phase for the elink RX GBT phase.
      */
-    constexpr uint8_t phaseMax = 15;
+    constexpr uint8_t PHASE_MAX = 15;
 
     /*! \brief GE1/1 specific namespace.
      */
     namespace ge11{
         /*! \brief The number of GBT's per OptoHybrid.
          */
-        constexpr uint32_t gbtsPerOH = 3;
+        constexpr uint32_t GBTS_PER_OH = 3;
     }
 
     using namespace GEM_VARIANT;
@@ -62,19 +62,19 @@ namespace gbt{
         namespace ge11{
             /*! \brief Mapping from VFAT index to GBT index.
              */
-            constexpr std::array<uint32_t, 24> vfatToGBT{
+            constexpr std::array<uint32_t, 24> VFAT_TO_GBT{
                 { 1, 1, 1, 1, 1, 1, 1, 0, 1, 2, 2, 2, 0, 0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 0 }
             };
 
             /*! \brief Mapping from VFAT index to the elink of its corresponding GBT.
              */
-            constexpr std::array<uint8_t, 24> vfatToElink{
+            constexpr std::array<uint8_t, 24> VFAT_TO_ELINK{
                 { 5, 9, 2, 3, 1, 8, 6, 6, 4, 1, 5, 4, 3, 2, 1, 0, 7, 8, 6, 7, 2, 3, 9, 8 }
             };
 
             /*! \brief Mapping from elink index to the 3 registers addresses in the GBT.
 	         */
-            constexpr std::array<std::array<uint16_t, 3>, 10> elinkToRegisters{
+            constexpr std::array<std::array<uint16_t, 3>, 10> ELINK_TO_REGISTERS{
                 { {69, 73, 77}, {67, 71, 75}, {93, 97, 101}, {91, 95, 99}, {117, 121, 125}, {115, 119, 123}, {141, 145, 149}, {139, 143, 147}, {165, 169, 173}, {163, 167, 171} }
             };
         }

--- a/include/hw_constants.h
+++ b/include/hw_constants.h
@@ -6,18 +6,30 @@
 #ifndef HW_CONSTANTS_H
 #define HW_CONSTANTS_H
 
+#ifndef GEM_VARIANT
+#error You must define the GEM_VARIANT constant.
+#endif
+
 #include <stdint.h>
 #include <array>
 
+/*! \brief This namespace hold the constants related to the OptoHybrid.
+ */
+namespace oh{
+    /*! \brief GE1/1 specific namespace.
+     */
+    namespace ge11{
+        /*! \brief The number of VFAT's per OptoHybrid.
+         */
+        constexpr uint32_t vfatsPerOH = 24;
+    }
+
+    using namespace GEM_VARIANT;
+}
+
+/*! \brief This namespace hold the constants related to the GBT.
+ */
 namespace gbt{
-    /*! \brief The number of GBT's per OptoHybrid.
-     */
-    constexpr uint32_t gbtsPerOH = 3;
-
-    /*! \brief The number of VFAT's prt OptoHybrid.
-     */
-    constexpr uint32_t vfatsPerOH = 24;
-
     /*! \brief The size of the GBT configuration address space. The corresponding addresses span from 0 to 365.
      */
     constexpr uint16_t configSize = 366;
@@ -34,26 +46,40 @@ namespace gbt{
      */
     constexpr uint8_t phaseMax = 15;
 
+    /*! \brief GE1/1 specific namespace.
+     */
+    namespace ge11{
+        /*! \brief The number of GBT's per OptoHybrid.
+         */
+        constexpr uint32_t gbtsPerOH = 3;
+    }
+
+    using namespace GEM_VARIANT;
+
     /*! \brief Mappings between elinks, GBT index and VFAT index.
      */
     namespace elinkMappings {
-        /*! \brief Mapping from VFAT index to GBT index.
-	 */
-        constexpr std::array<uint32_t, 24> vfatToGBT{
-            { 1, 1, 1, 1, 1, 1, 1, 0, 1, 2, 2, 2, 0, 0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 0 }
-        };
+        namespace ge11{
+            /*! \brief Mapping from VFAT index to GBT index.
+             */
+            constexpr std::array<uint32_t, 24> vfatToGBT{
+                { 1, 1, 1, 1, 1, 1, 1, 0, 1, 2, 2, 2, 0, 0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 0 }
+            };
 
-        /*! \brief Mapping from VFAT index to the elink of its corresponding GBT.
-	 */
-        constexpr std::array<uint8_t, 24> vfatToElink{
-            { 5, 9, 2, 3, 1, 8, 6, 6, 4, 1, 5, 4, 3, 2, 1, 0, 7, 8, 6, 7, 2, 3, 9, 8 }
-        };
+            /*! \brief Mapping from VFAT index to the elink of its corresponding GBT.
+             */
+            constexpr std::array<uint8_t, 24> vfatToElink{
+                { 5, 9, 2, 3, 1, 8, 6, 6, 4, 1, 5, 4, 3, 2, 1, 0, 7, 8, 6, 7, 2, 3, 9, 8 }
+            };
 
-        /*! \brief Mapping from elink index to the 3 registers addresses in the GBT.
-	 */
-        constexpr std::array<std::array<uint16_t, 3>, 10> elinkToRegisters{
-            { {69, 73, 77}, {67, 71, 75}, {93, 97, 101}, {91, 95, 99}, {117, 121, 125}, {115, 119, 123}, {141, 145, 149}, {139, 143, 147}, {165, 169, 173}, {163, 167, 171} }
-        };
+            /*! \brief Mapping from elink index to the 3 registers addresses in the GBT.
+	         */
+            constexpr std::array<std::array<uint16_t, 3>, 10> elinkToRegisters{
+                { {69, 73, 77}, {67, 71, 75}, {93, 97, 101}, {91, 95, 99}, {117, 121, 125}, {115, 119, 123}, {141, 145, 149}, {139, 143, 147}, {165, 169, 173}, {163, 167, 171} }
+            };
+        }
+
+        using namespace GEM_VARIANT;
     }
 }
 

--- a/include/hw_constants_checks.h
+++ b/include/hw_constants_checks.h
@@ -1,0 +1,30 @@
+/*! \file
+ *  \brief Header containing helper functions to check the hardware related constants.
+ *  \author Laurent Pétré <lpetre@ulb.ac.be>
+ */
+
+#ifndef HW_CONSTANTS_CHECKS_H
+#define HW_CONSTANTS_CHECKS_H
+
+#include "hw_constants.h"
+#include "wiscRPCMsg.h"
+
+/*! \brief This namespace hold the check for constants related to the GBT.
+ */
+namespace gbt{
+    /*! \brief This function checks the phase parameter validity.
+     *  \param[in, out] response Pointer to the RPC response object.
+     *  \param[in] phase Phase value to check.
+     *  \return Returns `false` in case of success; `true` in case of error. The precise error is logged and written to the `error` RPC key.
+     */
+    inline bool checkPhase(wisc::RPCMsg *response, uint8_t phase){
+        if (phase < gbt::PHASE_MIN)
+            EMIT_RPC_ERROR(response, stdsprintf("The phase parameter supplied (%hhu) is smaller than the minimal phase (%hhu).", phase, gbt::PHASE_MIN), true)
+        if (phase > gbt::PHASE_MAX)
+            EMIT_RPC_ERROR(response, stdsprintf("The phase parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phase, gbt::PHASE_MAX), true)
+        return false;
+    }
+}
+
+#endif
+

--- a/include/utils.h
+++ b/include/utils.h
@@ -52,6 +52,16 @@ std::string serialize(xhal::utils::Node n) {
   return std::to_string((uint32_t)n.real_address)+"|"+n.permission+"|"+std::to_string((uint32_t)n.mask);
 }
 
+/*! \brief This macro is used to terminate a function if an error occurs. It logs the message, write it to the `error` RPC key and returns the `error_code` value.
+ *  \param response A pointer to the RPC response object.
+ *  \param message The `std::string` error message.
+ *  \param error_code Value which is passed to the `return` statement.
+ */
+#define EMIT_RPC_ERROR(response, message, error_code){ \
+    LOGGER->log_message(LogManager::ERROR, message); \
+    response->set_string("error", message); \
+    return error_code; }
+
 /*! \fn uint32_t getNumNonzeroBits(uint32_t value)
  *  \brief returns the number of nonzero bits in an integer
  *  \param value integer to check the number of nonzero bits

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -10,6 +10,9 @@
 #include "memhub.h"
 #include "utils.h"
 
+#include <thread>
+#include <chrono>
+
 /*! \brief This macro is used to terminate a function if an error occurs. It logs the message, write it to the `error` RPC key and returns the `error_code` value.
  *  \param response A pointer to the RPC response object.
  *  \param message The `std::string` error message.
@@ -19,6 +22,115 @@
     LOGGER->log_message(LogManager::ERROR, message); \
     response->set_string("error", message); \
     return error_code; }
+
+void scanGBTPhases(const RPCMsg *request, RPCMsg *response){
+    auto env = lmdb::env::create();
+    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
+    std::string gem_path = std::getenv("GEM_PATH");
+    std::string lmdb_data_file = gem_path+"/address_table.mdb";
+    env.open(lmdb_data_file.c_str(), 0, 0664);
+    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+
+    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+
+    // ohN key
+    const uint32_t ohN = request->get_word("ohN");
+    const uint32_t ohMax = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    if (ohN >= ohMax)
+        EMIT_RPC_ERROR(response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), )
+
+    // N key
+    const uint32_t N = request->get_word("N");
+
+    // phases config keys
+    const uint8_t phaseMin = request->get_word("phaseMin");
+    if (phaseMin < gbt::phaseMin)
+        EMIT_RPC_ERROR(response, stdsprintf("The phaseMin parameter supplied (%hhu) is smaller than the minimal phase (%hhu).", phaseMin, gbt::phaseMin), )
+    if (phaseMin > gbt::phaseMax)
+        EMIT_RPC_ERROR(response, stdsprintf("The phaseMin parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phaseMin, gbt::phaseMax), )
+
+    const uint8_t phaseMax = request->get_word("phaseMax");
+    if (phaseMax < gbt::phaseMin)
+        EMIT_RPC_ERROR(response, stdsprintf("The phaseMax parameter supplied (%hhu) is smaller than the minimal phase (%hhu).", phaseMax, gbt::phaseMin), )
+    if (phaseMax > gbt::phaseMax)
+        EMIT_RPC_ERROR(response, stdsprintf("The phaseMax parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phaseMax, gbt::phaseMax), )
+
+    const uint8_t phaseStep = request->get_word("phaseStep");
+
+    // Perform the scan
+    std::vector<uint32_t> results;
+    if (scanGBTPhasesLocal(&la, results, ohN, N, phaseMin, phaseMax, phaseStep))
+        return;
+
+    response->set_word_array("results", results);
+
+    return;
+} //Enc scanGBTPhase
+
+bool scanGBTPhasesLocal(localArgs *la, std::vector<uint32_t> &results, const uint32_t ohN, const uint32_t N, const uint8_t phaseMin, const uint8_t phaseMax, const uint8_t phaseStep){
+    LOGGER->log_message(LogManager::INFO, stdsprintf("Scannng the phases for OH #%u.", ohN));
+
+    // ohN check
+    const uint32_t ohMax = readReg(la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
+    if (ohN >= ohMax)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), true)
+
+    // phaseMin check
+    if (phaseMin < gbt::phaseMin)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The phaseMin parameter supplied (%hhu) is smaller than the minimal phase (%hhu).", phaseMin, gbt::phaseMin), true)
+    if (phaseMin > gbt::phaseMax)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The phaseMin parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phaseMin, gbt::phaseMax), true)
+
+    // phaseMax check
+    if (phaseMax < gbt::phaseMin)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The phaseMax parameter supplied (%hhu) is smaller than the minimal phase (%hhu).", phaseMax, gbt::phaseMin), true)
+    if (phaseMax > gbt::phaseMax)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The phaseMax parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phaseMax, gbt::phaseMax), true)
+
+    // Perform the scan
+    for(uint8_t phase = phaseMin; phase <= phaseMax; phase += phaseStep){
+        // Each measurement is composed as such :
+        //  - [31:28] : OH number
+        //  - [27:24] : Phase value
+        //  - [23:0] : VFAT i status
+        uint32_t result = ((ohN << 28) & 0xf0000000) |
+                          ((phase << 24) & 0x0f000000) |
+                          0x00ffffff;
+
+        // Set the new phases
+        for(uint32_t vfatN = 0; vfatN < gbt::vfatsPerOH; vfatN++){
+            if (writeGBTPhaseLocal(la, ohN, vfatN, phase))
+                return true;
+        }
+
+	// Wait for the phases to be set
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        for (uint32_t repN = 0; repN < N; repN++){
+            // Try to synchronize the VFAT's
+            writeReg(la, "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 1);
+            std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+            // Check the VFAT status
+            for(uint32_t vfatN = 0; vfatN < gbt::vfatsPerOH; vfatN++){
+                const bool linkGood = (readReg(la, stdsprintf("GEM_AMC.OH_LINKS.OH%hu.VFAT%hu.LINK_GOOD", ohN, vfatN)) == 1);
+                const bool syncErrCnt = (readReg(la, stdsprintf("GEM_AMC.OH_LINKS.OH%hu.VFAT%hu.SYNC_ERR_CNT", ohN, vfatN)) == 0);
+                const bool cfgRun = (readReg(la, stdsprintf("GEM_AMC.OH.OH%hu.GEB.VFAT%hu.CFG_RUN", ohN, vfatN)) != 0xdeaddead);
+
+                // If no errors, the phase is good
+                if (linkGood && syncErrCnt && cfgRun)
+                    continue;
+
+                result &= ~(0x1 << vfatN);
+            }
+        }
+
+        results.push_back(result);
+    }
+
+    return false;
+} //End scanGBTPhaseLocal
 
 void writeGBTConfig(const RPCMsg *request, RPCMsg *response){
     auto env = lmdb::env::create();
@@ -178,6 +290,7 @@ extern "C" {
         }
         modmgr->register_method("gbt", "writeGBTConfig", writeGBTConfig);
         modmgr->register_method("gbt", "writeGBTPhase", writeGBTPhase);
+        modmgr->register_method("gbt", "scanGBTPhases", scanGBTPhases);
     }
 }
 

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -13,16 +13,6 @@
 #include <thread>
 #include <chrono>
 
-/*! \brief This macro is used to terminate a function if an error occurs. It logs the message, write it to the `error` RPC key and returns the `error_code` value.
- *  \param response A pointer to the RPC response object.
- *  \param message The `std::string` error message.
- *  \param error_code Value which is passed to the `return` statement.
- */
-#define EMIT_RPC_ERROR(response, message, error_code){ \
-    LOGGER->log_message(LogManager::ERROR, message); \
-    response->set_string("error", message); \
-    return error_code; }
-
 void scanGBTPhases(const RPCMsg *request, RPCMsg *response){
     auto env = lmdb::env::create();
     env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -5,6 +5,7 @@
 
 #include "gbt.h"
 #include "hw_constants.h"
+#include "hw_constants_checks.h"
 
 #include "moduleapi.h"
 #include "memhub.h"
@@ -48,16 +49,12 @@ bool scanGBTPhasesLocal(localArgs *la, const uint32_t ohN, const uint32_t N, con
         EMIT_RPC_ERROR(la->response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), true)
 
     // phaseMin check
-    if (phaseMin < gbt::PHASE_MIN)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The phaseMin parameter supplied (%hhu) is smaller than the minimal phase (%hhu).", phaseMin, gbt::PHASE_MIN), true)
-    if (phaseMin > gbt::PHASE_MAX)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The phaseMin parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phaseMin, gbt::PHASE_MAX), true)
+    if (gbt::checkPhase(la->response, phaseMin))
+        return true;
 
     // phaseMax check
-    if (phaseMax < gbt::PHASE_MIN)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The phaseMax parameter supplied (%hhu) is smaller than the minimal phase (%hhu).", phaseMax, gbt::PHASE_MIN), true)
-    if (phaseMax > gbt::PHASE_MAX)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The phaseMax parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phaseMax, gbt::PHASE_MAX), true)
+    if (gbt::checkPhase(la->response, phaseMax))
+        return true;
 
     // Results array
     std::vector<std::vector<uint32_t>> results(oh::VFATS_PER_OH, std::vector<uint32_t>(16));
@@ -184,10 +181,8 @@ bool writeGBTPhaseLocal(localArgs *la, const uint32_t ohN, const uint32_t vfatN,
         EMIT_RPC_ERROR(la->response, stdsprintf("The vfatN parameter supplied (%u) exceeds the number of VFAT's per OH (%u).", vfatN, oh::VFATS_PER_OH), true)
 
     // phase check
-    if (phase < gbt::PHASE_MIN)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The phase parameter supplied (%hhu) is smaller than the minimal phase (%hhu).", phase, gbt::PHASE_MIN), true)
-    if (phase > gbt::PHASE_MAX)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The phase parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phase, gbt::PHASE_MAX), true)
+    if (gbt::checkPhase(la->response, phase))
+        return true;
 
     // Write the triplicated phase registers
     const uint32_t gbtN = gbt::elinkMappings::VFAT_TO_GBT[vfatN];

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -1,0 +1,23 @@
+/*! \file
+ *  \brief RPC module for GBT methods
+ *  \author Laurent Pétré <lpetre@ulb.ac.be>
+ */
+
+#include "gbt.h"
+
+#include "moduleapi.h"
+#include "memhub.h"
+#include "utils.h"
+
+extern "C" {
+    const char *module_version_key = "gbt v1.0.1";
+    int module_activity_color = 4;
+    void module_init(ModuleManager *modmgr) {
+        if (memhub_open(&memsvc) != 0) {
+            LOGGER->log_message(LogManager::ERROR, stdsprintf("Unable to connect to memory service: %s", memsvc_get_last_error(memsvc)));
+            LOGGER->log_message(LogManager::ERROR, "Unable to load module");
+            return; // Do not register our functions, we depend on memsvc.
+        }
+    }
+}
+

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -46,7 +46,7 @@ bool scanGBTPhasesLocal(localArgs *la, const uint32_t ohN, const uint32_t N, con
     // ohN check
     const uint32_t ohMax = readReg(la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (ohN >= ohMax)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), true)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), true);
 
     // phaseMin check
     if (gbt::checkPhase(la->response, phaseMin))
@@ -114,7 +114,7 @@ void writeGBTConfig(const RPCMsg *request, RPCMsg *response){
     // We must check the size of the config key
     const uint32_t configSize = request->get_binarydata_size("config");
     if (configSize != gbt::CONFIG_SIZE)
-        EMIT_RPC_ERROR(response, stdsprintf("The provided configuration has not the correct size. It is %u registers long while this methods expects %hu 8-bits registers.", configSize, gbt::CONFIG_SIZE), );
+        EMIT_RPC_ERROR(response, stdsprintf("The provided configuration has not the correct size. It is %u registers long while this methods expects %hu 8-bits registers.", configSize, gbt::CONFIG_SIZE), (void)"");
 
     gbt::config_t config{};
     request->get_binarydata("config", config.data(), config.size());
@@ -131,11 +131,11 @@ bool writeGBTConfigLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN,
     // ohN check
     const uint32_t ohMax = readReg(la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (ohN >= ohMax)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), true)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), true);
 
     // gbtN check
     if (gbtN >= gbt::GBTS_PER_OH)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The gbtN parameter supplied (%u) exceeds the number of GBT's per OH (%u).", gbtN, gbt::GBTS_PER_OH), true)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The gbtN parameter supplied (%u) exceeds the number of GBT's per OH (%u).", gbtN, gbt::GBTS_PER_OH), true);
 
     // Write all the registers
     for (size_t address = 0; address < gbt::CONFIG_SIZE; address++){
@@ -174,11 +174,11 @@ bool writeGBTPhaseLocal(localArgs *la, const uint32_t ohN, const uint32_t vfatN,
     // ohN check
     const uint32_t ohMax = readReg(la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (ohN >= ohMax)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), true)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), true);
 
     // vfatN check
     if (vfatN >= oh::VFATS_PER_OH)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The vfatN parameter supplied (%u) exceeds the number of VFAT's per OH (%u).", vfatN, oh::VFATS_PER_OH), true)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The vfatN parameter supplied (%u) exceeds the number of VFAT's per OH (%u).", vfatN, oh::VFATS_PER_OH), true);
 
     // phase check
     if (gbt::checkPhase(la->response, phase))
@@ -200,11 +200,11 @@ bool writeGBTPhaseLocal(localArgs *la, const uint32_t ohN, const uint32_t vfatN,
 bool writeGBTRegLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN, const uint16_t address, const uint8_t value){
     // Check that the GBT exists
     if (gbtN >= gbt::GBTS_PER_OH)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The gbtN parameter supplied (%u) is larger than the number of GBT's per OH (%u).", gbtN, gbt::GBTS_PER_OH), true)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The gbtN parameter supplied (%u) is larger than the number of GBT's per OH (%u).", gbtN, gbt::GBTS_PER_OH), true);
 
     // Check that the address is writable
     if (address >= gbt::CONFIG_SIZE)
-        EMIT_RPC_ERROR(la->response, stdsprintf("GBT has %hu writable addresses while the provided address is %hu.", gbt::CONFIG_SIZE-1, address), true)
+        EMIT_RPC_ERROR(la->response, stdsprintf("GBT has %hu writable addresses while the provided address is %hu.", gbt::CONFIG_SIZE-1, address), true);
 
     // GBT registers are 8 bits long
     writeReg(la, "GEM_AMC.SLOW_CONTROL.IC.READ_WRITE_LENGTH", 1);

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -4,10 +4,45 @@
  */
 
 #include "gbt.h"
+#include "gbt_constants.h"
 
 #include "moduleapi.h"
 #include "memhub.h"
 #include "utils.h"
+
+/*! \brief This macro is used to terminate a function if an error occurs. It logs the message, write it to the `error` RPC key and returns the `error_code` value.
+ *  \param response A pointer to the RPC response object.
+ *  \param message The `std::string` error message.
+ *  \param error_code Value which is passed to the `return` statement.
+ */
+#define EMIT_RPC_ERROR(response, message, error_code){ \
+    LOGGER->log_message(LogManager::ERROR, message); \
+    response->set_string("error", message); \
+    return error_code; }
+
+bool writeGBTRegLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN, const uint16_t address, const uint8_t value){
+    // Check that the GBT exists
+    if (gbtN >= gbt::gbtsPerOH)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The gbtN parameter supplied (%u) is larger than the number of GBT's per OH (%u).", gbtN, gbt::gbtsPerOH), true)
+
+    // Check that the address is writable
+    if (address >= gbt::configSize)
+        EMIT_RPC_ERROR(la->response, stdsprintf("GBT has %hu writable addresses while the provided address is %hu.", gbt::configSize-1, address), true)
+
+    // GBT registers are 8 bits long
+    writeReg(la, "GEM_AMC.SLOW_CONTROL.IC.READ_WRITE_LENGTH", 1);
+
+    // Select the link number
+    const uint32_t linkN = ohN*gbt::gbtsPerOH + gbtN;
+    writeReg(la, "GEM_AMC.SLOW_CONTROL.IC.GBTX_LINK_SELECT", linkN);
+
+    // Write to the register
+    writeReg(la, "GEM_AMC.SLOW_CONTROL.IC.ADDRESS", address);
+    writeReg(la, "GEM_AMC.SLOW_CONTROL.IC.WRITE_DATA", value);
+    writeReg(la, "GEM_AMC.SLOW_CONTROL.IC.EXECUTE_WRITE", 1);
+
+    return false;
+} //End writeGBTRegLocal(...)
 
 extern "C" {
     const char *module_version_key = "gbt v1.0.1";

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -4,7 +4,7 @@
  */
 
 #include "gbt.h"
-#include "gbt_constants.h"
+#include "hw_constants.h"
 
 #include "moduleapi.h"
 #include "memhub.h"

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -99,12 +99,12 @@ bool scanGBTPhasesLocal(localArgs *la, std::vector<uint32_t> &results, const uin
                           0x00ffffff;
 
         // Set the new phases
-        for(uint32_t vfatN = 0; vfatN < gbt::vfatsPerOH; vfatN++){
+        for(uint32_t vfatN = 0; vfatN < oh::vfatsPerOH; vfatN++){
             if (writeGBTPhaseLocal(la, ohN, vfatN, phase))
                 return true;
         }
 
-	// Wait for the phases to be set
+        // Wait for the phases to be set
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
         for (uint32_t repN = 0; repN < N; repN++){
@@ -113,7 +113,7 @@ bool scanGBTPhasesLocal(localArgs *la, std::vector<uint32_t> &results, const uin
             std::this_thread::sleep_for(std::chrono::milliseconds(300));
 
             // Check the VFAT status
-            for(uint32_t vfatN = 0; vfatN < gbt::vfatsPerOH; vfatN++){
+            for(uint32_t vfatN = 0; vfatN < oh::vfatsPerOH; vfatN++){
                 const bool linkGood = (readReg(la, stdsprintf("GEM_AMC.OH_LINKS.OH%hu.VFAT%hu.LINK_GOOD", ohN, vfatN)) == 1);
                 const bool syncErrCnt = (readReg(la, stdsprintf("GEM_AMC.OH_LINKS.OH%hu.VFAT%hu.SYNC_ERR_CNT", ohN, vfatN)) == 0);
                 const bool cfgRun = (readReg(la, stdsprintf("GEM_AMC.OH.OH%hu.GEB.VFAT%hu.CFG_RUN", ohN, vfatN)) != 0xdeaddead);
@@ -208,8 +208,8 @@ void writeGBTPhase(const RPCMsg *request, RPCMsg *response){
 
     // vfatN key
     const uint32_t vfatN = request->get_word("vfatN");
-    if (vfatN >= gbt::vfatsPerOH)
-        EMIT_RPC_ERROR(response, stdsprintf("The vfatN parameter supplied (%u) exceeds the number of GBT's per OH (%u).", vfatN, gbt::vfatsPerOH), )
+    if (vfatN >= oh::vfatsPerOH)
+        EMIT_RPC_ERROR(response, stdsprintf("The vfatN parameter supplied (%u) exceeds the number of GBT's per OH (%u).", vfatN, oh::vfatsPerOH), )
 
     // phase key
     const uint8_t phase = request->get_word("phase");
@@ -233,8 +233,8 @@ bool writeGBTPhaseLocal(localArgs *la, const uint32_t ohN, const uint32_t vfatN,
         EMIT_RPC_ERROR(la->response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), true)
 
     // vfatN check
-    if (vfatN >= gbt::vfatsPerOH)
-        EMIT_RPC_ERROR(la->response, stdsprintf("The vfatN parameter supplied (%u) exceeds the number of VFAT's per OH (%u).", vfatN, gbt::vfatsPerOH), true)
+    if (vfatN >= oh::vfatsPerOH)
+        EMIT_RPC_ERROR(la->response, stdsprintf("The vfatN parameter supplied (%u) exceeds the number of VFAT's per OH (%u).", vfatN, oh::vfatsPerOH), true)
 
     // phase check
     if (phase < gbt::phaseMin)

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -24,28 +24,11 @@ void scanGBTPhases(const RPCMsg *request, RPCMsg *response){
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
 
-    // ohN key
+    // Get the keys
     const uint32_t ohN = request->get_word("ohN");
-    const uint32_t ohMax = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
-    if (ohN >= ohMax)
-        EMIT_RPC_ERROR(response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), )
-
-    // N key
     const uint32_t N = request->get_word("N");
-
-    // phases config keys
     const uint8_t phaseMin = request->get_word("phaseMin");
-    if (phaseMin < gbt::phaseMin)
-        EMIT_RPC_ERROR(response, stdsprintf("The phaseMin parameter supplied (%hhu) is smaller than the minimal phase (%hhu).", phaseMin, gbt::phaseMin), )
-    if (phaseMin > gbt::phaseMax)
-        EMIT_RPC_ERROR(response, stdsprintf("The phaseMin parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phaseMin, gbt::phaseMax), )
-
     const uint8_t phaseMax = request->get_word("phaseMax");
-    if (phaseMax < gbt::phaseMin)
-        EMIT_RPC_ERROR(response, stdsprintf("The phaseMax parameter supplied (%hhu) is smaller than the minimal phase (%hhu).", phaseMax, gbt::phaseMin), )
-    if (phaseMax > gbt::phaseMax)
-        EMIT_RPC_ERROR(response, stdsprintf("The phaseMax parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phaseMax, gbt::phaseMax), )
-
     const uint8_t phaseStep = request->get_word("phaseStep");
 
     // Perform the scan
@@ -59,7 +42,7 @@ void scanGBTPhases(const RPCMsg *request, RPCMsg *response){
 } //Enc scanGBTPhase
 
 bool scanGBTPhasesLocal(localArgs *la, std::vector<uint32_t> &results, const uint32_t ohN, const uint32_t N, const uint8_t phaseMin, const uint8_t phaseMax, const uint8_t phaseStep){
-    LOGGER->log_message(LogManager::INFO, stdsprintf("Scannng the phases for OH #%u.", ohN));
+    LOGGER->log_message(LogManager::INFO, stdsprintf("Scanning the phases for OH #%u.", ohN));
 
     // ohN check
     const uint32_t ohMax = readReg(la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
@@ -133,18 +116,11 @@ void writeGBTConfig(const RPCMsg *request, RPCMsg *response){
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
 
-    // ohN key
+    // Get the keys
     const uint32_t ohN = request->get_word("ohN");
-    const uint32_t ohMax = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
-    if (ohN >= ohMax)
-        EMIT_RPC_ERROR(response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), )
-
-    // gbtN key
     const uint32_t gbtN = request->get_word("gbtN");
-    if (gbtN >= gbt::gbtsPerOH)
-        EMIT_RPC_ERROR(response, stdsprintf("The gbtN parameter supplied (%u) exceeds the number of GBT's per OH (%u).", gbtN, gbt::gbtsPerOH),)
 
-    // config key
+    // We must check the size of the config key
     const uint32_t configSize = request->get_binarydata_size("config");
     if (configSize != gbt::configSize)
         EMIT_RPC_ERROR(response, stdsprintf("The provided configuration has not the correct size. It is %u registers long while this methods expects %hu 8-bits registers.", configSize, gbt::configSize), );
@@ -190,23 +166,10 @@ void writeGBTPhase(const RPCMsg *request, RPCMsg *response){
 
     struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
 
-    // ohN key
+    // Get the keys
     const uint32_t ohN = request->get_word("ohN");
-    const uint32_t ohMax = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
-    if (ohN >= ohMax)
-        EMIT_RPC_ERROR(response, stdsprintf("The ohN parameter supplied (%u) exceeds the number of OH's supported by the CTP7 (%u).", ohN, ohMax), )
-
-    // vfatN key
     const uint32_t vfatN = request->get_word("vfatN");
-    if (vfatN >= oh::vfatsPerOH)
-        EMIT_RPC_ERROR(response, stdsprintf("The vfatN parameter supplied (%u) exceeds the number of GBT's per OH (%u).", vfatN, oh::vfatsPerOH), )
-
-    // phase key
     const uint8_t phase = request->get_word("phase");
-    if (phase < gbt::phaseMin)
-        EMIT_RPC_ERROR(response, stdsprintf("The phase parameter supplied (%hhu) is smaller than the minimal phase (%hhu).", phase, gbt::phaseMin), )
-    if (phase > gbt::phaseMax)
-        EMIT_RPC_ERROR(response, stdsprintf("The phase parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phase, gbt::phaseMax), )
 
     // Write the phase
     writeGBTPhaseLocal(&la, ohN, vfatN, phase);
@@ -232,7 +195,7 @@ bool writeGBTPhaseLocal(localArgs *la, const uint32_t ohN, const uint32_t vfatN,
     if (phase > gbt::phaseMax)
         EMIT_RPC_ERROR(la->response, stdsprintf("The phase parameter supplied (%hhu) is bigger than the maximal phase (%hhu).", phase, gbt::phaseMax), true)
 
-    // Write the triplcated phase registers
+    // Write the triplicated phase registers
     const uint32_t gbtN = gbt::elinkMappings::vfatToGBT[vfatN];
 
     for(unsigned char regN = 0; regN < 3; regN++){

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -68,12 +68,12 @@ bool scanGBTPhasesLocal(localArgs *la, const uint32_t ohN, const uint32_t N, con
         }
 
         // Wait for the phases to be set
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
         for (uint32_t repN = 0; repN < N; repN++){
             // Try to synchronize the VFAT's
             writeReg(la, "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 1);
-            std::this_thread::sleep_for(std::chrono::milliseconds(300));
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
             // Check the VFAT status
             for(uint32_t vfatN = 0; vfatN < oh::VFATS_PER_OH; vfatN++){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

[This PR is the continuation of the [previous PR about GBTX's](https://github.com/cms-gem-daq-project/ctp7_modules/pull/73). I started the new PR in order to keep the git log clean, but also the GitHub comments readable.]

Addresses https://github.com/cms-gem-daq-project/ctp7_modules/issues/72.

This PR adds a new RPC module which implements 3 new methods related to the GBTX configuration :

* `writeGBTConfig` updates the configuration of one chosen GBTX.
* `writeGBTPhase` updates one VFAT RX phase of one OH.
* `scanGBTPhases` scans the phases on one OH.

It lacks the MultiLink versions, but all the important functionalities are working. If the code and the documentation meet the expectation, I will add these methods.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

This PR fixes issue https://github.com/cms-gem-daq-project/ctp7_modules/issues/72.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

These tests were performed to see if the functionalities implemented in the `gbt.py` were still working with the RPC modules and so the new CTP7 releases :

* Writing the GBTX configurations. It has been tested for different OH and multiple GBTX's.
* Setting the GBTX RX phases for 1 VFAT at a time.
* Scanning the GBTX RX phases for one OH.

The environment was the following :
* CTP7 : eagle63
* CTP7 firmware : 3.7.0
* CTP7 build-id : CTP7-GENERIC-20180529T153916-0500-4935611
* `xHAL` commit https://github.com/cms-gem-daq-project/xhal/pull/99/commits/cfa38ed635ca078c0d3a2c24d02db9b9da17c327
* `cmsgemos` commit https://github.com/cms-gem-daq-project/cmsgemos/pull/226/commits/fd0747ed87a4f087bb00d1857ac6feae46a9d5fe
* The new `gbt.py` used for these tests comes from commit (in progress).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
