### PR TITLE
Fixing DAC scans with cached registers for nOH != 0

### DIFF
--- a/include/lmdb_cpp_wrapper.h
+++ b/include/lmdb_cpp_wrapper.h
@@ -1534,6 +1534,20 @@ public:
    * @param key
    * @throws lmdb::error on failure
    */
+  bool get(MDB_txn* const txn,
+           const std::string& key) const {
+    const lmdb::val k{key};
+    lmdb::val v{};
+    return lmdb::dbi_get(txn, handle(), k, v);
+  }
+
+  /**
+   * Retrieves a key from this database.
+   *
+   * @param txn a transaction handle
+   * @param key
+   * @throws lmdb::error on failure
+   */
   template<typename K>
   bool get(MDB_txn* const txn,
            const K& key) const {

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1149,7 +1149,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
     LOGGER->log_message(LogManager::INFO, stdsprintf("Scanning DAC: %s",regName.c_str()));
     uint32_t adcAddr[24];
     uint32_t adcCacheUpdateAddr[24];
-    bool foundAdcCached=false;
+    bool foundAdcCached = false;
     for(int vfatN=0; vfatN<24; ++vfatN){
         //Skip Masked VFATs
         if ( !( (notmask >> vfatN) & 0x1)) continue;
@@ -1160,11 +1160,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
         //Get ADC address
         if(useExtRefADC){ //Case: Use ADC with external reference
             //for backward compatibility, use ADC1 instead of ADC1_CACHED if it exists
-            lmdb::val key, db_res;
-
-            key.assign(strRegBase+"ADC1_CACHED");
-            foundAdcCached = la->dbi.get(la->rtxn,key,db_res);
-            if(foundAdcCached){
+            if((foundAdcCached = la->dbi.get(la->rtxn, strRegBase + "ADC1_CACHED"))){
                 adcAddr[vfatN] = getAddress(la, strRegBase + "ADC1_CACHED");
                 adcCacheUpdateAddr[vfatN] = getAddress(la, strRegBase + "ADC1_UPDATE");                
             }
@@ -1173,10 +1169,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
         } //End Case: Use ADC with external reference
         else{ //Case: Use ADC with internal reference
             //for backward compatibility, use ADC0 instead of ADC0_CACHED if it exists
-            lmdb::val key, db_res;
-            key.assign(strRegBase+"ADC0_CACHED");
-            foundAdcCached = la->dbi.get(la->rtxn,key,db_res);
-            if(foundAdcCached) {
+            if((foundAdcCached = la->dbi.get(la->rtxn, strRegBase + "ADC0_CACHED"))){
                 adcAddr[vfatN] = getAddress(la, strRegBase + "ADC0_CACHED");
                 adcCacheUpdateAddr[vfatN] = getAddress(la, strRegBase + "ADC0_UPDATE");
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR fixes a bug occurring when trying to perform DAC scans with cached registers on multiple links on `eagle64` at first and then on `eagle63` (CTP7 firmware >= 3.7.1). The scans failed when OH's different than 0 were unmasked.

## Description

Fixes https://github.com/cms-gem-daq-project/ctp7_modules/issues/80 with the solution discussed in the comments.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Multiple DAC scans were taken on `eagle63` for different OH's.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
