### PR TITLE
New Feature: Added Link Monitoring [develop]

### DIFF
--- a/include/daq_monitor.h
+++ b/include/daq_monitor.h
@@ -41,6 +41,29 @@ void getmonDAQOHmainLocal(localArgs * la, int NOH=12, int ohMask=0xfff);
  */
 void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response);
 
+/*! \fn void getmonGBTLinkLocal(const RPCMsg *request, RPCMsg *response);
+ *  \brief Local version of getmonGBTLink
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ *  \param doReset boolean if true (false) a link reset will (not) be sent
+ */
+void getmonGBTLinkLocal(localArgs * la, int NOH=12, bool doReset=false);
+
+/*! \fn void getmonGBTLink(const RPCMsg *request, RPCMsg *response);
+ *  \brief Reads the GBT link status registers (READY, WAS_NOT_READY, etc...) for a particular ohMask
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonGBTLink(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonOHLinkmain(const RPCMsg *request, RPCMsg *response)
+ *  \brief Checks the status of the GBT and VFAT links on this OH in one RPC call
+ *  \details Expects the "NOH" RPC key specifying the number of optohybrids.  No local callable version
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonOHLink(const RPCMsg *request, RPCMsg *response);
+
 /*! \fn void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
  *  \brief Local version of getmonOHmain
  *  \param la Local arguments
@@ -136,5 +159,20 @@ void getmonTTCmainLocal(localArgs * la);
  *  \param response RPC response message
  */
 void getmonTTCmain(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void getmonVFATLinkLocal(const RPCMsg *request, RPCMsg *response);
+ *  \brief Local version of getmonVFATLink
+ *  \param la Local arguments
+ *  \param NOH Number of optohybrids in FW
+ *  \param doReset boolean if true (false) a link reset will (not) be sent
+ */
+void getmonVFATLinkLocal(localArgs * la, int NOH=12, bool doReset=false);
+
+/*! \fn void getmonVFATLink(const RPCMsg *request, RPCMsg *response);
+ *  \brief Reads the VFAT link status registers (LINK_GOOD, SYNC_ERR_CNT, etc...) for a particular ohMask
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void getmonVFATLink(const RPCMsg *request, RPCMsg *response);
 
 #endif

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1295,7 +1295,8 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
             int dacMax = std::get<2>(dacInfo.map_dacInfo[dacSelect]);
-            dacScanResults.resize( (dacMax+1)*24/dacStep );
+            //dacScanResults.resize( (dacMax+1)*24/dacStep );
+            dacScanResults.assign( (dacMax+1)*24/dacStep, 0xdeaddead );
             std::copy(dacScanResults.begin(), dacScanResults.end(), std::back_inserter(dacScanResultsAll));
             continue;
         }

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1295,7 +1295,6 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response){
         // If this Optohybrid is masked skip it
         if(!((ohMask >> ohN) & 0x1)){
             int dacMax = std::get<2>(dacInfo.map_dacInfo[dacSelect]);
-            //dacScanResults.resize( (dacMax+1)*24/dacStep );
             dacScanResults.assign( (dacMax+1)*24/dacStep, 0xdeaddead );
             std::copy(dacScanResults.begin(), dacScanResults.end(), std::back_inserter(dacScanResultsAll));
             continue;

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -300,15 +300,7 @@ void getmonGBTLinkLocal(localArgs * la, int NOH, bool doReset)
 
 void getmonGBTLink(const RPCMsg *request, RPCMsg *response)
 {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  GETLOCALARGS(response);
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
   if (request->get_key_exists("NOH")){
@@ -332,15 +324,7 @@ void getmonGBTLink(const RPCMsg *request, RPCMsg *response)
 
 void getmonOHLink(const RPCMsg *request, RPCMsg *response)
 {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  GETLOCALARGS(response);
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
   if (request->get_key_exists("NOH")){
@@ -853,15 +837,7 @@ void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
 
 void getmonVFATLink(const RPCMsg *request, RPCMsg *response)
 {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  GETLOCALARGS(response);
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
   if (request->get_key_exists("NOH")){

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -294,6 +294,9 @@ void getmonGBTLinkLocal(localArgs * la, int NOH, bool doReset)
     if (doReset)
     {
          writeReg(la, "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
+
+         //Apply recursion once
+         getmonGBTLinkLocal(la, NOH, false); //Returned information will reflect post reset values
     }
 
     return;
@@ -842,6 +845,9 @@ void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
     if (doReset && vfatOutOfSync)
     {
          writeReg(la, "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
+
+         //Apply recursion once
+         getmonVFATLinkLocal(la, NOH, false); //Returned information will reflect post reset values
     }
 
     return;

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -845,7 +845,7 @@ void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
     //Set OOS flag (out of sync)
     if(vfatOutOfSync)
     {
-        la->response->set_string("error","One or more VFATs found to be out of sync\n");
+        la->response->set_string("warning","One or more VFATs found to be out of sync\n");
     }
 
     return;

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -28,7 +28,7 @@ void scanGBTPhases(const RPCMsg *request, RPCMsg *response){
 
     // Get the keys
     const uint32_t ohN = request->get_word("ohN");
-    const uint32_t N = request->get_word("N");
+    const uint32_t N = request->get_word("nScans");
     const uint8_t phaseMin = request->get_word("phaseMin");
     const uint8_t phaseMax = request->get_word("phaseMax");
     const uint8_t phaseStep = request->get_word("phaseStep");

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -28,14 +28,14 @@ void scanGBTPhases(const RPCMsg *request, RPCMsg *response){
 
     // Get the keys
     const uint32_t ohN = request->get_word("ohN");
-    const uint32_t N = request->get_word("nScans");
+    const uint32_t nScans = request->get_word("nScans");
     const uint8_t phaseMin = request->get_word("phaseMin");
     const uint8_t phaseMax = request->get_word("phaseMax");
     const uint8_t phaseStep = request->get_word("phaseStep");
 
     // Perform the scan
     LOGGER->log_message(LogManager::INFO, stdsprintf("Calling Local Method for OH #%u.", ohN));
-    if (scanGBTPhasesLocal(&la, ohN, N, phaseMin, phaseMax, phaseStep))
+    if (scanGBTPhasesLocal(&la, ohN, nScans, phaseMin, phaseMax, phaseStep))
     {
         LOGGER->log_message(LogManager::INFO, stdsprintf("GBT Scan for OH #%u Failed.", ohN));
         return;

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -34,8 +34,12 @@ void scanGBTPhases(const RPCMsg *request, RPCMsg *response){
     const uint8_t phaseStep = request->get_word("phaseStep");
 
     // Perform the scan
+    LOGGER->log_message(LogManager::INFO, stdsprintf("Calling Local Method for OH #%u.", ohN));
     if (scanGBTPhasesLocal(&la, ohN, N, phaseMin, phaseMax, phaseStep))
+    {
+        LOGGER->log_message(LogManager::INFO, stdsprintf("GBT Scan for OH #%u Failed.", ohN));
         return;
+    }
 
     return;
 } //Enc scanGBTPhase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses issue #66.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Provides link monitoring.  Is needed for connectivity testing proposal, see [steps 2 & 5](https://mattermost.web.cern.ch/cms-gem-ops/pl/brc3p9q95t8o3bd7uiubdy3hxa). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```bash
 testConnectivity.py -m 5 --shelf=2 -s5 --skipDACScan --skipScurve -o 0x1 -d --nPhaseScans=50 -o 0x1
Open pickled address table if available  /opt/cmsgemos/etc/maps/amc_address_table_top.pickle...
Initializing AMC gem-shelf02-amc05
====================
Step 1: Checking GBT Communication
====================
Checking GBT Communication (Before Programming GBTs)
--=======================================--
-> GEM SYSTEM GBT INFORMATION
--=======================================--

----------OH0----------
GBT0.READY              1
GBT0.NOT_READY          0
GBT0.RX_HAD_OVERFLOW    0
GBT0.RX_HAD_UNDERFLOW   0
GBT1.READY              1
GBT1.NOT_READY          0
GBT1.RX_HAD_OVERFLOW    0
GBT1.RX_HAD_UNDERFLOW   0
GBT2.READY              1
GBT2.NOT_READY          0
GBT2.RX_HAD_OVERFLOW    0
GBT2.RX_HAD_UNDERFLOW   0
Programming GBTs
Checking GBT Communication (After Programming GBTs)
--=======================================--
-> GEM SYSTEM GBT INFORMATION
--=======================================--

----------OH0----------
GBT0.READY              1
GBT0.NOT_READY          0
GBT0.RX_HAD_OVERFLOW    0
GBT0.RX_HAD_UNDERFLOW   0
GBT1.READY              1
GBT1.NOT_READY          0
GBT1.RX_HAD_OVERFLOW    0
GBT1.RX_HAD_UNDERFLOW   0
GBT2.READY              1
GBT2.NOT_READY          0
GBT2.RX_HAD_OVERFLOW    0
GBT2.RX_HAD_UNDERFLOW   0
GBT Communication Established
```

And for VFAT communication:

```bash
====================
Step 5: Checking VFAT Synchronization
====================
--=======================================--
-> GEM SYSTEM VFAT INFORMATION
--=======================================--

----------OH0----------
VFAT0.SYNC_ERR_CNT 0x0L
VFAT1.SYNC_ERR_CNT 0x0L
VFAT2.SYNC_ERR_CNT 0x0L
VFAT3.SYNC_ERR_CNT 0x0L
VFAT4.SYNC_ERR_CNT 0x0L
VFAT5.SYNC_ERR_CNT 0x0L
VFAT6.SYNC_ERR_CNT 0x0L
VFAT7.SYNC_ERR_CNT 0x0L
VFAT8.SYNC_ERR_CNT 0x0L
VFAT9.SYNC_ERR_CNT 0x0L
VFAT10.SYNC_ERR_CNT 0x0L
VFAT11.SYNC_ERR_CNT 0x0L
VFAT12.SYNC_ERR_CNT 0x0L
VFAT13.SYNC_ERR_CNT 0x0L
VFAT14.SYNC_ERR_CNT 0x0L
VFAT15.SYNC_ERR_CNT 0x0L
VFAT16.SYNC_ERR_CNT 0x0L
VFAT17.SYNC_ERR_CNT 0x0L
VFAT18.SYNC_ERR_CNT 0x0L
VFAT19.SYNC_ERR_CNT 0x0L
VFAT20.SYNC_ERR_CNT 0x0L
VFAT21.SYNC_ERR_CNT 0x0L
VFAT22.SYNC_ERR_CNT 0x0L
VFAT23.SYNC_ERR_CNT 0x0L
VFATs are properly synchronized
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
