### PR TITLE
Hot Fix: readVFAT3ADCLocal now uses cached registers [master]

### DIFF
--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -129,7 +129,7 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
 
         //Get VFAT Mask
         uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
-        
+
         LOGGER->log_message(LogManager::INFO, stdsprintf("Programming VFAT3 ADC Monitoring on OH%i for Selection %i",ohN,dacSelect));
         configureVFAT3DacMonitorLocal(&la, ohN, vfatMask, dacSelect);
     } //End Loop over all Optohybrids
@@ -261,10 +261,14 @@ void getChannelRegistersVFAT3Local(localArgs *la, uint32_t ohN, uint32_t vfatMas
 
 void readVFAT3ADCLocal(localArgs * la, uint32_t * outData, uint32_t ohN, bool useExtRefADC, uint32_t mask){
     if(useExtRefADC){ //Case: Use ADC with external reference
-        broadcastReadLocal(la, outData, ohN, "ADC1", mask);
+        broadcastReadLocal(la, outData, ohN, "ADC1_UPDATE", mask);
+        std::this_thread::sleep_for(std::chrono::microseconds(20));
+        broadcastReadLocal(la, outData, ohN, "ADC1_CACHED", mask);
     } //End Case: Use ADC with external reference
     else{ //Case: Use ADC with internal reference
-        broadcastReadLocal(la, outData, ohN, "ADC0", mask);
+        broadcastReadLocal(la, outData, ohN, "ADC0_UPDATE", mask);
+        std::this_thread::sleep_for(std::chrono::microseconds(20));
+        broadcastReadLocal(la, outData, ohN, "ADC0_CACHED", mask);
     } //End Case: Use ADC with internal reference
 
     return;
@@ -314,7 +318,7 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
             NOH = NOH_requested;
         else
             LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register value (%i), NOH request will be disregarded",NOH_requested,NOH));
-    }    
+    }
     uint32_t adcData[24] = {0};
     uint32_t adcDataAll[12*24] = {0};
     for(unsigned int ohN=0; ohN<NOH; ++ohN){
@@ -327,7 +331,7 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
 
         //Get VFAT Mask
         uint32_t vfatMask = getOHVFATMaskLocal(&la, ohN);
-        
+
         //Get all ADC values
         readVFAT3ADCLocal(&la, adcData, ohN, useExtRefADC, vfatMask);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
After CTP7 FW version [3.7.1](https://github.com/evka85/GEM_AMC/releases/tag/v3.7.1) the `ADCX` registers have been converted to `ADCX_CACHED` and `ADCX_UPDATE` for `X = 0,1`. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See discussion above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change was trivial.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
