### PR TITLE
Add Reed--Muller decoding function for VFAT3 ChipID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ IncludeDirs = $(PackageBase)/include
 IncludeDirs+= /opt/xhal/include
 # IncludeDirs+= /opt/cactus/include
 IncludeDirs+= /opt/wiscrpcsvc/include
+IncludeDirs+= /opt/reedmuller/include
 INC=$(IncludeDirs:%=-I%)
 
 ifndef GEM_VARIANT
@@ -41,6 +42,7 @@ LDFLAGS+= -Wl,--as-needed
 LibraryDirs = $(PackageBase)/lib
 LibraryDirs+= /opt/xhal/lib/arm
 LibraryDirs+= /opt/wiscrpcsvc/lib
+LibraryDirs+= /opt/reedmuller/lib/arm
 Libraries=$(LibraryDirs:%=-L%)
 
 .PHONY: clean rpc prerpm
@@ -126,7 +128,7 @@ daq_monitor: amc extras utils
 	$(MAKE) $(PackageLibraryDir)/daq_monitor.so EXTRA_LINKS="$(EXTRA_LINKS)"
 
 vfat3: optohybrid amc extras utils
-	$(eval export EXTRA_LINKS=$(^:%=-l:%.so))
+	$(eval export EXTRA_LINKS=$(^:%=-l:%.so) -lreedmuller)
 	$(MAKE) $(PackageLibraryDir)/vfat3.so EXTRA_LINKS="$(EXTRA_LINKS)"
 
 optohybrid: amc extras utils

--- a/include/vfat3.h
+++ b/include/vfat3.h
@@ -159,4 +159,12 @@ void statusVFAT3s(const RPCMsg *request, RPCMsg *response);
  */
 uint16_t decodeChipID(uint32_t encChipID);
 
+/*! \fn void statusVFAT3s(const RPCMsg *request, RPCMsg *response)
+ *  \brief Returns list of values of the most important VFAT3 register
+ *  \param request RPC request message
+ *  \param response RPC responce message
+ */
+void getVFAT3ChipIDsLocal(localArgs * la, uint32_t ohN, bool rawID=false);
+void getVFAT3ChipIDs(const RPCMsg *request, RPCMsg *response);
+
 #endif

--- a/include/vfat3.h
+++ b/include/vfat3.h
@@ -7,9 +7,9 @@
 
 #ifndef VFAT3_H
 #define VFAT3_H
+
 #include "utils.h"
 #include <string>
-
 
 /*! \fn uint32_t vfatSyncCheckLocal(localArgs * la, uint32_t ohN)
  *  \brief Local callable version of vfatSyncCheck
@@ -151,5 +151,12 @@ void statusVFAT3sLocal(localArgs * la, uint32_t ohN);
  *  \param response RPC responce message
  */
 void statusVFAT3s(const RPCMsg *request, RPCMsg *response);
+
+/*!
+ *  \brief Decode a Reed--Muller encoded VFAT3 ChipID
+ *  \param encChipID 32-bit encoded chip ID to decode
+ *  \return decoded VFAT3 chip ID
+ */
+uint16_t decodeChipID(uint32_t encChipID);
 
 #endif


### PR DESCRIPTION
## Description
Adds function `uint16_t decodeChipID(uint32_t encChipID)` to decode Reed--Muller encoded chip IDs

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context
Necessary to decode the Reed--Muller encoded VFAT3 chip IDs

## How Has This Been Tested?
* ~Hasn't been tested with hardware, due to previous lack of compatible hybrids.~
  * Tested on 4 new hybrids, performs as expected
* Encoding and decoding has been tested with command line function.
