### PR TITLE
[chore] Fix warnings about signed vs. unsigned comparisons

### DIFF
--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -188,7 +188,7 @@ std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acq
         }
 
         acquisitionTime=difftime(time(NULL),startTime);
-        if(acquisitionTime > acquireTime){
+        if(uint32_t(acquisitionTime) > acquireTime){
             acquire=false;
         }
     } //End readout sbits

--- a/src/amc/ttc.cpp
+++ b/src/amc/ttc.cpp
@@ -552,7 +552,7 @@ int checkPLLLockLocal(localArgs* la, int readAttempts)
   std::stringstream msg;
   msg << "Executing checkPLLLock with " << readAttempts << " attempted relocks";
   LOGGER->log_message(LogManager::DEBUG, msg.str());
-  for (uint32_t i = 0; i < readAttempts; ++i ) {
+  for (int i = 0; i < readAttempts; ++i ) {
     writeReg(la,"GEM_AMC.TTC.CTRL.PA_MANUAL_PLL_RESET", 0x1);
 
     // wait 100us to allow the PLL to lock

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1215,7 +1215,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
                 writeReg(la, strDacReg, dacVal);
                 //Read nReads times and take avg value
                 uint32_t adcVal=0;
-                for(int i=0; i<nReads; ++i){
+                for(uint32_t i=0; i<nReads; ++i){
                     //Read the ADC
                     if (foundAdcCached){
                         //either reading or writing this register will trigger a cache update


### PR DESCRIPTION
## Description
Clean up bad code leading to compiler warnings.

### Types of changes
- [x] Cleanup (non-breaking change which fixes an warning)
