### PR TITLE
SCA command control functions

### DIFF
--- a/include/amc/sca.h
+++ b/include/amc/sca.h
@@ -8,12 +8,99 @@
 #define AMC_SCA_H
 
 #include "utils.h"
+#include "amc/sca_enums.h"
 
 /*!
  * \defgroup sca SCA module functionality
  */
 
+/*!
+ * \brief Prepare data for use with the SCA communication interfaces
+ *
+ * \details SCA TX/RX data is transmitted using the HDLC protocol, which is 16-bit length, and sent LSB to MSB.
+ * In the HDLC packet, it is sent/received as [<16:31><0:15>].
+ * The GEM_AMC firmware stores it as [<7:0><15:8><23:16><31:24>]
+ *
+ * \param data is the data to be converted to the appropriate ordering
+ */
+uint32_t formatSCAData(uint32_t const& data);
+
+/*!
+ * \brief Execute a command using the SCA interface
+ * \details Generic command to drive commands to all SCA modules
+ *  *
+ * \param la Local arguments structure
+ * \param ch channel to communicate with
+ * \param cmd command to send, referenced in sca_enums.h
+ * \param len length of the data to send, available 1,2,4
+ * \param data to send to the CTRL command
+ * \param linkMask bit list of OptoHybrids to send the commands to
+ */
+void sendSCACommand(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask=0xfff);
+
+/*!
+ * \brief Execute a command using the SCA interface, and read the reply from the SCA
+ * \param la Local arguments structure
+ * \param ch channel to communicate with
+ * \param cmd command to send, referenced in sca_enums.h
+ * \param len length of the data to send, available 1,2,4
+ * \param data to send to the CTRL command
+ * \param linkMask bit list of OptoHybrids to send the commands to
+ */
+std::vector<uint32_t> sendSCACommandWithReply(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask=0xfff);
+
+/*!
+ * \brief Execute a command using the SCA CTRL interface
+ * \details CTRL contains
+ *  * generic SCA R/W control registers
+ *  * Chip ID (on channel 0x14, ADC)
+ *  * SEU counter and reset (on channel 0x13, JTAG)
+ * \param la Local arguments structure
+ * \param cmd which command to send, referenced in sca_enums.h
+ * \param linkMask bit list of OptoHybrids to send the commands to
+ * \param len length of the data to send, default is 0x1
+ * \param data to send to the CTRL command, default is 0x0
+ */
+std::vector<uint32_t> scaCTRLCommand(localArgs* la, SCACTRLCommandT const& cmd, uint16_t const& linkMask=0xfff, uint8_t const& len=0x1, uint32_t const& data=0x0);
+
 /** Locally executed methods */
+/*!
+ * \brief Execute a command using the SCA I2C interface
+ * \details I2C bus will be enabled
+ *  *
+ * \param la Local arguments structure
+ * \param ch I2C channel to communicate with
+ * \param cmd which command to send, referenced in sca_enums.h
+ * \param len length of the data to send, available 1,2,4
+ * \param data to send to the I2C command
+ * \param linkMask bit list of OptoHybrids to send the commands to
+ */
+std::vector<uint32_t> scaI2CCommand(localArgs* la, SCAI2CChannelT const& ch, SCAI2CCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask=0xfff);
+
+/*!
+ * \brief Execute a command using the SCA GPIO interface
+ * \details GPIO bus will be enabled
+ *  *
+ * \param la Local arguments structure
+ * \param ch GPIO channel to communicate with
+ * \param cmd which command to send, referenced in sca_enums.h
+ * \param len length of the data to send, available 1,2,4
+ * \param data to send to the GPIO command
+ * \param linkMask bit list of OptoHybrids to send the commands to
+ */
+std::vector<uint32_t> scaGPIOCommand(localArgs* la, SCAGPIOChannelT const& ch, uint8_t const& len, uint32_t data, uint16_t const& linkMask=0xfff);
+
+/*!
+ * \brief Execute a command using the SCA ADC interface
+ *
+ * \param la Local arguments structure
+ * \param ch ADC channel to communicate with
+ * \param len length of the data to send, available 1,2,4
+ * \param data to send to the ADC command
+ * \param linkMask bit list of OptoHybrids to send the commands to
+ */
+std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, uint8_t const& len, uint32_t data, uint16_t const& linkMask=0xfff);
+
 /*** CTRL submodule ***/
 /*!
  * \brief Reset the SCA module
@@ -22,8 +109,59 @@ void scaModuleResetLocal(localArgs* la);
 
 /*!
  * \brief Reset the SCA module
+ *
+ * \param en true to enable the TTC HardReset action
  */
 void scaHardResetEnableLocal(localArgs* la, bool en);
+
+/*!
+ * \brief Read the Chip ID from the SCA ASIC
+ *
+ * \param la Local arguments structure
+ * \param linkMask bit list of OptoHybrids to send the commands to
+ * \param scaV1 true for V1 of the SCA ASIC
+ */
+std::vector<uint32_t> readSCAChipIDLocal(localArgs* la, uint16_t const& linkMask=0xfff, bool scaV1=false);
+
+/*!
+ * \brief Read the SEU coutner from the SCA ASIC
+ *
+ * \param la Local arguments structure
+ * \param linkMask bit list of OptoHybrids to send the commands to
+ * \param reset true to reset the counter before reading
+ */
+std::vector<uint32_t> readSCASEUCounterLocal(localArgs* la, uint16_t const& linkMask=0xfff, bool reset=false);
+
+/*!
+ * \brief Reset the SCA SEU counter
+ *
+ * \param la Local arguments structure
+ * \param linkMask bit list of OptoHybrids to send the reset command to
+ */
+void resetSCASEUCounterLocal(localArgs* la, uint16_t const& linkMask=0xfff);
+
+/* /\*** SCA ADC submodule ***\/ */
+/* /\*! */
+/*  * \brief Reset the SCA module */
+/*  *\/ */
+/* void scaModuleResetLocal(localArgs* la); */
+
+/* /\*** GPIO CTRL submodule ***\/ */
+/* /\*! */
+/*  * \brief Reset the SCA module */
+/*  *\/ */
+/* void scaModuleResetLocal(localArgs* la); */
+
+/* /\*** I2C CTRL submodule ***\/ */
+/* /\*! */
+/*  * \brief Reset the SCA module */
+/*  *\/ */
+/* void scaModuleResetLocal(localArgs* la); */
+
+/*** JTAG CTRL submodule ***/
+/*!
+ * \brief Low priority
+ */
 
 /** RPC callbacks */
 /*!
@@ -32,5 +170,8 @@ void scaHardResetEnableLocal(localArgs* la, bool en);
  *  \param response RPC response message
  */
 void scaModuleReset(const RPCMsg *request, RPCMsg *response);
+void readSCAChipID(const RPCMsg *request, RPCMsg *response);
+void readSCASEUCounter(const RPCMsg *request, RPCMsg *response);
+void resetSCASEUCounter(const RPCMsg *request, RPCMsg *response);
 
 #endif

--- a/include/amc/sca.h
+++ b/include/amc/sca.h
@@ -34,9 +34,9 @@ uint32_t formatSCAData(uint32_t const& data);
  * \param cmd command to send, referenced in sca_enums.h
  * \param len length of the data to send, available 1,2,4
  * \param data to send to the CTRL command
- * \param linkMask bit list of OptoHybrids to send the commands to
+ * \param ohMask bit list of OptoHybrids to send the commands to
  */
-void sendSCACommand(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask=0xfff);
+void sendSCACommand(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask=0xfff);
 
 /*!
  * \brief Execute a command using the SCA interface, and read the reply from the SCA
@@ -45,9 +45,9 @@ void sendSCACommand(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_
  * \param cmd command to send, referenced in sca_enums.h
  * \param len length of the data to send, available 1,2,4
  * \param data to send to the CTRL command
- * \param linkMask bit list of OptoHybrids to send the commands to
+ * \param ohMask bit list of OptoHybrids to send the commands to
  */
-std::vector<uint32_t> sendSCACommandWithReply(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask=0xfff);
+std::vector<uint32_t> sendSCACommandWithReply(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask=0xfff);
 
 /*!
  * \brief Execute a command using the SCA CTRL interface
@@ -57,11 +57,11 @@ std::vector<uint32_t> sendSCACommandWithReply(localArgs* la, uint8_t const& ch, 
  *  * SEU counter and reset (on channel 0x13, JTAG)
  * \param la Local arguments structure
  * \param cmd which command to send, referenced in sca_enums.h
- * \param linkMask bit list of OptoHybrids to send the commands to
+ * \param ohMask bit list of OptoHybrids to send the commands to
  * \param len length of the data to send, default is 0x1
  * \param data to send to the CTRL command, default is 0x0
  */
-std::vector<uint32_t> scaCTRLCommand(localArgs* la, SCACTRLCommandT const& cmd, uint16_t const& linkMask=0xfff, uint8_t const& len=0x1, uint32_t const& data=0x0);
+std::vector<uint32_t> scaCTRLCommand(localArgs* la, SCACTRLCommandT const& cmd, uint16_t const& ohMask=0xfff, uint8_t const& len=0x1, uint32_t const& data=0x0);
 
 /** Locally executed methods */
 /*!
@@ -73,9 +73,9 @@ std::vector<uint32_t> scaCTRLCommand(localArgs* la, SCACTRLCommandT const& cmd, 
  * \param cmd which command to send, referenced in sca_enums.h
  * \param len length of the data to send, available 1,2,4
  * \param data to send to the I2C command
- * \param linkMask bit list of OptoHybrids to send the commands to
+ * \param ohMask bit list of OptoHybrids to send the commands to
  */
-std::vector<uint32_t> scaI2CCommand(localArgs* la, SCAI2CChannelT const& ch, SCAI2CCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask=0xfff);
+std::vector<uint32_t> scaI2CCommand(localArgs* la, SCAI2CChannelT const& ch, SCAI2CCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask=0xfff);
 
 /*!
  * \brief Execute a command using the SCA GPIO interface
@@ -86,9 +86,9 @@ std::vector<uint32_t> scaI2CCommand(localArgs* la, SCAI2CChannelT const& ch, SCA
  * \param cmd which command to send, referenced in sca_enums.h
  * \param len length of the data to send, available 1,2,4
  * \param data to send to the GPIO command
- * \param linkMask bit list of OptoHybrids to send the commands to
+ * \param ohMask bit list of OptoHybrids to send the commands to
  */
-std::vector<uint32_t> scaGPIOCommand(localArgs* la, SCAGPIOChannelT const& ch, uint8_t const& len, uint32_t data, uint16_t const& linkMask=0xfff);
+std::vector<uint32_t> scaGPIOCommand(localArgs* la, SCAGPIOChannelT const& ch, uint8_t const& len, uint32_t data, uint16_t const& ohMask=0xfff);
 
 /*!
  * \brief Execute a command using the SCA ADC interface
@@ -97,15 +97,15 @@ std::vector<uint32_t> scaGPIOCommand(localArgs* la, SCAGPIOChannelT const& ch, u
  * \param ch ADC channel to communicate with
  * \param len length of the data to send, available 1,2,4
  * \param data to send to the ADC command
- * \param linkMask bit list of OptoHybrids to send the commands to
+ * \param ohMask bit list of OptoHybrids to send the commands to
  */
-std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, uint8_t const& len, uint32_t data, uint16_t const& linkMask=0xfff);
+std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, uint8_t const& len, uint32_t data, uint16_t const& ohMask=0xfff);
 
 /*** CTRL submodule ***/
 /*!
  * \brief Reset the SCA module
  */
-void scaModuleResetLocal(localArgs* la);
+void scaModuleResetLocal(localArgs* la, uint16_t const& ohMask);
 
 /*!
  * \brief Reset the SCA module
@@ -118,27 +118,27 @@ void scaHardResetEnableLocal(localArgs* la, bool en);
  * \brief Read the Chip ID from the SCA ASIC
  *
  * \param la Local arguments structure
- * \param linkMask bit list of OptoHybrids to send the commands to
+ * \param ohMask bit list of OptoHybrids to send the commands to
  * \param scaV1 true for V1 of the SCA ASIC
  */
-std::vector<uint32_t> readSCAChipIDLocal(localArgs* la, uint16_t const& linkMask=0xfff, bool scaV1=false);
+std::vector<uint32_t> readSCAChipIDLocal(localArgs* la, uint16_t const& ohMask=0xfff, bool scaV1=false);
 
 /*!
  * \brief Read the SEU coutner from the SCA ASIC
  *
  * \param la Local arguments structure
- * \param linkMask bit list of OptoHybrids to send the commands to
+ * \param ohMask bit list of OptoHybrids to send the commands to
  * \param reset true to reset the counter before reading
  */
-std::vector<uint32_t> readSCASEUCounterLocal(localArgs* la, uint16_t const& linkMask=0xfff, bool reset=false);
+std::vector<uint32_t> readSCASEUCounterLocal(localArgs* la, uint16_t const& ohMask=0xfff, bool reset=false);
 
 /*!
  * \brief Reset the SCA SEU counter
  *
  * \param la Local arguments structure
- * \param linkMask bit list of OptoHybrids to send the reset command to
+ * \param ohMask bit list of OptoHybrids to send the reset command to
  */
-void resetSCASEUCounterLocal(localArgs* la, uint16_t const& linkMask=0xfff);
+void resetSCASEUCounterLocal(localArgs* la, uint16_t const& ohMask=0xfff);
 
 /* /\*** SCA ADC submodule ***\/ */
 /* /\*! */

--- a/include/amc/sca_enums.h
+++ b/include/amc/sca_enums.h
@@ -1,0 +1,297 @@
+#ifndef SCA_ENUMS_H
+#define SCA_ENUMS_H
+
+class SCASettings {
+ public:
+
+  /**
+   * \brief SCA Resets
+   * Types of resets able to be sent via the SCA
+   */
+  struct SCAResetType {
+    enum ESCAResetType {
+      SCAReset  = 0x0, ///< Reset the SCA
+      HardReset = 0x1, ///< Use the SCA to send a TTC-style HardReset command
+    } SCAResetType;
+  };
+
+  /**
+   * \brief SCA channels
+   * List of channels with which the SCA can be controlled
+   */
+  struct SCAChannel {
+    enum ESCAChannel {
+      CTRL  = 0x00, ///< SCA configuration registers
+      SPI   = 0x01, ///< Serial peripheral master interface, disconnected in GEM OH
+      GPIO  = 0x02, ///< General purpose parallel I/O interface
+      I2C00 = 0x03, ///< I2C serial interface - master 0
+      I2C01 = 0x04, ///< I2C serial interface - master 1
+      I2C02 = 0x05, ///< I2C serial interface - master 2
+      I2C03 = 0x06, ///< I2C serial interface - master 3
+      I2C04 = 0x07, ///< I2C serial interface - master 4
+      I2C05 = 0x08, ///< I2C serial interface - master 5
+      I2C06 = 0x09, ///< I2C serial interface - master 6
+      I2C07 = 0x0a, ///< I2C serial interface - master 7
+      I2C08 = 0x0b, ///< I2C serial interface - master 8
+      I2C09 = 0x0c, ///< I2C serial interface - master 9
+      I2C10 = 0x0d, ///< I2C serial interface - master 10
+      I2C11 = 0x0e, ///< I2C serial interface - master 11
+      I2C12 = 0x0f, ///< I2C serial interface - master 12
+      I2C13 = 0x10, ///< I2C serial interface - master 13
+      I2C14 = 0x11, ///< I2C serial interface - master 14
+      I2C15 = 0x12, ///< I2C serial interface - master 15
+      JTAG  = 0x13, ///< JTAG serial master interface
+      ADC   = 0x14, ///< Analog-to-digital converter
+      DAC   = 0x15, ///< Digital-to-analog converter, disconnected in GEM OH
+    } SCAChannel;
+  };  // struct SCAChannel
+
+  /**
+   * \brief SCA control commands
+   * Command aliases that can be used when controlling the SCA generic control interface
+   */
+  struct CTRLCommand {  //CTRLCommand settings
+    enum ECTRLCommand { //CTRLCommand settings
+      GET_DATA     = 0x00, ///< Read the data
+      CTRL_R_ID_V1 = 0x91, ///< Read the SCA ChipID (channel 0x14)
+      CTRL_R_ID_V2 = 0xD1, ///< Read the SCA ChipID (channel 0x14)
+      CTRL_W_CRB   = 0x02, ///< Write to CTRL register B
+      CTRL_W_CRC   = 0x04, ///< Write to CTRL register C
+      CTRL_W_CRD   = 0x06, ///< Write to CTRL register D
+      CTRL_R_CRB   = 0x03, ///< Read from CTRL register B
+      CTRL_R_CRC   = 0x05, ///< Read from CTRL register C
+      CTRL_R_CRD   = 0x07, ///< Read from CTRL register D
+      CTRL_R_SEU   = 0xF1, ///< Read from the SEU monitor (channel 0x13)
+      CTRL_C_SEU   = 0xF0, ///< Reset the SEU monitor (channel 0x13)
+    } CTRLCommand;
+  };
+
+  /**
+   * \brief SCA I2C commands
+   * Command aliases that can be used when controlling the I2C interface of the SCA
+   */
+  struct I2CCommand {  //I2CCommand settings
+    enum EI2CCommand { //I2CCommand settings
+      // I2C commands
+      I2C_W_CTRL   = 0x30, ///< Write I2C control register
+      I2C_R_CTRL   = 0x31, ///< Read I2C control register
+      I2C_R_STR    = 0x11, ///< Read I2C status register
+      I2C_W_MSK    = 0x20, ///< Write I2C mask register
+      I2C_R_MSK    = 0x21, ///< Read I2C mask register
+      I2C_W_DATA0  = 0x40, ///< Write I2C data register bytes [3:0]
+      I2C_R_DATA0  = 0x41, ///< Read I2C data register bytes [3:0]
+      I2C_W_DATA1  = 0x50, ///< Write I2C data register bytes [7:4]
+      I2C_R_DATA1  = 0x51, ///< Read I2C data register bytes [7:4]
+      I2C_W_DATA2  = 0x60, ///< Write I2C data register bytes [11:8]
+      I2C_R_DATA2  = 0x61, ///< Read I2C data register bytes [11:8]
+      I2C_W_DATA3  = 0x70, ///< Write I2C data register bytes [15:12]
+      I2C_R_DATA3  = 0x71, ///< Read I2C data register bytes [15:12]
+      I2C_S_7B_W   = 0x82, ///< Start I2C single-byte write with 7-bit address
+      I2C_S_7B_R   = 0x86, ///< Start I2C single-byte read with 7-bit address
+      I2C_S_10B_W  = 0x8A, ///< Start I2C single-byte write with 10-bit address
+      I2C_S_10B_R  = 0x8E, ///< Start I2C single-byte read with 10-bit address
+      I2C_M_7B_W   = 0xDA, ///< Start I2C multi-byte write with 7-bit address
+      I2C_M_7B_R   = 0xDE, ///< Start I2C multi-byte read with 7-bit address
+      I2C_M_10B_W  = 0xE2, ///< Start I2C multi-byte write with 10-bit address
+      I2C_M_10B_R  = 0xE6, ///< Start I2C multi-byte read with 10-bit address
+      /* I2C_RMW_AND  = 0xXX, ///< Start RMW transaction with AND */
+      I2C_RMW_OR   = 0xC6, ///< Start RMW transaction with OR
+      I2C_RMW_XOR  = 0xCA, ///< Start RMW transaction with XOR
+    } I2CCommand;
+  };
+
+  /**
+   * \brief SCA GPIO commands
+   * Command aliases that can be used when controlling the GPIO interface of the SCA
+   */
+  struct GPIOCommand {  //GPIOCommand settings
+    enum EGPIOCommand { //GPIOCommand settings
+      // GPIO commands
+      GPIO_W_DATAOUT   = 0x10, ///< Write GPIO DATAOUT register, length 4, read length 2
+      GPIO_R_DATAOUT   = 0x11, ///< Read GPIO DATAOUT register, length 1, read length 4
+      GPIO_R_DATAIN    = 0x01, ///< Read GPIO DATAIN register, length 1, read length 4
+      GPIO_W_DIRECTION = 0x20, ///< Write GPIO direction register, length 4, read length 2
+      GPIO_R_DIRECTION = 0x21, ///< Read GPIO direction register, length 1, read length 4
+      GPIO_W_INTENABLE = 0x60, ///< Write GPIO interrupt enable register, length 4, read length 2
+      GPIO_R_INTENABLE = 0x61, ///< Read GPIO interrupt enable register, length 4, read length 2
+      GPIO_W_INTSEL    = 0x30, ///< Write GPIO interrupt line select register, length 4, read length 2
+      GPIO_R_INTSEL    = 0x31, ///< Read GPIO interrupt line select register, length 4, read length 2
+      GPIO_W_INTTRIG   = 0x40, ///< Write GPIO edge select for interrupt register, length 4, read length 2
+      GPIO_R_INTTRIG   = 0x41, ///< Read GPIO edge select for interrupt register, length 4, read length 2
+      GPIO_W_INTS      = 0x70, ///< Write GPIO interrupt vector register, length 4, read length 2
+      GPIO_R_INTS      = 0x71, ///< Read GPIO interrupt vector register, length 4, read length 2
+      GPIO_W_CLKSEL    = 0x80, ///< Write GPIO clock select register, length 4, read length 2
+      GPIO_R_CLKSEL    = 0x81, ///< Read GPIO clock select register, length 4, read length 2
+      GPIO_W_EDGESEL   = 0x90, ///< Write GPIO clock edge select register, length 4, read length 2
+      GPIO_R_EDGESEL   = 0x91, ///< Read GPIO clock edge select register, length 4, read length 2
+    } GPIOCommand;
+  };
+
+  /**
+   * \brief SCA ADC commands
+   * Command aliases that can be used when controlling the ADC interface of the SCA
+   */
+  struct ADCCommand {  //ADCCommand settings
+    enum EADCCommand { //ADCCommand settings
+      // ADC commands V2
+      ADC_GO     = 0x02, ///< [SCA V2 only] Start of ADC conversion
+      ADC_W_MUX  = 0x50, ///< [SCA V2 only] Write ADC register INSEL
+      ADC_R_MUX  = 0x51, ///< [SCA V2 only] Read ADC register INSEL
+      ADC_W_CURR = 0x60, ///< [SCA V2 only] Write ADC register
+      ADC_R_CURR = 0x61, ///< [SCA V2 only] Read ADC register
+      ADC_W_GAIN = 0x10, ///< [SCA V2 only] Write ADC register output A
+      ADC_R_GAIN = 0x11, ///< [SCA V2 only] Read ADC register output A
+      ADC_R_DATA = 0x21, ///< [SCA V2 only] Read ADC converted value
+      ADC_R_RAW  = 0x31, ///< [SCA V2 only] Read ADC raw value
+      ADC_R_OFS  = 0x41, ///< [SCA V2 only] Read ADC offset
+      // ADC commands V1??
+      ADC_V1_GO       = 0xB2, ///< [SCA V1 only] Start of ADC conversion
+      ADC_V1_W_INSEL  = 0x30, ///< [SCA V1 only] Write ADC register INSEL
+      ADC_V1_R_INSEL  = 0x31, ///< [SCA V1 only] Read ADC register INSEL
+      ADC_V1_W_CURREN = 0x40, ///< [SCA V1 only] Write ADC register
+      ADC_V1_R_CURREN = 0x41, ///< [SCA V1 only] Read ADC register
+    } ADCCommand;
+  };  // struct ADCCommand
+
+  /**
+   * \brief SCA Error Flags
+   * List of error flags that can be set in the reply
+   */
+  struct SCAErrorFlags {  //SCAErrorFlags settings
+    enum ESCAErrorFlags { //SCAErrorFlags settings
+      Generic     = 0x01, ///< Generic error flag
+      InvChReq    = 0x02, ///< Invalid channel requested
+      InvCmdReq   = 0x04, ///< Invalid command requested
+      InvTranReqN = 0x08, ///< Invalid transaction request number
+      InvLen      = 0x10, ///< Invalid length
+      ChNotEn     = 0x20, ///< Channel not enabled
+      ChBusy      = 0x40, ///< Channel busy
+      CmdInTreat  = 0x80, ///< Command in treatment
+    } SCAErrorFlags;
+  };  // struct SCAErrorFlags
+
+  /**
+   * \brief SCA I2C channel
+   * List of I2C channel aliases on the SCA
+   */
+  struct I2CChannel {  //I2CChannel settings
+    enum EI2CChannel { //I2CChannel settings
+      I2C00 = 0x03, ///< I2C serial interface - master 0
+      I2C01 = 0x04, ///< I2C serial interface - master 1
+      I2C02 = 0x05, ///< I2C serial interface - master 2
+      I2C03 = 0x06, ///< I2C serial interface - master 3
+      I2C04 = 0x07, ///< I2C serial interface - master 4
+      I2C05 = 0x08, ///< I2C serial interface - master 5
+      I2C06 = 0x09, ///< I2C serial interface - master 6
+      I2C07 = 0x0a, ///< I2C serial interface - master 7
+      I2C08 = 0x0b, ///< I2C serial interface - master 8
+      I2C09 = 0x0c, ///< I2C serial interface - master 9
+      I2C10 = 0x0d, ///< I2C serial interface - master 10
+      I2C11 = 0x0e, ///< I2C serial interface - master 11
+      I2C12 = 0x0f, ///< I2C serial interface - master 12
+      I2C13 = 0x10, ///< I2C serial interface - master 13
+      I2C14 = 0x11, ///< I2C serial interface - master 14
+      I2C15 = 0x12, ///< I2C serial interface - master 15
+    } I2CChannel;
+  };  // struct I2CChannel
+
+  /**
+   * \brief SCA GPIO channel
+   * List of GPIO channels on the SCA
+   */
+  struct GPIOChannel {  //GPIOChannel settings
+    enum EGPIOChannel { //GPIOChannel settings
+    } GPIOChannel;
+  };  // struct GPIOChannel
+
+  /**
+   * \brief SCA ADC channel
+   * List of ADC channels on the SCA
+   */
+  struct ADCChannel {  //ADCChannel settings
+    enum EADCChannel { //ADCChannel settings
+      // ADC 12-bit range
+      // * Voltage 0-1V (1V/0xfff) LSB, offset 0V
+      // * Temperature -30-80C (110C/0xfff) LSB, offset -30Cbusiness/SitePages/Fermilab%20Official%20Travel.aspx
+      AVCCN_V1P0     = 27, ///< FPGA MGT 1.0V
+      AVTTN_V1P2     = 30, ///< FPGA MGT 1.2V
+      INT_V1P0       = 17, ///< 1.0V FPGA core voltage
+      ADC_V1P8       = 14, ///< 1.8V used by the PROM
+      ADC_V1P5       = 24, ///< 1.5V used by the GBTXs and SCA
+      ADC_2V5        = 15, ///< 2.5V used by FPGA I/O and VTRXs/VTTXs
+      SCA_TEMP       = 31, ///< Internal SCA temperature sensor
+
+      // Aliases
+      FPGA_MGT_V1P0  = 27, ///< FPGA MGT 1.0V
+      FPGA_MGT_V1P2  = 30, ///< FPGA MGT 1.2V
+      FPGA_CORE      = 17, ///< 1.0V FPGA core voltage
+      PROM_V1P8      = 14, ///< 1.8V used by the PROM
+      GBTX_V1P5      = 24, ///< 1.5V used by the GBTXs and SCA
+      SCA_V1P5       = 24, ///< 1.5V used by the GBTXs and SCA
+      FPGA_IO_V2P5   = 15, ///< 2.5V used by FPGA I/O and VTRXs/VTTXs
+      VTTX_VTRX_V2P5 = 15, ///< 2.5V used by FPGA I/O and VTRXs/VTTXs
+
+      ADC_CH00 = 0x00, ///< ADC channel 00, Temp sensor
+      ADC_CH01 = 0x01, ///< ADC channel 01, NOT CONNECTED
+      ADC_CH02 = 0x02, ///< ADC channel 02, NOT CONNECTED
+      ADC_CH03 = 0x03, ///< ADC channel 03, NOT CONNECTED
+      ADC_CH04 = 0x04, ///< ADC channel 04, Temp sensor
+      ADC_CH05 = 0x05, ///< ADC channel 05, NOT CONNECTED
+      ADC_CH06 = 0x06, ///< ADC channel 06
+      ADC_CH07 = 0x07, ///< ADC channel 07, Temp sensor
+      ADC_CH08 = 0x08, ///< ADC channel 08, Temp sensor
+      ADC_CH09 = 0x09, ///< ADC channel 09
+      ADC_CH10 = 0x0A, ///< ADC channel 10
+      ADC_CH11 = 0x0B, ///< ADC channel 11
+      ADC_CH12 = 0x0C, ///< ADC channel 12, NOT CONNECTED
+      ADC_CH13 = 0x0D, ///< ADC channel 13
+      ADC_CH14 = 0x0E, ///< ADC channel 14, 1.8V
+      ADC_CH15 = 0x0F, ///< ADC channel 15, 2.5V I/O
+      ADC_CH16 = 0x10, ///< ADC channel 16
+      ADC_CH17 = 0x11, ///< ADC channel 17, internal 1.0V
+      ADC_CH18 = 0x12, ///< ADC channel 18, VTRx rssi3
+      ADC_CH19 = 0x13, ///< ADC channel 19, VTRx rssi2
+      ADC_CH20 = 0x14, ///< ADC channel 20
+      ADC_CH21 = 0x15, ///< ADC channel 21, VTRx rssi1
+      ADC_CH22 = 0x16, ///< ADC channel 22
+      ADC_CH23 = 0x17, ///< ADC channel 23
+      ADC_CH24 = 0x18, ///< ADC channel 24, 1.5V
+      ADC_CH25 = 0x19, ///< ADC channel 25
+      ADC_CH26 = 0x1A, ///< ADC channel 26
+      ADC_CH27 = 0x1B, ///< ADC channel 27, AVCCN
+      ADC_CH28 = 0x1C, ///< ADC channel 28
+      ADC_CH29 = 0x1D, ///< ADC channel 29
+      ADC_CH30 = 0x1E, ///< ADC channel 30, AVTTN
+      ADC_CH31 = 0x1F, ///< ADC channel 31
+    } ADCChannel;
+  };  // struct ADCChannel
+
+};
+
+// <name>  is the enum scoped namespace for scope::VALUE access
+// <name>T is the enum type
+
+// typedef the struct for access to the members via struct::VALUE
+typedef SCASettings::SCAResetType  SCAResetType;
+typedef SCASettings::SCAChannel    SCAChannel;
+typedef SCASettings::CTRLCommand   SCACTRLCommand;
+typedef SCASettings::I2CCommand    SCAI2CCommand;
+typedef SCASettings::GPIOCommand   SCAGPIOCommand;
+typedef SCASettings::ADCCommand    SCAADCCommand;
+typedef SCASettings::I2CChannel    SCAI2CChannel;
+typedef SCASettings::GPIOChannel   SCAGPIOChannel;
+typedef SCASettings::ADCChannel    SCAADCChannel;
+
+// typedef the enum for casting and access
+typedef SCASettings::SCAResetType::ESCAResetType  SCAResetTypeT;
+typedef SCASettings::SCAChannel::ESCAChannel      SCAChannelT;
+typedef SCASettings::CTRLCommand::ECTRLCommand    SCACTRLCommandT;
+typedef SCASettings::I2CCommand::EI2CCommand      SCAI2CCommandT;
+typedef SCASettings::GPIOCommand::EGPIOCommand    SCAGPIOCommandT;
+typedef SCASettings::ADCCommand::EADCCommand      SCAADCCommandT;
+typedef SCASettings::I2CChannel::EI2CChannel      SCAI2CChannelT;
+typedef SCASettings::GPIOChannel::EGPIOChannel    SCAGPIOChannelT;
+typedef SCASettings::ADCChannel::EADCChannel      SCAADCChannelT;
+
+
+#endif

--- a/src/amc/sca.cpp
+++ b/src/amc/sca.cpp
@@ -5,6 +5,146 @@
 
 #include "amc/sca.h"
 
+uint32_t formatSCAData(uint32_t const& data)
+{
+  return (
+          ((data&0xff000000)>>24) +
+          ((data>>8)&0x0000ff00)  +
+          ((data&0x0000ff00)<<8) +
+          ((data&0x000000ff)<<24)
+          );
+}
+
+void sendSCACommand(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask)
+{
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_CHANNEL",ch);
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_COMMAND",cmd);
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_LENGTH", len);
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_DATA",   formatSCAData(data));
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_EXECUTE",0x1);
+}
+
+std::vector<uint32_t> sendSCACommandWithReply(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask)
+{
+  sendSCACommand(la, ch, cmd, len, data, linkMask);
+
+  // read reply from 12 OptoHybrids
+  std::vector<uint32_t> reply;
+  reply.reserve(12);
+  for (size_t oh = 0; oh < 12; ++oh) {
+    if ((linkMask >> oh) & 0x1) {
+      std::stringstream regName;
+      regName << "GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_REPLY_OH"
+              << oh << ".SCA_RPY_DATA";
+      reply.push_back(formatSCAData(readReg(la,regName.str())));
+    } else {
+      // FIXME Sensible null value?
+      reply.push_back(0);
+    }
+  }
+  return reply;
+}
+
+std::vector<uint32_t> scaCTRLCommand(localArgs* la, SCACTRLCommandT const& cmd, uint16_t const& linkMask, uint8_t const& len, uint32_t const& data)
+{
+  std::vector<uint32_t> result;
+  switch (cmd) {
+  case SCACTRLCommand::CTRL_R_ID_V2:
+    result = sendSCACommandWithReply(la, 0x14, cmd, 0x1, 0x1, linkMask);
+  case SCACTRLCommand::CTRL_R_ID_V1:
+    result = sendSCACommandWithReply(la, 0x14, cmd, 0x1, 0x1, linkMask);
+  case SCACTRLCommand::CTRL_R_SEU:
+    result = sendSCACommandWithReply(la, 0x13, cmd, 0x1, 0x0, linkMask);
+  case SCACTRLCommand::CTRL_C_SEU:
+    result = sendSCACommandWithReply(la, 0x13, cmd, 0x1, 0x0, linkMask);
+  case SCACTRLCommand::CTRL_W_CRB:
+    sendSCACommand(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+  case SCACTRLCommand::CTRL_W_CRC:
+    sendSCACommand(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+  case SCACTRLCommand::CTRL_W_CRD:
+    sendSCACommand(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+  case SCACTRLCommand::CTRL_R_CRB:
+    result = sendSCACommandWithReply(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+  case SCACTRLCommand::CTRL_R_CRC:
+    result = sendSCACommandWithReply(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+  case SCACTRLCommand::CTRL_R_CRD:
+    result = sendSCACommandWithReply(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+  default:
+    // maybe don't do this by default, return error or invalid option?
+    result = sendSCACommandWithReply(la, SCAChannel::CTRL, SCACTRLCommand::GET_DATA, len, data, linkMask);
+  }
+  return result;
+}
+
+std::vector<uint32_t> scaI2CCommand(localArgs* la, SCAI2CChannelT const& ch, SCAI2CCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask)
+{
+
+  // enable the I2C bus through the CTRL CR{B,C,D} registers
+  // 16 I2C channels available
+  // 4 I2C modes of communication
+  // I2C frequency selection
+  // Allows RMW transactions
+
+  std::vector<uint32_t> result;
+
+  sendSCACommand(la, ch, cmd, len, data, linkMask);
+
+  return result;
+}
+
+std::vector<uint32_t> scaGPIOCommandLocal(localArgs* la, SCAGPIOCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask)
+{
+  // enable the GPIO bus through the CTRL CRB register, bit 2
+  std::vector<uint32_t> reply = sendSCACommandWithReply(la, SCAChannel::GPIO, cmd, len, data, linkMask);
+  return reply;
+}
+
+std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, SCAADCCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask)
+{
+  // enable the ADC bus through the CTRL CRD register, bit 4
+  // select the ADC channel
+  sendSCACommand(la, uint8_t(SCAChannel::ADC), uint8_t(SCAADCCommand::ADC_W_MUX), 0x4, ch, linkMask);
+
+  // enable/disable the current sink
+  sendSCACommand(la, uint8_t(SCAChannel::ADC), uint8_t(SCAADCCommand::ADC_W_CURR), 0x4, 0x1<<ch, linkMask);
+  // start the conversion and get the result
+  std::vector<uint32_t> result = sendSCACommandWithReply(la, uint8_t(SCAChannel::ADC), uint8_t(SCAADCCommand::ADC_GO), 0x4, 0x1, linkMask);
+
+  // // get the last data
+  // std::vector<uint32_t> last = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_DATA, 0x1, 0x0, linkMask);
+  // // get the raw data
+  // std::vector<uint32_t> raw  = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_RAW, 0x1, 0x0, linkMask);
+  // // get the offset
+  // std::vector<uint32_t> raw  = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_OFS, 0x1, 0x0, linkMask);
+
+  return result;
+}
+
+std::vector<uint32_t> readSCAChipIDLocal(localArgs* la, uint16_t const& linkMask, bool scaV1)
+{
+  if (scaV1)
+    return scaCTRLCommand(la, SCACTRLCommand::CTRL_R_ID_V1, linkMask);
+  else
+    return scaCTRLCommand(la, SCACTRLCommand::CTRL_R_ID_V2, linkMask);
+
+  // ID = DATA[23:0], need to have this set up in the reply function somehow?
+}
+
+std::vector<uint32_t> readSCASEUCounterLocal(localArgs* la, uint16_t const& linkMask, bool reset)
+{
+  if (reset)
+    resetSCASEUCounterLocal(la, linkMask);
+
+  return scaCTRLCommand(la, SCACTRLCommand::CTRL_R_SEU, linkMask);
+
+  // SEU count = DATA[31:0]
+}
+
+void resetSCASEUCounterLocal(localArgs* la, uint16_t const& linkMask)
+{
+  scaCTRLCommand(la, SCACTRLCommand::CTRL_C_SEU, linkMask);
+}
+
 void scaModuleResetLocal(localArgs* la)
 {
   writeReg(la, "GEM_AMC.SLOW_CONTROL.SCA.CTRL.MODULE_RESET", 0x1);
@@ -20,4 +160,47 @@ void scaModuleReset(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
+
+  scaModuleResetLocal(&la);
+  
+  rtxn.abort();
+  return;
+}
+
+void readSCAChipID(const RPCMsg *request, RPCMsg *response)
+{
+  // struct localArgs la = getLocalArgs(response);
+  GETLOCALARGS(response);
+
+  uint32_t ohMask = request->get_word("ohMask");
+  bool     scaV1  = request->get_word("scaV1");
+  std::vector<uint32_t> scaChipIDs = readSCAChipIDLocal(&la, ohMask, scaV1);
+
+  rtxn.abort();
+  return;
+}
+
+void readSCASEUCounter(const RPCMsg *request, RPCMsg *response)
+{
+  // struct localArgs la = getLocalArgs(response);
+  GETLOCALARGS(response);
+
+  uint32_t ohMask = request->get_word("ohMask");
+  bool     reset  = request->get_word("reset");
+  std::vector<uint32_t> seuCounts = readSCASEUCounterLocal(&la, ohMask, reset);
+
+  rtxn.abort();
+  return;
+}
+
+void resetSCASEUCounter(const RPCMsg *request, RPCMsg *response)
+{
+  // struct localArgs la = getLocalArgs(response);
+  GETLOCALARGS(response);
+
+  uint32_t ohMask = request->get_word("ohMask");
+  resetSCASEUCounterLocal(&la, ohMask);
+
+  rtxn.abort();
+  return;
 }

--- a/src/amc/sca.cpp
+++ b/src/amc/sca.cpp
@@ -15,8 +15,10 @@ uint32_t formatSCAData(uint32_t const& data)
           );
 }
 
-void sendSCACommand(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask)
+void sendSCACommand(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask)
 {
+  // FIXME: DECIDE WHETHER TO HAVE HERE // writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",         0xffffffff);
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.LINK_ENABLE_MASK",       ohMask);
   writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_CHANNEL",ch);
   writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_COMMAND",cmd);
   writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_LENGTH", len);
@@ -24,15 +26,18 @@ void sendSCACommand(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_
   writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_EXECUTE",0x1);
 }
 
-std::vector<uint32_t> sendSCACommandWithReply(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask)
+std::vector<uint32_t> sendSCACommandWithReply(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask)
 {
-  sendSCACommand(la, ch, cmd, len, data, linkMask);
+  // FIXME: DECIDE WHETHER TO HAVE HERE // uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
+  // FIXME: DECIDE WHETHER TO HAVE HERE // writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+
+  sendSCACommand(la, ch, cmd, len, data, ohMask);
 
   // read reply from 12 OptoHybrids
   std::vector<uint32_t> reply;
   reply.reserve(12);
   for (size_t oh = 0; oh < 12; ++oh) {
-    if ((linkMask >> oh) & 0x1) {
+    if ((ohMask >> oh) & 0x1) {
       std::stringstream regName;
       regName << "GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_REPLY_OH"
               << oh << ".SCA_RPY_DATA";
@@ -42,41 +47,47 @@ std::vector<uint32_t> sendSCACommandWithReply(localArgs* la, uint8_t const& ch, 
       reply.push_back(0);
     }
   }
+  // FIXME: DECIDE WHETHER TO HAVE HERE // writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
   return reply;
 }
 
-std::vector<uint32_t> scaCTRLCommand(localArgs* la, SCACTRLCommandT const& cmd, uint16_t const& linkMask, uint8_t const& len, uint32_t const& data)
+std::vector<uint32_t> scaCTRLCommand(localArgs* la, SCACTRLCommandT const& cmd, uint16_t const& ohMask, uint8_t const& len, uint32_t const& data)
 {
+  uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+  
   std::vector<uint32_t> result;
   switch (cmd) {
   case SCACTRLCommand::CTRL_R_ID_V2:
-    result = sendSCACommandWithReply(la, 0x14, cmd, 0x1, 0x1, linkMask);
+    result = sendSCACommandWithReply(la, 0x14, cmd, 0x1, 0x1, ohMask);
   case SCACTRLCommand::CTRL_R_ID_V1:
-    result = sendSCACommandWithReply(la, 0x14, cmd, 0x1, 0x1, linkMask);
+    result = sendSCACommandWithReply(la, 0x14, cmd, 0x1, 0x1, ohMask);
   case SCACTRLCommand::CTRL_R_SEU:
-    result = sendSCACommandWithReply(la, 0x13, cmd, 0x1, 0x0, linkMask);
+    result = sendSCACommandWithReply(la, 0x13, cmd, 0x1, 0x0, ohMask);
   case SCACTRLCommand::CTRL_C_SEU:
-    result = sendSCACommandWithReply(la, 0x13, cmd, 0x1, 0x0, linkMask);
+    result = sendSCACommandWithReply(la, 0x13, cmd, 0x1, 0x0, ohMask);
   case SCACTRLCommand::CTRL_W_CRB:
-    sendSCACommand(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+    sendSCACommand(la, SCAChannel::CTRL, cmd, len, data, ohMask);
   case SCACTRLCommand::CTRL_W_CRC:
-    sendSCACommand(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+    sendSCACommand(la, SCAChannel::CTRL, cmd, len, data, ohMask);
   case SCACTRLCommand::CTRL_W_CRD:
-    sendSCACommand(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+    sendSCACommand(la, SCAChannel::CTRL, cmd, len, data, ohMask);
   case SCACTRLCommand::CTRL_R_CRB:
-    result = sendSCACommandWithReply(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+    result = sendSCACommandWithReply(la, SCAChannel::CTRL, cmd, len, data, ohMask);
   case SCACTRLCommand::CTRL_R_CRC:
-    result = sendSCACommandWithReply(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+    result = sendSCACommandWithReply(la, SCAChannel::CTRL, cmd, len, data, ohMask);
   case SCACTRLCommand::CTRL_R_CRD:
-    result = sendSCACommandWithReply(la, SCAChannel::CTRL, cmd, len, data, linkMask);
+    result = sendSCACommandWithReply(la, SCAChannel::CTRL, cmd, len, data, ohMask);
   default:
     // maybe don't do this by default, return error or invalid option?
-    result = sendSCACommandWithReply(la, SCAChannel::CTRL, SCACTRLCommand::GET_DATA, len, data, linkMask);
+    result = sendSCACommandWithReply(la, SCAChannel::CTRL, SCACTRLCommand::GET_DATA, len, data, ohMask);
   }
+
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
   return result;
 }
 
-std::vector<uint32_t> scaI2CCommand(localArgs* la, SCAI2CChannelT const& ch, SCAI2CCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask)
+std::vector<uint32_t> scaI2CCommand(localArgs* la, SCAI2CChannelT const& ch, SCAI2CCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask)
 {
 
   // enable the I2C bus through the CTRL CR{B,C,D} registers
@@ -87,67 +98,89 @@ std::vector<uint32_t> scaI2CCommand(localArgs* la, SCAI2CChannelT const& ch, SCA
 
   std::vector<uint32_t> result;
 
-  sendSCACommand(la, ch, cmd, len, data, linkMask);
+  uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+
+  sendSCACommand(la, ch, cmd, len, data, ohMask);
+
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
 
   return result;
 }
 
-std::vector<uint32_t> scaGPIOCommandLocal(localArgs* la, SCAGPIOCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask)
+std::vector<uint32_t> scaGPIOCommandLocal(localArgs* la, SCAGPIOCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask)
 {
   // enable the GPIO bus through the CTRL CRB register, bit 2
-  std::vector<uint32_t> reply = sendSCACommandWithReply(la, SCAChannel::GPIO, cmd, len, data, linkMask);
+  uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+
+  std::vector<uint32_t> reply = sendSCACommandWithReply(la, SCAChannel::GPIO, cmd, len, data, ohMask);
+
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
   return reply;
 }
 
-std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, SCAADCCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& linkMask)
+std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, SCAADCCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask)
 {
+  uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+
   // enable the ADC bus through the CTRL CRD register, bit 4
   // select the ADC channel
-  sendSCACommand(la, uint8_t(SCAChannel::ADC), uint8_t(SCAADCCommand::ADC_W_MUX), 0x4, ch, linkMask);
+  sendSCACommand(la, SCAChannel::ADC, SCAADCCommand::ADC_W_MUX, 0x4, ch, ohMask);
 
   // enable/disable the current sink
-  sendSCACommand(la, uint8_t(SCAChannel::ADC), uint8_t(SCAADCCommand::ADC_W_CURR), 0x4, 0x1<<ch, linkMask);
+  sendSCACommand(la, SCAChannel::ADC, SCAADCCommand::ADC_W_CURR, 0x4, 0x1<<ch, ohMask);
   // start the conversion and get the result
-  std::vector<uint32_t> result = sendSCACommandWithReply(la, uint8_t(SCAChannel::ADC), uint8_t(SCAADCCommand::ADC_GO), 0x4, 0x1, linkMask);
+  std::vector<uint32_t> result = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_GO, 0x4, 0x1, ohMask);
 
   // // get the last data
-  // std::vector<uint32_t> last = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_DATA, 0x1, 0x0, linkMask);
+  // std::vector<uint32_t> last = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_DATA, 0x1, 0x0, ohMask);
   // // get the raw data
-  // std::vector<uint32_t> raw  = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_RAW, 0x1, 0x0, linkMask);
+  // std::vector<uint32_t> raw  = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_RAW, 0x1, 0x0, ohMask);
   // // get the offset
-  // std::vector<uint32_t> raw  = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_OFS, 0x1, 0x0, linkMask);
+  // std::vector<uint32_t> raw  = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_OFS, 0x1, 0x0, ohMask);
+
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
 
   return result;
 }
 
-std::vector<uint32_t> readSCAChipIDLocal(localArgs* la, uint16_t const& linkMask, bool scaV1)
+std::vector<uint32_t> readSCAChipIDLocal(localArgs* la, uint16_t const& ohMask, bool scaV1)
 {
   if (scaV1)
-    return scaCTRLCommand(la, SCACTRLCommand::CTRL_R_ID_V1, linkMask);
+    return scaCTRLCommand(la, SCACTRLCommand::CTRL_R_ID_V1, ohMask);
   else
-    return scaCTRLCommand(la, SCACTRLCommand::CTRL_R_ID_V2, linkMask);
+    return scaCTRLCommand(la, SCACTRLCommand::CTRL_R_ID_V2, ohMask);
 
   // ID = DATA[23:0], need to have this set up in the reply function somehow?
 }
 
-std::vector<uint32_t> readSCASEUCounterLocal(localArgs* la, uint16_t const& linkMask, bool reset)
+std::vector<uint32_t> readSCASEUCounterLocal(localArgs* la, uint16_t const& ohMask, bool reset)
 {
   if (reset)
-    resetSCASEUCounterLocal(la, linkMask);
+    resetSCASEUCounterLocal(la, ohMask);
 
-  return scaCTRLCommand(la, SCACTRLCommand::CTRL_R_SEU, linkMask);
+  return scaCTRLCommand(la, SCACTRLCommand::CTRL_R_SEU, ohMask);
 
   // SEU count = DATA[31:0]
 }
 
-void resetSCASEUCounterLocal(localArgs* la, uint16_t const& linkMask)
+void resetSCASEUCounterLocal(localArgs* la, uint16_t const& ohMask)
 {
-  scaCTRLCommand(la, SCACTRLCommand::CTRL_C_SEU, linkMask);
+  scaCTRLCommand(la, SCACTRLCommand::CTRL_C_SEU, ohMask);
 }
 
-void scaModuleResetLocal(localArgs* la)
+void scaModuleResetLocal(localArgs* la, uint16_t const& ohMask)
 {
-  writeReg(la, "GEM_AMC.SLOW_CONTROL.SCA.CTRL.MODULE_RESET", 0x1);
+  // Does this need to be protected, or do all versions of FW have this register?
+  uint32_t origMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.CTRL.SCA_RESET_ENABLE_MASK");
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.CTRL.SCA_RESET_ENABLE_MASK", ohMask);
+
+  // Send the reset
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.CTRL.MODULE_RESET", 0x1);
+
+  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.CTRL.SCA_RESET_ENABLE_MASK", origMask);
 }
 
 void scaHardResetEnableLocal(localArgs* la, bool en)
@@ -161,8 +194,10 @@ void scaModuleReset(const RPCMsg *request, RPCMsg *response)
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
 
-  scaModuleResetLocal(&la);
-  
+  uint32_t ohMask = request->get_word("ohMask");
+
+  scaModuleResetLocal(&la, ohMask);
+
   rtxn.abort();
   return;
 }


### PR DESCRIPTION
## Description

Initial placeholders for SCA interface functionality, as discussed in #93 

* Add local-only functions to control the use of the various interfaces:
  * Generic `sendSCACommand` and then interfaces to the different blocks that call this command
    * `sendSCACommandWithReply` for transactions that expect returned data
  * SCA `CTRL` interface
    * Generic control registers B, C, and D
    * Chip ID and SEU counters
  * SCA `ADC` interface placeholder
  * SCA `GPIO` interface placeholder
  * SCA `I2C` interface placeholder
* Add enums
  * Per interface
    * for the different channels (e.g., ADC channels)
    * for the different commands
  * Different SCA communication channels
  * Different bits in the SCA command error word

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context
Need to be able to reliably interface with the various interfaces on the SCA for GPIO/ADC/I2C

## How Has This Been Tested?
Has not been, for now just placeholders and framework for future development.
