### PR TITLE
New Feature: Adding vfatMask argument to getVFAT3ChipIDsLocal and a check for sync

### DIFF
--- a/include/vfat3.h
+++ b/include/vfat3.h
@@ -164,7 +164,7 @@ uint16_t decodeChipID(uint32_t encChipID);
  *  \param request RPC request message
  *  \param response RPC responce message
  */
-void getVFAT3ChipIDsLocal(localArgs * la, uint32_t ohN, bool rawID=false);
+void getVFAT3ChipIDsLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask=0xFF000000, bool rawID=false);
 void getVFAT3ChipIDs(const RPCMsg *request, RPCMsg *response);
 
 #endif

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -572,15 +572,16 @@ void getVFAT3ChipIDsLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask, bool 
   std::string regName;
 
   for(int vfatN = 0; vfatN < 24; vfatN++) {
-    // Check if vfat is masked
-    if(!((notmask >> vfatN) & 0x1)){
-        continue;
-    } //End check if VFAT is masked
-
     char regBase [100];
     sprintf(regBase, "GEM_AMC.OH.OH%i.GEB.VFAT%i.HW_CHIP_ID",ohN, vfatN);
 
     regName = std::string(regBase);
+    // Check if vfat is masked
+    if(!((notmask >> vfatN) & 0x1)){
+        la->response->set_word(regName,0xdeaddead);
+        continue;
+    } //End check if VFAT is masked
+
     uint32_t id = readReg(la,regName);
     uint16_t decChipID = 0x0;
     try {
@@ -635,11 +636,11 @@ extern "C" {
         modmgr->register_method("vfat3", "configureVFAT3DacMonitor", configureVFAT3DacMonitor);
         modmgr->register_method("vfat3", "configureVFAT3DacMonitorMultiLink", configureVFAT3DacMonitorMultiLink);
         modmgr->register_method("vfat3", "getChannelRegistersVFAT3", getChannelRegistersVFAT3);
+        modmgr->register_method("vfat3", "getVFAT3ChipIDs", getVFAT3ChipIDs);
         modmgr->register_method("vfat3", "readVFAT3ADC", readVFAT3ADC);
         modmgr->register_method("vfat3", "readVFAT3ADCMultiLink", readVFAT3ADCMultiLink);
         modmgr->register_method("vfat3", "setChannelRegistersVFAT3", setChannelRegistersVFAT3);
         modmgr->register_method("vfat3", "statusVFAT3s", statusVFAT3s);
         modmgr->register_method("vfat3", "vfatSyncCheck", vfatSyncCheck);
-        modmgr->register_method("vfat3", "getVFAT3ChipIDs", getVFAT3ChipIDs);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`getVFAT3ChipIDsLocal(...)` now takes a vfatMask argument which defaults to no vfat's masked.  It will also check for sync before querying chipID.  It will skip masked VFATs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Need a way to skip VFATs that are incommunicado.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on QC7 setup with a vfatmask of `0x8`

```python
In [1]: from gempython.tools.vfat_user_functions_xhal import HwVFAT

In [2]: vfatBoard = HwVFAT("eagle60",4)
Open pickled address table if available  /opt/cmsgemos/etc/maps/amc_address_table_top.pickle...
Initializing AMC eagle60
In [5]: chipIDs = vfatBoard.getAllChipIDs(mask=0x8,rawID=False)

In [6]: for vfatN,ID in enumerate(chipIDs):
    print(vfatN,hex(ID))
   ...: 
(0, '0xfbbL')
(1, '0xc440L')
(2, '0xe200L')
(3, '0x0L')
(4, '0x1705L')
(5, '0x3300L')
(6, '0x4610L')
(7, '0x3300L')
(8, '0x2001078L')
(9, '0x3742L')
(10, '0x800f68L')
(11, '0x2ec0L')
(12, '0xd100L')
(13, '0x2ec0L')
(14, '0x401775L')
(15, '0xf69L')
(16, '0xea80L')
(17, '0x3300L')
(18, '0x4841L')
(19, '0xd748L')
(20, '0xd100L')
(21, '0x3300L')
(22, '0xd100L')
(23, '0x40afeL')
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
