### PR TITLE
Hotfix for V2B scan issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ utils: memhub
 	$(eval export EXTRA_LINKS=$(^:%=-l:%.so))
 	$(MAKE) $(PackageLibraryDir)/utils.so EXTRA_LINKS="$(EXTRA_LINKS)"
 
-extras: utils
+extras: memhub utils
 	$(eval export EXTRA_LINKS=$(^:%=-l:%.so))
 	$(MAKE) $(PackageLibraryDir)/extras.so EXTRA_LINKS="$(EXTRA_LINKS)"
 


### PR DESCRIPTION
## Description

* Update the V2B `ULTRA` scan modules to use the `CONF` node for the configuration registers
* Fix bug in `stopCalPulse2AllChannelsLocal`
  * Writing was allowed to VFAT channel 128
  * Error message was incorrectly using user specified `ch_max`
* Fix bug in the linking of the `extras` library, to ensure it links against `memhub`

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context
V2B scans were failing due to a change in the address table structure that was not propagated.

## How Has This Been Tested?
@ElizabethRoseStarling is testing while taking scurves on the P5 chambers.
