### PR TITLE
Cleanup

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -39,10 +39,12 @@ typedef struct localArgs {
  */
 LocalArgs getLocalArgs(RPCMsg *response);
 
+static constexpr uint32_t LMDB_SIZE = 1UL * 1024UL * 1024UL * 40UL; ///< Maximum size of the LMDB object, currently 40 MiB
+
 // FIXME: to be replaced with the above function when the struct is properly implemented
 #define GETLOCALARGS(response)                                  \
     auto env = lmdb::env::create();                             \
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */ \
+    env.set_mapsize(LMDB_SIZE);                                 \
     std::string gem_path       = std::getenv("GEM_PATH");       \
     std::string lmdb_data_file = gem_path+"/address_table.mdb"; \
     env.open(lmdb_data_file.c_str(), 0, 0664);                  \

--- a/src/amc/daq.cpp
+++ b/src/amc/daq.cpp
@@ -227,6 +227,7 @@ void enableDAQLink(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t enableMask = request->get_word("enableMask");
   enableDAQLinkLocal(&la, enableMask);
+  rtxn.abort();
 }
 
 void disableDAQLink(const RPCMsg *request, RPCMsg *response)
@@ -234,6 +235,7 @@ void disableDAQLink(const RPCMsg *request, RPCMsg *response)
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   disableDAQLinkLocal(&la);
+  rtxn.abort();
 }
 
 void setZS(const RPCMsg *request, RPCMsg *response)
@@ -242,6 +244,7 @@ void setZS(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   bool enable = request->get_word("enable");
   setZSLocal(&la,enable);
+  rtxn.abort();
 }
 
 void disableZS(const RPCMsg *request, RPCMsg *response)
@@ -249,6 +252,7 @@ void disableZS(const RPCMsg *request, RPCMsg *response)
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   disableZSLocal(&la);
+  rtxn.abort();
 }
 
 void resetDAQLink(const RPCMsg *request, RPCMsg *response)
@@ -259,6 +263,7 @@ void resetDAQLink(const RPCMsg *request, RPCMsg *response)
   uint32_t davTO       = request->get_word("davTO");
   uint32_t ttsOverride = request->get_word("ttsOverride");
   resetDAQLinkLocal(&la, davTO, ttsOverride);
+  rtxn.abort();
 }
 
 void getDAQLinkControl(const RPCMsg *request, RPCMsg *response)
@@ -267,6 +272,7 @@ void getDAQLinkControl(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkControlLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void getDAQLinkStatus(const RPCMsg *request, RPCMsg *response)
@@ -275,6 +281,7 @@ void getDAQLinkStatus(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkStatusLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void daqLinkReady(const RPCMsg *request, RPCMsg *response)
@@ -283,6 +290,7 @@ void daqLinkReady(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   bool res = daqLinkReadyLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void daqClockLocked(const RPCMsg *request, RPCMsg *response)
@@ -291,6 +299,7 @@ void daqClockLocked(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   bool res = daqClockLockedLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void daqTTCReady(const RPCMsg *request, RPCMsg *response)
@@ -299,6 +308,7 @@ void daqTTCReady(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   bool res = daqTTCReadyLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void daqTTSState(const RPCMsg *request, RPCMsg *response)
@@ -307,6 +317,7 @@ void daqTTSState(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t res = daqTTSStateLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void daqAlmostFull(const RPCMsg *request, RPCMsg *response)
@@ -315,6 +326,7 @@ void daqAlmostFull(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t res = daqAlmostFullLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void l1aFIFOIsEmpty(const RPCMsg *request, RPCMsg *response)
@@ -323,6 +335,7 @@ void l1aFIFOIsEmpty(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   bool res = l1aFIFOIsEmptyLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void l1aFIFOIsAlmostFull(const RPCMsg *request, RPCMsg *response)
@@ -331,6 +344,7 @@ void l1aFIFOIsAlmostFull(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   bool res = l1aFIFOIsAlmostFullLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void l1aFIFOIsFull(const RPCMsg *request, RPCMsg *response)
@@ -339,6 +353,7 @@ void l1aFIFOIsFull(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   bool res = l1aFIFOIsFullLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void l1aFIFOIsUnderflow(const RPCMsg *request, RPCMsg *response)
@@ -347,6 +362,7 @@ void l1aFIFOIsUnderflow(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   bool res = l1aFIFOIsUnderflowLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void getDAQLinkEventsSent(const RPCMsg *request, RPCMsg *response)
@@ -355,6 +371,7 @@ void getDAQLinkEventsSent(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkEventsSentLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void getDAQLinkL1AID(const RPCMsg *request, RPCMsg *response)
@@ -363,6 +380,7 @@ void getDAQLinkL1AID(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkL1AIDLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void getDAQLinkL1ARate(const RPCMsg *request, RPCMsg *response)
@@ -371,6 +389,7 @@ void getDAQLinkL1ARate(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkL1ARateLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void getDAQLinkDisperErrors(const RPCMsg *request, RPCMsg *response)
@@ -379,6 +398,7 @@ void getDAQLinkDisperErrors(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkDisperErrorsLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void getDAQLinkNonidentifiableErrors(const RPCMsg *request, RPCMsg *response)
@@ -387,6 +407,7 @@ void getDAQLinkNonidentifiableErrors(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkNonidentifiableErrorsLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void getDAQLinkInputMask(const RPCMsg *request, RPCMsg *response)
@@ -395,6 +416,7 @@ void getDAQLinkInputMask(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkInputMaskLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
 
 void getDAQLinkDAVTimeout(const RPCMsg *request, RPCMsg *response)
@@ -403,8 +425,8 @@ void getDAQLinkDAVTimeout(const RPCMsg *request, RPCMsg *response)
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkDAVTimeoutLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getDAQLinkDAVTimer(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -412,8 +434,8 @@ void getDAQLinkDAVTimer(const RPCMsg *request, RPCMsg *response)
   bool max = request->get_word("max");
   uint32_t res = getDAQLinkDAVTimerLocal(&la, max);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getLinkDAQStatus(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -421,8 +443,8 @@ void getLinkDAQStatus(const RPCMsg *request, RPCMsg *response)
   uint8_t gtx = request->get_word("gtx");
   uint32_t res = getLinkDAQStatusLocal(&la, gtx);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getLinkDAQCounters(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -431,8 +453,8 @@ void getLinkDAQCounters(const RPCMsg *request, RPCMsg *response)
   uint8_t mode = request->get_word("mode");
   uint32_t res = getLinkDAQCountersLocal(&la, gtx, mode);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getLinkLastDAQBlock(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -440,32 +462,32 @@ void getLinkLastDAQBlock(const RPCMsg *request, RPCMsg *response)
   uint8_t gtx  = request->get_word("gtx");
   uint32_t res = getLinkLastDAQBlockLocal(&la, gtx);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getDAQLinkInputTimeout(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkInputTimeoutLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getDAQLinkRunType(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkRunTypeLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getDAQLinkRunParameters(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   uint32_t res = getDAQLinkRunParametersLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getDAQLinkRunParameter(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -473,24 +495,24 @@ void getDAQLinkRunParameter(const RPCMsg *request, RPCMsg *response)
   uint8_t parameter  = request->get_word("parameter");
   uint32_t res = getDAQLinkRunParameterLocal(&la, parameter);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void setDAQLinkInputTimeout(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   uint32_t inputTO = request->get_word("inputTO");
   setDAQLinkInputTimeoutLocal(&la, inputTO);
+  rtxn.abort();
 }
-
 void setDAQLinkRunType(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   uint32_t runType = request->get_word("runType");
   setDAQLinkRunTypeLocal(&la, runType);
+  rtxn.abort();
 }
-
 void setDAQLinkRunParameter(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -498,16 +520,16 @@ void setDAQLinkRunParameter(const RPCMsg *request, RPCMsg *response)
   uint8_t parN   = request->get_word("parameterN");
   uint8_t runPar = request->get_word("runParameter");
   setDAQLinkRunParameterLocal(&la, parN, runPar);
+  rtxn.abort();
 }
-
 void setDAQLinkRunParameters(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   uint32_t runPars    = request->get_word("runParameters");
   setDAQLinkRunParametersLocal(&la, runPars);
+  rtxn.abort();
 }
-
 /** Composite RPC methods */
 void configureDAQModule(const RPCMsg *request, RPCMsg *response)
 {
@@ -537,6 +559,8 @@ void configureDAQModule(const RPCMsg *request, RPCMsg *response)
   setZSLocal(&la, enableZS);
   setDAQLinkRunTypeLocal(&la, 0x0);
   setDAQLinkRunParametersLocal(&la, 0xfaac);
+
+  rtxn.abort();
 }
 
 void enableDAQModule(const RPCMsg *request, RPCMsg *response)
@@ -553,4 +577,6 @@ void enableDAQModule(const RPCMsg *request, RPCMsg *response)
   resetDAQLinkLocal(&la);
   setZSLocal(&la, enableZS);
   setL1AEnableLocal(&la, true);
+
+  rtxn.abort();
 }

--- a/src/amc/sca.cpp
+++ b/src/amc/sca.cpp
@@ -55,7 +55,7 @@ std::vector<uint32_t> scaCTRLCommand(localArgs* la, SCACTRLCommandT const& cmd, 
 {
   uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
   writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
-  
+
   std::vector<uint32_t> result;
   switch (cmd) {
   case SCACTRLCommand::CTRL_R_ID_V2:
@@ -199,7 +199,6 @@ void scaModuleReset(const RPCMsg *request, RPCMsg *response)
   scaModuleResetLocal(&la, ohMask);
 
   rtxn.abort();
-  return;
 }
 
 void readSCAChipID(const RPCMsg *request, RPCMsg *response)
@@ -212,7 +211,6 @@ void readSCAChipID(const RPCMsg *request, RPCMsg *response)
   std::vector<uint32_t> scaChipIDs = readSCAChipIDLocal(&la, ohMask, scaV1);
 
   rtxn.abort();
-  return;
 }
 
 void readSCASEUCounter(const RPCMsg *request, RPCMsg *response)
@@ -225,7 +223,6 @@ void readSCASEUCounter(const RPCMsg *request, RPCMsg *response)
   std::vector<uint32_t> seuCounts = readSCASEUCounterLocal(&la, ohMask, reset);
 
   rtxn.abort();
-  return;
 }
 
 void resetSCASEUCounter(const RPCMsg *request, RPCMsg *response)
@@ -237,5 +234,4 @@ void resetSCASEUCounter(const RPCMsg *request, RPCMsg *response)
   resetSCASEUCounterLocal(&la, ohMask);
 
   rtxn.abort();
-  return;
 }

--- a/src/amc/ttc.cpp
+++ b/src/amc/ttc.cpp
@@ -738,16 +738,16 @@ void ttcModuleReset(const RPCMsg *request, RPCMsg *response)
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   ttcModuleResetLocal(&la);
+  rtxn.abort();
 }
-
 void ttcMMCMReset(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   // LocalArgs la = getLocalArgs(response);
   ttcMMCMResetLocal(&la);
+  rtxn.abort();
 }
-
 void ttcMMCMPhaseShift(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -759,9 +759,8 @@ void ttcMMCMPhaseShift(const RPCMsg *request, RPCMsg *response)
 
   ttcMMCMPhaseShiftLocal(&la, relock, modeBC0, scan);
 
-  return;
+  rtxn.abort();
 }
-
 void checkPLLLock(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -776,9 +775,8 @@ void checkPLLLock(const RPCMsg *request, RPCMsg *response)
 
   response->set_word("lockCnt",lockCnt);
 
-  return;
+  rtxn.abort();
 }
-
 void getMMCMPhaseMean(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -786,8 +784,8 @@ void getMMCMPhaseMean(const RPCMsg *request, RPCMsg *response)
   uint32_t reads = request->get_word("reads");
   double res = getMMCMPhaseMeanLocal(&la, reads);
   response->set_word("phase", res);
+  rtxn.abort();
 }
-
 void getMMCMPhaseMedian(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -795,8 +793,8 @@ void getMMCMPhaseMedian(const RPCMsg *request, RPCMsg *response)
   uint32_t reads = request->get_word("reads");
   double res = getMMCMPhaseMedianLocal(&la, reads);
   response->set_word("phase", res);
+  rtxn.abort();
 }
-
 void getGTHPhaseMean(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -804,8 +802,8 @@ void getGTHPhaseMean(const RPCMsg *request, RPCMsg *response)
   uint32_t reads = request->get_word("reads");
   double res = getGTHPhaseMeanLocal(&la, reads);
   response->set_word("phase", res);
+  rtxn.abort();
 }
-
 void getGTHPhaseMedian(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -813,30 +811,30 @@ void getGTHPhaseMedian(const RPCMsg *request, RPCMsg *response)
   uint32_t reads = request->get_word("reads");
   double res = getGTHPhaseMedianLocal(&la, reads);
   response->set_word("phase", res);
+  rtxn.abort();
 }
-
 void ttcCounterReset(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   ttcCounterResetLocal(&la);
-}
-void getL1AEnable(const RPCMsg *request, RPCMsg *response)
+  rtxn.abort();
+}void getL1AEnable(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   uint32_t res = getL1AEnableLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void setL1AEnable(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   bool en = request->get_word("enable");
   setL1AEnableLocal(&la, en);
+  rtxn.abort();
 }
-
 void getTTCConfig(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -844,8 +842,8 @@ void getTTCConfig(const RPCMsg *request, RPCMsg *response)
   uint8_t cmd = request->get_word("cmd");
   uint32_t res = getTTCConfigLocal(&la, cmd);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void setTTCConfig(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -853,8 +851,8 @@ void setTTCConfig(const RPCMsg *request, RPCMsg *response)
   uint8_t cmd = request->get_word("cmd");
   uint8_t val = request->get_word("value");
   setTTCConfigLocal(&la, cmd, val);
+  rtxn.abort();
 }
-
 void getTTCStatus(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -862,8 +860,8 @@ void getTTCStatus(const RPCMsg *request, RPCMsg *response)
   uint32_t status = getTTCStatusLocal(&la);
   // uint32_t status = 0xdeadbeef;
   response->set_word("result", status);
+  rtxn.abort();
 }
-
 void getTTCErrorCount(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -871,8 +869,8 @@ void getTTCErrorCount(const RPCMsg *request, RPCMsg *response)
   bool single = request->get_word("single");
   uint32_t res = getTTCErrorCountLocal(&la, single);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getTTCCounter(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
@@ -880,28 +878,29 @@ void getTTCCounter(const RPCMsg *request, RPCMsg *response)
   uint8_t cmd = request->get_word("cmd");
   uint32_t res = getTTCCounterLocal(&la, cmd);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getL1AID(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   uint32_t res = getL1AIDLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getL1ARate(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   uint32_t res = getL1ARateLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }
-
 void getTTCSpyBuffer(const RPCMsg *request, RPCMsg *response)
 {
   // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
   uint32_t res = getTTCSpyBufferLocal(&la);
   response->set_word("result", res);
+  rtxn.abort();
 }

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -340,7 +340,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                     uint32_t l1aCnt = 0;
                     while(l1aCnt < nevts) {
                         l1aCnt = readRawAddress(l1CntAddr, la->response);
-                        std::this_thread::sleep_for (std::chrono::microseconds(200));
+                        std::this_thread::sleep_for(std::chrono::microseconds(200));
                     }
 
                     writeReg(la, "GEM_AMC.TTC.CTRL.L1A_ENABLE", 0x0);
@@ -350,7 +350,7 @@ void genScanLocal(localArgs *la, uint32_t *outData, uint32_t ohN, uint32_t mask,
                     writeReg(la, "GEM_AMC.TTC.GENERATOR.CYCLIC_START", 0x1);
                     if (readReg(la, "GEM_AMC.TTC.GENERATOR.ENABLE")) { //TTC Commands from TTC.GENERATOR
                         while(readReg(la, "GEM_AMC.TTC.GENERATOR.CYCLIC_RUNNING")) {
-                            std::this_thread::sleep_for (std::chrono::microseconds(50));
+                            std::this_thread::sleep_for(std::chrono::microseconds(50));
                         }
                     } //End TTC Commands from TTC.GENERATOR
                 }
@@ -576,7 +576,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
             for (uint32_t dacVal = dacMin; dacVal <= dacMax; dacVal += dacStep) {
                 sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str());
                 writeReg(la, regBuf, dacVal);
-                std::this_thread::sleep_for (std::chrono::milliseconds(waitTime));
+                std::this_thread::sleep_for(std::chrono::milliseconds(waitTime));
 
                 int idx = (dacVal-dacMin)/dacStep;
                 outDataDacVal[idx] = dacVal;
@@ -657,7 +657,7 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
                 writeReg(la, stdsprintf("GEM_AMC.OH.OH%i.FPGA.TRIG.CNT.RESET",ohN), 0x1);
 
                 //Wait just over 1 second
-                std::this_thread::sleep_for (std::chrono::milliseconds(1005));
+                std::this_thread::sleep_for(std::chrono::milliseconds(1005));
 
                 //Read the counters
                 int idx = (dacVal-dacMin)/dacStep;
@@ -813,7 +813,7 @@ void checkSbitMappingWithCalPulseLocal(localArgs *la, uint32_t *outData, uint32_
             }
 
             //Sleep for 200 us + pulseDelay * 25 ns * (0.001 us / ns)
-            std::this_thread::sleep_for (std::chrono::microseconds(200+int(ceil(pulseDelay*25*0.001))));
+            std::this_thread::sleep_for(std::chrono::microseconds(200+int(ceil(pulseDelay*25*0.001))));
 
             //Check clusers
             for (int cluster=0; cluster<nclusters; ++cluster) {
@@ -1003,7 +1003,7 @@ void checkSbitRateWithCalPulseLocal(localArgs *la, uint32_t *outDataCTP7Rate, ui
         writeRawAddress(addrTtcStart, 0x1, la->response);
 
         //Sleep for waitTime of milliseconds
-        std::this_thread::sleep_for (std::chrono::milliseconds(waitTime));
+        std::this_thread::sleep_for(std::chrono::milliseconds(waitTime));
 
         //Read All Trigger Registers
         LOGGER->log_message(LogManager::INFO, "Reading trigger counters");
@@ -1155,7 +1155,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
     //Set the VFATs into Run Mode
     broadcastWriteLocal(la, ohN, "CFG_RUN", 0x1, mask);
     LOGGER->log_message(LogManager::INFO, stdsprintf("VFATs not in 0x%x were set to run mode", mask));
-    std::this_thread::sleep_for (std::chrono::seconds(1)); //I noticed that DAC values behave weirdly immediately after VFAT is placed in run mode (probably voltage/current takes a moment to stabalize)
+    std::this_thread::sleep_for(std::chrono::seconds(1)); //I noticed that DAC values behave weirdly immediately after VFAT is placed in run mode (probably voltage/current takes a moment to stabalize)
 
     //Scan the DAC
 
@@ -1183,7 +1183,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
                         //either reading or writing this register will trigger a cache update
                         readRawAddress(adcCacheUpdateAddr[vfatN], la->response);
                         //updating the cache takes 20 us, including a 50% safety factor
-                        std::this_thread::sleep_for (std::chrono::microseconds(20));
+                        std::this_thread::sleep_for(std::chrono::microseconds(20));
                     }
                     adcVal += readRawAddress(adcAddr[vfatN], la->response);
                 }

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -22,14 +22,7 @@ void getmonTTCmainLocal(localArgs * la)
 
 void getmonTTCmain(const RPCMsg *request, RPCMsg *response)
 {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  GETLOCALARGS(response);
   getmonTTCmainLocal(&la);
   rtxn.abort();
 }
@@ -38,9 +31,9 @@ void getmonTRIGGERmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
   la->response->set_word("OR_TRIGGER_RATE",readReg(la,"GEM_AMC.TRIGGER.STATUS.OR_TRIGGER_RATE"));
-  for (int ohN = 0; ohN < NOH; ohN++){
+  for (int ohN = 0; ohN < NOH; ohN++) {
     // If this Optohybrid is masked fill with 0xdeaddead
-    if(!((ohMask >> ohN) & 0x1)){
+    if (!((ohMask >> ohN) & 0x1)) {
       t1 = stdsprintf("OH%s.TRIGGER_RATE",std::to_string(ohN).c_str());
       la->response->set_word(t1,0xdeaddead);
       continue;
@@ -53,22 +46,15 @@ void getmonTRIGGERmainLocal(localArgs * la, int NOH, int ohMask)
 
 void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
 {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  GETLOCALARGS(response);
 
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
+  if (request->get_key_exists("ohMask")) {
     ohMask = request->get_word("ohMask");
   }
 
-  if (request->get_key_exists("NOH")){
+  if (request->get_key_exists("NOH")) {
     unsigned int NOH_requested = request->get_word("NOH");
     if (NOH_requested > NOH) {
       LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i)",NOH_requested,NOH));
@@ -84,9 +70,9 @@ void getmonTRIGGERmain(const RPCMsg *request, RPCMsg *response)
 void getmonTRIGGEROHmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
-  for (int ohN = 0; ohN < NOH; ohN++){
+  for (int ohN = 0; ohN < NOH; ohN++) {
     // If this Optohybrid is masked skip it
-    if(!((ohMask >> ohN) & 0x1)){
+    if (!((ohMask >> ohN) & 0x1)) {
       t1 = stdsprintf("OH%s.LINK0_MISSED_COMMA_CNT",std::to_string(ohN).c_str());
       la->response->set_word(t1,0xdeaddead);
       t1 = stdsprintf("OH%s.LINK1_MISSED_COMMA_CNT",std::to_string(ohN).c_str());
@@ -134,22 +120,15 @@ void getmonTRIGGEROHmainLocal(localArgs * la, int NOH, int ohMask)
 
 void getmonTRIGGEROHmain(const RPCMsg *request, RPCMsg *response)
 {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  GETLOCALARGS(response);
 
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
+  if (request->get_key_exists("ohMask")) {
     ohMask = request->get_word("ohMask");
   }
 
-  if (request->get_key_exists("NOH")){
+  if (request->get_key_exists("NOH")) {
     unsigned int NOH_requested = request->get_word("NOH");
     if (NOH_requested > NOH) {
       LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i)",NOH_requested,NOH));
@@ -179,14 +158,7 @@ void getmonDAQmainLocal(localArgs * la)
 
 void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
 {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  GETLOCALARGS(response);
   getmonDAQmainLocal(&la);
   rtxn.abort();
 }
@@ -194,9 +166,9 @@ void getmonDAQmain(const RPCMsg *request, RPCMsg *response)
 void getmonDAQOHmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
-  for (int ohN = 0; ohN < NOH; ohN++){
+  for (int ohN = 0; ohN < NOH; ohN++) {
     // If this Optohybrid is masked skip it
-    if(!((ohMask >> ohN) & 0x1)){
+    if (!((ohMask >> ohN) & 0x1)) {
       t1 = stdsprintf("OH%s.STATUS.EVT_SIZE_ERR",std::to_string(ohN).c_str());
       la->response->set_word(t1,0xdeaddead);
       t1 = stdsprintf("OH%s.STATUS.EVENT_FIFO_HAD_OFLOW",std::to_string(ohN).c_str());
@@ -234,22 +206,15 @@ void getmonDAQOHmainLocal(localArgs * la, int NOH, int ohMask)
 
 void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
 {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  GETLOCALARGS(response);
 
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
+  if (request->get_key_exists("ohMask")) {
     ohMask = request->get_word("ohMask");
   }
 
-  if (request->get_key_exists("NOH")){
+  if (request->get_key_exists("NOH")) {
     unsigned int NOH_requested = request->get_word("NOH");
     if (NOH_requested > NOH) {
       LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i)",NOH_requested,NOH));
@@ -265,14 +230,13 @@ void getmonDAQOHmain(const RPCMsg *request, RPCMsg *response)
 void getmonGBTLinkLocal(localArgs * la, int NOH, bool doReset)
 {
     //Reset Requested?
-    if (doReset)
-    {
+    if (doReset) {
          writeReg(la, "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
     }
 
     std::string regName, respName; //regName used for read/write, respName sets word in RPC response
-    for (int ohN=0; ohN < NOH; ++ohN){
-        for(unsigned int gbtN=0; gbtN < gbt::GBTS_PER_OH; ++gbtN){
+    for (int ohN=0; ohN < NOH; ++ohN) {
+        for (unsigned int gbtN=0; gbtN < gbt::GBTS_PER_OH; ++gbtN) {
             //Ready
             respName = stdsprintf("OH%i.GBT%i.READY",ohN,gbtN);
             regName = stdsprintf("GEM_AMC.OH_LINKS.OH%i.GBT%i_READY",ohN,gbtN);
@@ -301,9 +265,10 @@ void getmonGBTLinkLocal(localArgs * la, int NOH, bool doReset)
 void getmonGBTLink(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
+  
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
-  if (request->get_key_exists("NOH")){
+  if (request->get_key_exists("NOH")) {
     unsigned int NOH_requested = request->get_word("NOH");
     if (NOH_requested > NOH) {
       LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i)",NOH_requested,NOH));
@@ -312,22 +277,21 @@ void getmonGBTLink(const RPCMsg *request, RPCMsg *response)
   }
 
   bool doReset = false;
-  if(request->get_key_exists("doReset") ) {
+  if (request->get_key_exists("doReset") ) {
     doReset = request->get_word("doReset");
   }
 
   getmonGBTLinkLocal(&la, NOH, doReset);
   rtxn.abort();
-
-  return;
 } //End getmonGBTLink()
 
 void getmonOHLink(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
+  
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
-  if (request->get_key_exists("NOH")){
+  if (request->get_key_exists("NOH")) {
     unsigned int NOH_requested = request->get_word("NOH");
     if (NOH_requested > NOH) {
       LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i)",NOH_requested,NOH));
@@ -336,23 +300,22 @@ void getmonOHLink(const RPCMsg *request, RPCMsg *response)
   }
 
   bool doReset = false;
-  if(request->get_key_exists("doReset") ) {
+  if (request->get_key_exists("doReset") ) {
     doReset = request->get_word("doReset");
   }
 
   getmonGBTLinkLocal(&la, NOH, doReset);
   getmonVFATLinkLocal(&la, NOH, doReset);
-  rtxn.abort();
 
-  return;
+  rtxn.abort();
 } //End getmonOHLink()
 
 void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
 {
   std::string t1,t2;
-  for (int ohN = 0; ohN < NOH; ohN++){
+  for (int ohN = 0; ohN < NOH; ohN++) {
     // If this Optohybrid is masked skip it
-    if(!((ohMask >> ohN) & 0x1)){
+    if (!((ohMask >> ohN) & 0x1)) {
       t1 = stdsprintf("OH%s.FW_VERSION",std::to_string(ohN).c_str());
       la->response->set_word(t1,0xdeaddead);
       t1 = stdsprintf("OH%s.EVENT_COUNTER",std::to_string(ohN).c_str());
@@ -374,8 +337,7 @@ void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
       continue;
     }
     t1 = stdsprintf("OH%s.FW_VERSION",std::to_string(ohN).c_str());
-    if (fw_version_check("getmonOHmain",la) == 3)
-    {
+    if (fw_version_check("getmonOHmain",la) == 3) {
       uint32_t t_fwver=0xffffffff;
       t2 = stdsprintf("GEM_AMC.OH.OH%s.FPGA.CONTROL.RELEASE.VERSION.MAJOR",std::to_string(ohN).c_str());
       t_fwver = t_fwver & (0x00ffffff|(readReg(la,t2) << 24));
@@ -423,22 +385,15 @@ void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
 
 void getmonOHmain(const RPCMsg *request, RPCMsg *response)
 {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  GETLOCALARGS(response);
+  
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
+  if (request->get_key_exists("ohMask")) {
     ohMask = request->get_word("ohMask");
   }
 
-  if (request->get_key_exists("NOH")){
+  if (request->get_key_exists("NOH")) {
     unsigned int NOH_requested = request->get_word("NOH");
     if (NOH_requested > NOH) {
       LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i)",NOH_requested,NOH));
@@ -451,7 +406,8 @@ void getmonOHmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask){
+void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask)
+{
     std::string strRegName, strKeyName;
 
     //Get original monitoring mask
@@ -460,14 +416,14 @@ void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask){
     //Turn on monitoring for requested links
     writeReg(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", (~ohMask) & 0x3fc);
 
-    for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
+    for (int ohN = 0; ohN < NOH; ++ohN) { //Loop over all optohybrids
         // If this Optohybrid is masked skip it
-        if(!((ohMask >> ohN) & 0x1)){
+        if (!((ohMask >> ohN) & 0x1)) {
           //SCA Temperature
           strKeyName = stdsprintf("OH%i.SCA_TEMP",ohN);
           la->response->set_word(strKeyName,0xdeaddead);
           //OH Temperature Sensors
-          for(int tempVal=1; tempVal <= 9; ++tempVal){ //Loop over optohybrid temperatures sensosrs
+          for (int tempVal=1; tempVal <= 9; ++tempVal) { //Loop over optohybrid temperatures sensosrs
               strKeyName = stdsprintf("OH%i.BOARD_TEMP%i",ohN,tempVal);
               la->response->set_word(strKeyName, 0xdeaddead);
           } //End Loop over optohybrid temeprature sensors
@@ -513,7 +469,7 @@ void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask){
         la->response->set_word(strKeyName,readReg(la, strRegName));
 
         //OH Temperature Sensors
-        for(int tempVal=1; tempVal <= 9; ++tempVal){ //Loop over optohybrid temperatures sensosrs
+        for (int tempVal=1; tempVal <= 9; ++tempVal) { //Loop over optohybrid temperatures sensosrs
             strRegName = stdsprintf("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.OH%i.BOARD_TEMP%i",ohN,tempVal);
             strKeyName = stdsprintf("OH%i.BOARD_TEMP%i",ohN,tempVal);
             la->response->set_word(strKeyName, readReg(la, strRegName));
@@ -578,22 +534,15 @@ void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask){
 
 void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
 {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+  GETLOCALARGS(response);
+  
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
+  if (request->get_key_exists("ohMask")) {
     ohMask = request->get_word("ohMask");
   }
 
-  if (request->get_key_exists("NOH")){
+  if (request->get_key_exists("NOH")) {
     unsigned int NOH_requested = request->get_word("NOH");
     if (NOH_requested > NOH) {
       LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i)",NOH_requested,NOH));
@@ -606,14 +555,15 @@ void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask, bool doReset){
+void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask, bool doReset)
+{
     std::string strKeyName;
     std::string strRegBase;
 
-    if (fw_version_check("getmonOHSysmon", la) == 3){
-        for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
+    if (fw_version_check("getmonOHSysmon", la) == 3) {
+        for (int ohN = 0; ohN < NOH; ++ohN) { //Loop over all optohybrids
             // If this Optohybrid is masked skip it
-            if(!((ohMask >> ohN) & 0x1)){
+            if (!((ohMask >> ohN) & 0x1)) {
               //Read Alarm conditions & counters - OVERTEMP
               strKeyName = stdsprintf("OH%i.OVERTEMP",ohN);
               la->response->set_word(strKeyName,0xdeaddead);
@@ -648,7 +598,7 @@ void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask, bool doReset){
             LOGGER->log_message(LogManager::INFO, stdsprintf("Reading Sysmon Values for OH%i",ohN));
 
             //Issue reset??
-            if(doReset){
+            if (doReset) {
                 LOGGER->log_message(LogManager::INFO, stdsprintf("Reseting CNT_OVERTEMP, CNT_VCCAUX_ALARM and CNT_VCCINT_ALARM for OH%i",ohN));
                 writeReg(la, strRegBase+"RESET", 0x1);
             }
@@ -697,9 +647,9 @@ void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask, bool doReset){
         } //End Loop over all optohybrids
     } //End Case: v3 Electronics
     else{ //Case: v2b Electronics
-        for (int ohN = 0; ohN < NOH; ++ohN){ //Loop over all optohybrids
+        for (int ohN = 0; ohN < NOH; ++ohN) { //Loop over all optohybrids
             // If this Optohybrid is masked skip it
-            if(!((ohMask >> ohN) & 0x1)){
+            if (!((ohMask >> ohN) & 0x1)) {
               //Read Sysmon Values - Core Temperature
               strKeyName = stdsprintf("OH%i.FPGA_CORE_TEMP",ohN);
               la->response->set_word(strKeyName, 0xdeaddead);
@@ -735,23 +685,17 @@ void getmonOHSysmonLocal(localArgs *la, int NOH, int ohMask, bool doReset){
     return;
 } //End getmonOHSysmonLocal()
 
-void getmonOHSysmon(const RPCMsg *request, RPCMsg *response){
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+void getmonOHSysmon(const RPCMsg *request, RPCMsg *response)
+{
+  GETLOCALARGS(response);
 
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   int ohMask = 0xfff;
-  if(request->get_key_exists("ohMask")){
+  if (request->get_key_exists("ohMask")) {
     ohMask = request->get_word("ohMask");
   }
 
-  if (request->get_key_exists("NOH")){
+  if (request->get_key_exists("NOH")) {
     unsigned int NOH_requested = request->get_word("NOH");
     if (NOH_requested > NOH) {
       LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i)",NOH_requested,NOH));
@@ -778,17 +722,12 @@ void getmonSCALocal(localArgs * la, int NOH)
   }
 }
 
-void getmonSCA(const RPCMsg *request, RPCMsg *response){
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+void getmonSCA(const RPCMsg *request, RPCMsg *response)
+{
+  GETLOCALARGS(response);
+
   int NOH = request->get_word("NOH");
 
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
   getmonSCALocal(&la, NOH);
   rtxn.abort();
 } //End getmonSCA()
@@ -796,21 +735,20 @@ void getmonSCA(const RPCMsg *request, RPCMsg *response){
 void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
 {
     //Reset Requested?
-    if (doReset)
-    {
+    if (doReset) {
          writeReg(la, "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
     }
 
     std::string regName, respName; //regName used for read/write, respName sets word in RPC response
     bool vfatOutOfSync = false;
-    for (int ohN=0; ohN < NOH; ++ohN){
-        for(unsigned int vfatN=0; vfatN < oh::VFATS_PER_OH; ++vfatN){
+    for (int ohN=0; ohN < NOH; ++ohN) {
+        for (unsigned int vfatN=0; vfatN < oh::VFATS_PER_OH; ++vfatN) {
             //Sync Error Counters
             respName = stdsprintf("OH%i.VFAT%i.SYNC_ERR_CNT",ohN,vfatN);
             regName = stdsprintf("GEM_AMC.OH_LINKS.OH%i.VFAT%i.SYNC_ERR_CNT",ohN,vfatN);
             int nSyncErrs = readReg(la,regName);
             la->response->set_word(respName,nSyncErrs);
-            if( nSyncErrs > 0 ){
+            if ( nSyncErrs > 0 ) {
                 vfatOutOfSync = true;
             }
 
@@ -827,8 +765,7 @@ void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
     } //End Loop Over All OH's
 
     //Set OOS flag (out of sync)
-    if(vfatOutOfSync)
-    {
+    if (vfatOutOfSync) {
         la->response->set_string("warning","One or more VFATs found to be out of sync\n");
     }
 
@@ -838,9 +775,10 @@ void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
 void getmonVFATLink(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
+  
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
-  if (request->get_key_exists("NOH")){
+  if (request->get_key_exists("NOH")) {
     unsigned int NOH_requested = request->get_word("NOH");
     if (NOH_requested > NOH) {
       LOGGER->log_message(LogManager::WARNING, stdsprintf("NOH requested (%i) > NUM_OF_OH AMC register (%i)",NOH_requested,NOH));
@@ -849,14 +787,12 @@ void getmonVFATLink(const RPCMsg *request, RPCMsg *response)
   }
 
   bool doReset = false;
-  if(request->get_key_exists("doReset") ) {
+  if (request->get_key_exists("doReset") ) {
     doReset = request->get_word("doReset");
   }
 
   getmonVFATLinkLocal(&la, NOH, doReset);
   rtxn.abort();
-
-  return;
 } //End getmonVFATLink()
 
 extern "C" {

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -15,16 +15,9 @@
 #include <thread>
 #include <chrono>
 
-void scanGBTPhases(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+void scanGBTPhases(const RPCMsg *request, RPCMsg *response)
+{
+    GETLOCALARGS(response);
 
     // Get the keys
     const uint32_t ohN = request->get_word("ohN");
@@ -35,16 +28,16 @@ void scanGBTPhases(const RPCMsg *request, RPCMsg *response){
 
     // Perform the scan
     LOGGER->log_message(LogManager::INFO, stdsprintf("Calling Local Method for OH #%u.", ohN));
-    if (scanGBTPhasesLocal(&la, ohN, nScans, phaseMin, phaseMax, phaseStep))
-    {
+    if (scanGBTPhasesLocal(&la, ohN, nScans, phaseMin, phaseMax, phaseStep)) {
         LOGGER->log_message(LogManager::INFO, stdsprintf("GBT Scan for OH #%u Failed.", ohN));
-        return;
+        rtxn.abort();
     }
 
-    return;
+    rtxn.abort();
 } //Enc scanGBTPhase
 
-bool scanGBTPhasesLocal(localArgs *la, const uint32_t ohN, const uint32_t N, const uint8_t phaseMin, const uint8_t phaseMax, const uint8_t phaseStep){
+bool scanGBTPhasesLocal(localArgs *la, const uint32_t ohN, const uint32_t N, const uint8_t phaseMin, const uint8_t phaseMax, const uint8_t phaseStep)
+{
     LOGGER->log_message(LogManager::INFO, stdsprintf("Scanning the phases for OH #%u.", ohN));
 
     // ohN check
@@ -64,23 +57,23 @@ bool scanGBTPhasesLocal(localArgs *la, const uint32_t ohN, const uint32_t N, con
     std::vector<std::vector<uint32_t>> results(oh::VFATS_PER_OH, std::vector<uint32_t>(16));
 
     // Perform the scan
-    for(uint8_t phase = phaseMin; phase <= phaseMax; phase += phaseStep){
+    for (uint8_t phase = phaseMin; phase <= phaseMax; phase += phaseStep) {
         // Set the new phases
-        for(uint32_t vfatN = 0; vfatN < oh::VFATS_PER_OH; vfatN++){
+        for (uint32_t vfatN = 0; vfatN < oh::VFATS_PER_OH; vfatN++) {
             if (writeGBTPhaseLocal(la, ohN, vfatN, phase))
                 return true;
         }
 
         // Wait for the phases to be set
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for (std::chrono::milliseconds(10));
 
-        for (uint32_t repN = 0; repN < N; repN++){
+        for (uint32_t repN = 0; repN < N; repN++) {
             // Try to synchronize the VFAT's
             writeReg(la, "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 1);
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            std::this_thread::sleep_for (std::chrono::milliseconds(10));
 
             // Check the VFAT status
-            for(uint32_t vfatN = 0; vfatN < oh::VFATS_PER_OH; vfatN++){
+            for (uint32_t vfatN = 0; vfatN < oh::VFATS_PER_OH; vfatN++) {
                 const bool linkGood = (readReg(la, stdsprintf("GEM_AMC.OH_LINKS.OH%hu.VFAT%hu.LINK_GOOD", ohN, vfatN)) == 1);
                 const bool syncErrCnt = (readReg(la, stdsprintf("GEM_AMC.OH_LINKS.OH%hu.VFAT%hu.SYNC_ERR_CNT", ohN, vfatN)) == 0);
                 const bool cfgRun = (readReg(la, stdsprintf("GEM_AMC.OH.OH%hu.GEB.VFAT%hu.CFG_RUN", ohN, vfatN)) != 0xdeaddead);
@@ -93,23 +86,16 @@ bool scanGBTPhasesLocal(localArgs *la, const uint32_t ohN, const uint32_t N, con
     }
 
     // Write the results to RPC keys
-    for(uint32_t vfatN = 0; vfatN < oh::VFATS_PER_OH; vfatN++){
+    for (uint32_t vfatN = 0; vfatN < oh::VFATS_PER_OH; vfatN++) {
         la->response->set_word_array(stdsprintf("OH%u.VFAT%u", ohN, vfatN), results[vfatN]);
     }
 
     return false;
 } //End scanGBTPhaseLocal
 
-void writeGBTConfig(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+void writeGBTConfig(const RPCMsg *request, RPCMsg *response)
+{
+    GETLOCALARGS(response);
 
     // Get the keys
     const uint32_t ohN = request->get_word("ohN");
@@ -126,10 +112,11 @@ void writeGBTConfig(const RPCMsg *request, RPCMsg *response){
     // Write the configuration
     writeGBTConfigLocal(&la, ohN, gbtN, config);
 
-    return;
+    rtxn.abort();
 } //End writeGBTConfig(...)
 
-bool writeGBTConfigLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN, const gbt::config_t &config){
+bool writeGBTConfigLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN, const gbt::config_t &config)
+{
     LOGGER->log_message(LogManager::INFO, stdsprintf("Writing the configuration of OH #%u - GBTX #%u.", ohN, gbtN));
 
     // ohN check
@@ -142,7 +129,7 @@ bool writeGBTConfigLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN,
         EMIT_RPC_ERROR(la->response, stdsprintf("The gbtN parameter supplied (%u) exceeds the number of GBT's per OH (%u).", gbtN, gbt::GBTS_PER_OH), true);
 
     // Write all the registers
-    for (size_t address = 0; address < gbt::CONFIG_SIZE; address++){
+    for (size_t address = 0; address < gbt::CONFIG_SIZE; address++) {
         if (writeGBTRegLocal(la, ohN, gbtN, static_cast<uint16_t>(address), config[address]))
             return true;
     }
@@ -150,16 +137,9 @@ bool writeGBTConfigLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN,
     return false;
 } //End writeGBTConfigLocal(...)
 
-void writeGBTPhase(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+void writeGBTPhase(const RPCMsg *request, RPCMsg *response)
+{
+    GETLOCALARGS(response);
 
     // Get the keys
     const uint32_t ohN = request->get_word("ohN");
@@ -169,10 +149,11 @@ void writeGBTPhase(const RPCMsg *request, RPCMsg *response){
     // Write the phase
     writeGBTPhaseLocal(&la, ohN, vfatN, phase);
 
-    return;
+    rtxn.abort();
 } //End writeGBTPhase
 
-bool writeGBTPhaseLocal(localArgs *la, const uint32_t ohN, const uint32_t vfatN, const uint8_t phase){
+bool writeGBTPhaseLocal(localArgs *la, const uint32_t ohN, const uint32_t vfatN, const uint8_t phase)
+{
     LOGGER->log_message(LogManager::INFO, stdsprintf("Writing the VFAT #%u phase of OH #%u.", vfatN, ohN));
 
     // ohN check
@@ -191,7 +172,7 @@ bool writeGBTPhaseLocal(localArgs *la, const uint32_t ohN, const uint32_t vfatN,
     // Write the triplicated phase registers
     const uint32_t gbtN = gbt::elinkMappings::VFAT_TO_GBT[vfatN];
 
-    for(unsigned char regN = 0; regN < 3; regN++){
+    for (unsigned char regN = 0; regN < 3; regN++) {
         const uint16_t regAddress = gbt::elinkMappings::ELINK_TO_REGISTERS[gbt::elinkMappings::VFAT_TO_ELINK[vfatN]][regN];
 
         if (writeGBTRegLocal(la, ohN, gbtN, regAddress, phase))
@@ -201,7 +182,8 @@ bool writeGBTPhaseLocal(localArgs *la, const uint32_t ohN, const uint32_t vfatN,
     return false;
 } //End writeGBTPhaseLocal
 
-bool writeGBTRegLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN, const uint16_t address, const uint8_t value){
+bool writeGBTRegLocal(localArgs *la, const uint32_t ohN, const uint32_t gbtN, const uint16_t address, const uint8_t value)
+{
     // Check that the GBT exists
     if (gbtN >= gbt::GBTS_PER_OH)
         EMIT_RPC_ERROR(la->response, stdsprintf("The gbtN parameter supplied (%u) is larger than the number of GBT's per OH (%u).", gbtN, gbt::GBTS_PER_OH), true);
@@ -239,4 +221,3 @@ extern "C" {
         modmgr->register_method("gbt", "scanGBTPhases", scanGBTPhases);
     }
 }
-

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -65,12 +65,12 @@ bool scanGBTPhasesLocal(localArgs *la, const uint32_t ohN, const uint32_t N, con
         }
 
         // Wait for the phases to be set
-        std::this_thread::sleep_for (std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
         for (uint32_t repN = 0; repN < N; repN++) {
             // Try to synchronize the VFAT's
             writeReg(la, "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 1);
-            std::this_thread::sleep_for (std::chrono::milliseconds(10));
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
             // Check the VFAT status
             for (uint32_t vfatN = 0; vfatN < oh::VFATS_PER_OH; vfatN++) {

--- a/src/optohybrid.cpp
+++ b/src/optohybrid.cpp
@@ -41,18 +41,13 @@ void broadcastWriteLocal(localArgs * la, uint32_t ohN, std::string regName, uint
 }
 
 void broadcastWrite(const RPCMsg *request, RPCMsg *response) {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  GETLOCALARGS(response);
+
   std::string regName = request->get_string("reg_name");
   uint32_t value = request->get_word("value");
   uint32_t mask = request->get_key_exists("mask")?request->get_word("mask"):0xFF000000;
   uint32_t ohN = request->get_word("ohN");
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+
   broadcastWriteLocal(&la, ohN, regName, value, mask);
   rtxn.abort();
 }
@@ -81,20 +76,16 @@ void broadcastReadLocal(localArgs * la, uint32_t * outData, uint32_t ohN, std::s
 }
 
 void broadcastRead(const RPCMsg *request, RPCMsg *response) {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  GETLOCALARGS(response);
+
   std::string regName = request->get_string("reg_name");
   uint32_t mask = request->get_key_exists("mask")?request->get_word("mask"):0xFF000000;
   uint32_t ohN = request->get_word("ohN");
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+
   uint32_t outData[24];
   broadcastReadLocal(&la, outData, ohN, regName, mask);
   response->set_word_array("data", outData, 24);
+
   rtxn.abort();
 }
 
@@ -172,18 +163,14 @@ void loadVT1Local(localArgs * la, uint32_t ohN, std::string config_file, uint32_
 }
 
 void loadVT1(const RPCMsg *request, RPCMsg *response) {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  GETLOCALARGS(response);
+
   uint32_t ohN = request->get_word("ohN");
   std::string config_file = request->get_key_exists("thresh_config_filename")?request->get_string("thresh_config_filename"):"";
   uint32_t vt1 = request->get_key_exists("vt1")?request->get_word("vt1"):0x64;
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+
   loadVT1Local(&la, ohN, config_file, vt1);
+
   rtxn.abort();
 }
 
@@ -209,33 +196,23 @@ void loadTRIMDACLocal(localArgs * la, uint32_t ohN, std::string config_file) {
 }
 
 void loadTRIMDAC(const RPCMsg *request, RPCMsg *response) {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  GETLOCALARGS(response);
+
   uint32_t ohN = request->get_word("ohN");
   std::string config_file = request->get_string("trim_config_filename");//"/mnt/persistent/texas/test/chConfig_GEMINIm01L1.txt";
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+
   loadTRIMDACLocal(&la, ohN, config_file);
   rtxn.abort();
 }
 
 void configureVFATs(const RPCMsg *request, RPCMsg *response) {
-  auto env = lmdb::env::create();
-  env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-  std::string gem_path = std::getenv("GEM_PATH");
-  std::string lmdb_data_file = gem_path+"/address_table.mdb";
-  env.open(lmdb_data_file.c_str(), 0, 0664);
-  auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-  auto dbi = lmdb::dbi::open(rtxn, nullptr);
+  GETLOCALARGS(response);
+
   uint32_t ohN = request->get_word("ohN");
   std::string trim_config_file = request->get_string("trim_config_filename");//"/mnt/persistent/texas/test/chConfig_GEMINIm01L1.txt";
   std::string thresh_config_file = request->get_key_exists("thresh_config_filename")?request->get_string("thresh_config_filename"):"";
   uint32_t vt1 = request->get_key_exists("vt1")?request->get_word("vt1"):0x64;
-  struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+
   LOGGER->log_message(LogManager::INFO, "BIAS VFATS");
   biasAllVFATsLocal(&la, ohN);
   LOGGER->log_message(LogManager::INFO, "LOAD VT1 VFATS");
@@ -243,6 +220,7 @@ void configureVFATs(const RPCMsg *request, RPCMsg *response) {
   LOGGER->log_message(LogManager::INFO, "LOAD TRIM VFATS");
   loadTRIMDACLocal(&la, ohN, trim_config_file);
   if (request->get_key_exists("set_run")) setAllVFATsToRunModeLocal(&la, ohN);
+
   rtxn.abort();
 }
 
@@ -305,13 +283,7 @@ void configureScanModule(const RPCMsg *request, RPCMsg *response){
      *            for ULTRA scan, specify the VFAT mask
      */
 
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+    GETLOCALARGS(response);
 
     //Get OH and scanmode
     uint32_t ohN = request->get_word("ohN");
@@ -335,10 +307,10 @@ void configureScanModule(const RPCMsg *request, RPCMsg *response){
     uint32_t dacMax = request->get_word("dacMax");
     uint32_t dacStep = request->get_word("dacStep");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+
     configureScanModuleLocal(&la, ohN, vfatN, scanmode, useUltra, mask, ch, nevts, dacMin, dacMax, dacStep);
 
-    return;
+    rtxn.abort();
 } //End configureScanModule(...)
 
 void printScanConfigurationLocal(localArgs * la, uint32_t ohN, bool useUltra){
@@ -382,14 +354,8 @@ void printScanConfigurationLocal(localArgs * la, uint32_t ohN, bool useUltra){
 } //End printScanConfigurationLocal(...)
 
 void printScanConfiguration(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
+    GETLOCALARGS(response);
+    
     uint32_t ohN = request->get_word("ohN");
 
     bool useUltra = false;
@@ -397,10 +363,9 @@ void printScanConfiguration(const RPCMsg *request, RPCMsg *response){
         useUltra = true;
     }
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     printScanConfigurationLocal(&la, ohN, useUltra);
 
-    return;
+    rtxn.abort();
 } //End printScanConfiguration(...)
 
 void startScanModuleLocal(localArgs * la, uint32_t ohN, bool useUltra){
@@ -440,14 +405,8 @@ void startScanModuleLocal(localArgs * la, uint32_t ohN, bool useUltra){
 } //End startScanModuleLocal(...)
 
 void startScanModule(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
+    GETLOCALARGS(response);
+    
     uint32_t ohN = request->get_word("ohN");
 
     bool useUltra = false;
@@ -455,10 +414,9 @@ void startScanModule(const RPCMsg *request, RPCMsg *response){
         useUltra = true;
     }
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     startScanModuleLocal(&la, ohN, useUltra);
 
-    return;
+    rtxn.abort();
 } //End startScanModule(...)
 
 void getUltraScanResultsLocal(localArgs * la, uint32_t *outData, uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep){
@@ -523,26 +481,19 @@ void getUltraScanResultsLocal(localArgs * la, uint32_t *outData, uint32_t ohN, u
 } //End getUltraScanResultsLocal(...)
 
 void getUltraScanResults(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
+    GETLOCALARGS(response);
+    
     uint32_t ohN = request->get_word("ohN");
     uint32_t nevts = request->get_word("nevts");
     uint32_t dacMin = request->get_word("dacMin");
     uint32_t dacMax = request->get_word("dacMax");
     uint32_t dacStep = request->get_word("dacStep");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     uint32_t outData[24*(dacMax-dacMin+1)/dacStep];
     getUltraScanResultsLocal(&la, outData, ohN, nevts, dacMin, dacMax, dacStep);
     response->set_word_array("data",outData,24*(dacMax-dacMin+1)/dacStep);
 
-    return;
+    rtxn.abort();
 } //End getUltraScanResults(...)
 
 void stopCalPulse2AllChannelsLocal(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t ch_min, uint32_t ch_max){
@@ -577,23 +528,16 @@ void stopCalPulse2AllChannelsLocal(localArgs *la, uint32_t ohN, uint32_t mask, u
 }
 
 void stopCalPulse2AllChannels(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
-
+    GETLOCALARGS(response);
+    
     uint32_t ohN = request->get_word("ohN");
     uint32_t mask = request->get_word("mask");
     uint32_t ch_min = request->get_word("ch_min");
     uint32_t ch_max = request->get_word("ch_max");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     stopCalPulse2AllChannelsLocal(&la, ohN, mask, ch_min, ch_max);
 
-    return;
+    rtxn.abort();
 }
 
 void statusOHLocal(localArgs * la, uint32_t ohEnMask){
@@ -637,17 +581,11 @@ void statusOHLocal(localArgs * la, uint32_t ohEnMask){
 
 void statusOH(const RPCMsg *request, RPCMsg *response)
 {
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+    GETLOCALARGS(response);
+
     uint32_t ohEnMask = request->get_word("ohEnMask");
     LOGGER->log_message(LogManager::INFO, "Reeading OH status");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     statusOHLocal(&la, ohEnMask);
     rtxn.abort();
 }

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -32,22 +32,15 @@ uint32_t vfatSyncCheckLocal(localArgs * la, uint32_t ohN)
 
 void vfatSyncCheck(const RPCMsg *request, RPCMsg *response)
 {
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+    GETLOCALARGS(response);
 
     uint32_t ohN = request->get_word("ohN");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     uint32_t goodVFATs = vfatSyncCheckLocal(&la, ohN);
 
     response->set_word("goodVFATs", goodVFATs);
 
-    return;
+    rtxn.abort();
 }
 
 void configureVFAT3DacMonitorLocal(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t dacSelect){
@@ -83,39 +76,24 @@ void configureVFAT3DacMonitorLocal(localArgs *la, uint32_t ohN, uint32_t mask, u
 } //End configureVFAT3DacMonitorLocal(...)
 
 void configureVFAT3DacMonitor(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+    GETLOCALARGS(response);
 
     uint32_t ohN = request->get_word("ohN");
     uint32_t vfatMask = request->get_word("vfatMask");
     uint32_t dacSelect = request->get_word("dacSelect");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
-
     LOGGER->log_message(LogManager::INFO, stdsprintf("Programming VFAT3 ADC Monitoring for Selection %i",dacSelect));
     configureVFAT3DacMonitorLocal(&la, ohN, vfatMask, dacSelect);
 
-    return;
+    rtxn.abort();
 } //End configureVFAT3DacMonitor()
 
 void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+    GETLOCALARGS(response);
 
     uint32_t ohMask = request->get_word("ohMask");
     uint32_t dacSelect = request->get_word("dacSelect");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (request->get_key_exists("NOH")){
         unsigned int NOH_requested = request->get_word("NOH");
@@ -137,7 +115,7 @@ void configureVFAT3DacMonitorMultiLink(const RPCMsg *request, RPCMsg *response){
         configureVFAT3DacMonitorLocal(&la, ohN, vfatMask, dacSelect);
     } //End Loop over all Optohybrids
 
-    return;
+    rtxn.abort();
 } //End configureVFAT3DacMonitorMultiLink()
 
 void configureVFAT3sLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask) {
@@ -185,41 +163,30 @@ void configureVFAT3sLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask) {
 }
 
 void configureVFAT3s(const RPCMsg *request, RPCMsg *response) {
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+    GETLOCALARGS(response);
+
     uint32_t ohN = request->get_word("ohN");
     uint32_t vfatMask = request->get_word("vfatMask");
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
+
     configureVFAT3sLocal(&la, ohN, vfatMask);
     rtxn.abort();
 }
 
 void getChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
     LOGGER->log_message(LogManager::INFO, "Getting VFAT3 Channel Registers");
+
+    GETLOCALARGS(response);
 
     uint32_t ohN = request->get_word("ohN");
     uint32_t vfatMask = request->get_word("vfatMask");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     uint32_t chanRegData[24*128];
 
     getChannelRegistersVFAT3Local(&la, ohN, vfatMask, chanRegData);
 
     response->set_word_array("chanRegData",chanRegData,24*128);
 
-    return;
+    rtxn.abort();
 } //End getChannelRegistersVFAT3()
 
 void getChannelRegistersVFAT3Local(localArgs *la, uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData){
@@ -278,19 +245,12 @@ void readVFAT3ADCLocal(localArgs * la, uint32_t * outData, uint32_t ohN, bool us
 } //End readVFAT3ADCLocal
 
 void readVFAT3ADC(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+    GETLOCALARGS(response);
 
     uint32_t ohN = request->get_word("ohN");
     bool useExtRefADC = request->get_word("useExtRefADC");
     uint32_t vfatMask = request->get_word("vfatMask");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     uint32_t adcData[24];
 
     LOGGER->log_message(LogManager::INFO, stdsprintf("Reading VFAT3 ADC's for OH%i with mask %x",ohN, vfatMask));
@@ -298,22 +258,15 @@ void readVFAT3ADC(const RPCMsg *request, RPCMsg *response){
 
     response->set_word_array("adcData",adcData,24);
 
-    return;
+    rtxn.abort();
 } //End getChannelRegistersVFAT3()
 
 void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+    GETLOCALARGS(response);
 
     uint32_t ohMask = request->get_word("ohMask");
     bool useExtRefADC = request->get_word("useExtRefADC");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
     if (request->get_key_exists("NOH")){
         unsigned int NOH_requested = request->get_word("NOH");
@@ -344,7 +297,7 @@ void readVFAT3ADCMultiLink(const RPCMsg *request, RPCMsg *response){
 
     response->set_word_array("adcDataAll",adcDataAll,12*24);
 
-    return;
+    rtxn.abort();
 } //End readVFAT3ADCMultiLink()
 
 void setChannelRegistersVFAT3SimpleLocal(localArgs * la, uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData){
@@ -441,19 +394,13 @@ void setChannelRegistersVFAT3Local(localArgs * la, uint32_t ohN, uint32_t vfatMa
 } //end setChannelRegistersVFAT3Local()
 
 void setChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response){
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
     LOGGER->log_message(LogManager::INFO, "Setting VFAT3 Channel Registers");
+
+    GETLOCALARGS(response);
 
     uint32_t ohN = request->get_word("ohN");
     uint32_t vfatMask = request->get_word("vfatMask");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     if (request->get_key_exists("simple")){
         uint32_t chanRegData[3072];
 
@@ -479,7 +426,7 @@ void setChannelRegistersVFAT3(const RPCMsg *request, RPCMsg *response){
         setChannelRegistersVFAT3Local(&la, ohN, vfatMask, calEnable, masks, trimARM, trimARMPol, trimZCC, trimZCCPol);
     } //End Case: user provided multiple arrays
 
-    return;
+    rtxn.abort();
 } //End setChannelRegistersVFAT3()
 
 void statusVFAT3sLocal(localArgs * la, uint32_t ohN)
@@ -526,18 +473,13 @@ void statusVFAT3sLocal(localArgs * la, uint32_t ohN)
     }
 }
 
-void statusVFAT3s(const RPCMsg *request, RPCMsg *response) {
-    auto env = lmdb::env::create();
-    env.set_mapsize(1UL * 1024UL * 1024UL * 40UL); /* 40 MiB */
-    std::string gem_path = std::getenv("GEM_PATH");
-    std::string lmdb_data_file = gem_path+"/address_table.mdb";
-    env.open(lmdb_data_file.c_str(), 0, 0664);
-    auto rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
-    auto dbi = lmdb::dbi::open(rtxn, nullptr);
+void statusVFAT3s(const RPCMsg *request, RPCMsg *response)
+{
+    GETLOCALARGS(response);
+
     uint32_t ohN = request->get_word("ohN");
     LOGGER->log_message(LogManager::INFO, "Reading VFAT3 status");
 
-    struct localArgs la = {.rtxn = rtxn, .dbi = dbi, .response = response};
     statusVFAT3sLocal(&la, ohN);
     rtxn.abort();
 }
@@ -659,7 +601,6 @@ void getVFAT3ChipIDs(const RPCMsg *request, RPCMsg *response)
   getVFAT3ChipIDsLocal(&la, ohN, rawID);
 
   rtxn.abort();
-  return;
 }
 
 extern "C" {


### PR DESCRIPTION
## Description

* Replace all `localArgs` initialization with `GETLOCALARGS`
* Clean up some (not all) formatting mismatches
* Close all RPC callbacks with `rtxn.abort()`

### Types of changes
- [x] Cosmetic/cleanup

## Motivation and Context
Needed to happen, did it now to just be done with it
