### PR TITLE
Bug Fix: Bad Node Names & Hard Coded LMDB Size Limit

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -39,7 +39,7 @@ typedef struct localArgs {
  */
 LocalArgs getLocalArgs(RPCMsg *response);
 
-static constexpr uint32_t LMDB_SIZE = 1UL * 1024UL * 1024UL * 40UL; ///< Maximum size of the LMDB object, currently 40 MiB
+static constexpr uint32_t LMDB_SIZE = 1UL * 1024UL * 1024UL * 50UL; ///< Maximum size of the LMDB object, currently 50 MiB
 
 // FIXME: to be replaced with the above function when the struct is properly implemented
 #define GETLOCALARGS(response)                                  \

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -4,15 +4,11 @@
  *  \author Brian Dorney <brian.l.dorney@cern.ch>
  */
 
-#include "daq_monitor.h"
-
-#include <chrono>
-#include <thread>
-#include <string>
-
-#include "utils.h"
 #include "amc.h"
+#include "daq_monitor.h"
 #include "hw_constants.h"
+#include <string>
+#include "utils.h"
 
 void getmonTTCmainLocal(localArgs * la)
 {
@@ -240,7 +236,6 @@ void getmonGBTLinkLocal(localArgs * la, int NOH, bool doReset)
     //Reset Requested?
     if (doReset) {
          writeReg(la, "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
-         std::this_thread::sleep_for(std::chrono::microseconds(92)); // FIXME sleep for N orbits
     }
 
     std::string regName, respName; //regName used for read/write, respName sets word in RPC response
@@ -248,22 +243,22 @@ void getmonGBTLinkLocal(localArgs * la, int NOH, bool doReset)
         for (unsigned int gbtN=0; gbtN < gbt::GBTS_PER_OH; ++gbtN) {
             //Ready
             respName = stdsprintf("OH%i.GBT%i.READY",ohN,gbtN);
-            regName = stdsprintf("GEM_AMC.OH_LINKS.%s",respName.c_str());
+            regName = stdsprintf("GEM_AMC.OH_LINKS.OH%i.GBT%i_READY",ohN,gbtN);
             la->response->set_word(respName,readReg(la, regName));
 
             //Was not ready
             respName = stdsprintf("OH%i.GBT%i.WAS_NOT_READY",ohN,gbtN);
-            regName = stdsprintf("GEM_AMC.OH_LINKS.%s",respName.c_str());
+            regName = stdsprintf("GEM_AMC.OH_LINKS.OH%i.GBT%i_WAS_NOT_READY",ohN,gbtN);
             la->response->set_word(respName,readReg(la, regName));
 
             //Rx had overflow
             respName = stdsprintf("OH%i.GBT%i.RX_HAD_OVERFLOW",ohN,gbtN);
-            regName = stdsprintf("GEM_AMC.OH_LINKS.%s",respName.c_str());
+            regName = stdsprintf("GEM_AMC.OH_LINKS.OH%i.GBT%i_RX_HAD_OVERFLOW",ohN,gbtN);
             la->response->set_word(respName,readReg(la, regName));
 
             //Rx had underflow
             respName = stdsprintf("OH%i.GBT%i.RX_HAD_UNDERFLOW",ohN,gbtN);
-            regName = stdsprintf("GEM_AMC.OH_LINKS.%s",respName.c_str());
+            regName = stdsprintf("GEM_AMC.OH_LINKS.OH%i.GBT%i_RX_HAD_UNDERFLOW",ohN,gbtN);
             la->response->set_word(respName,readReg(la, regName));
         } //End Loop Over GBT's
     } //End Loop Over All OH's
@@ -274,7 +269,7 @@ void getmonGBTLinkLocal(localArgs * la, int NOH, bool doReset)
 void getmonGBTLink(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
-
+  
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
   if (request->get_key_exists("NOH")) {
@@ -297,7 +292,7 @@ void getmonGBTLink(const RPCMsg *request, RPCMsg *response)
 void getmonOHLink(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
-
+  
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
   if (request->get_key_exists("NOH")) {
@@ -397,7 +392,7 @@ void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
 void getmonOHmain(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
-
+  
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   int ohMask = 0xfff;
   if (request->get_key_exists("ohMask")) {
@@ -548,7 +543,7 @@ void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask)
 void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
-
+  
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   int ohMask = 0xfff;
   if (request->get_key_exists("ohMask")) {
@@ -754,7 +749,6 @@ void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
     //Reset Requested?
     if (doReset) {
          writeReg(la, "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
-         std::this_thread::sleep_for(std::chrono::microseconds(92)); // FIXME sleep for N orbits
     }
 
     std::string regName, respName; //regName used for read/write, respName sets word in RPC response
@@ -763,7 +757,7 @@ void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
         for (unsigned int vfatN=0; vfatN < oh::VFATS_PER_OH; ++vfatN) {
             //Sync Error Counters
             respName = stdsprintf("OH%i.VFAT%i.SYNC_ERR_CNT",ohN,vfatN);
-            regName = stdsprintf("GEM_AMC.OH_LINKS.%s",respName.c_str());
+            regName = stdsprintf("GEM_AMC.OH_LINKS.OH%i.VFAT%i.SYNC_ERR_CNT",ohN,vfatN);
             int nSyncErrs = readReg(la,regName);
             la->response->set_word(respName,nSyncErrs);
             if ( nSyncErrs > 0 ) {
@@ -772,12 +766,12 @@ void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
 
             //DAQ Event Counters
             respName = stdsprintf("OH%i.VFAT%i.DAQ_EVENT_CNT",ohN,vfatN);
-            regName = stdsprintf("GEM_AMC.OH_LINKS.%s",respName.c_str());
+            regName = stdsprintf("GEM_AMC.OH_LINKS.OH%i.VFAT%i.DAQ_EVENT_CNT",ohN,vfatN);
             la->response->set_word(respName,readReg(la,regName));
 
             //DAQ CRC Error Counters
             respName = stdsprintf("OH%i.VFAT%i.DAQ_CRC_ERROR_CNT",ohN,vfatN);
-            regName = stdsprintf("GEM_AMC.OH_LINKS.%s",respName.c_str());
+            regName = stdsprintf("GEM_AMC.OH_LINKS.OH%i.VFAT%i.DAQ_CRC_ERROR_CNT",ohN,vfatN);
             la->response->set_word(respName,readReg(la,regName));
         } //End Loop Over VFAT's
     } //End Loop Over All OH's
@@ -793,7 +787,7 @@ void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
 void getmonVFATLink(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
-
+  
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
   if (request->get_key_exists("NOH")) {

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -5,6 +5,8 @@
  */
 
 #include "amc.h"
+#include <chrono>
+#include <thread>
 #include "daq_monitor.h"
 #include "hw_constants.h"
 #include <string>
@@ -269,7 +271,7 @@ void getmonGBTLinkLocal(localArgs * la, int NOH, bool doReset)
 void getmonGBTLink(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
-  
+
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
   if (request->get_key_exists("NOH")) {
@@ -292,7 +294,7 @@ void getmonGBTLink(const RPCMsg *request, RPCMsg *response)
 void getmonOHLink(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
-  
+
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
   if (request->get_key_exists("NOH")) {
@@ -392,7 +394,7 @@ void getmonOHmainLocal(localArgs * la, int NOH, int ohMask)
 void getmonOHmain(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
-  
+
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   int ohMask = 0xfff;
   if (request->get_key_exists("ohMask")) {
@@ -543,7 +545,7 @@ void getmonOHSCAmainLocal(localArgs *la, int NOH, int ohMask)
 void getmonOHSCAmain(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
-  
+
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   int ohMask = 0xfff;
   if (request->get_key_exists("ohMask")) {
@@ -749,6 +751,7 @@ void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
     //Reset Requested?
     if (doReset) {
          writeReg(la, "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
+         std::this_thread::sleep_for(std::chrono::microseconds(92)); // FIXME sleep for N orbits
     }
 
     std::string regName, respName; //regName used for read/write, respName sets word in RPC response
@@ -787,7 +790,7 @@ void getmonVFATLinkLocal(localArgs * la, int NOH, bool doReset)
 void getmonVFATLink(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
-  
+
   unsigned int NOH = readReg(&la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
   if (request->get_key_exists("NOH")) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Reverted #110 as it adds an unnecessary sleep to `getmonGBTLinkLocal` and also the node names used there are *invalid*.

Keeps the sleep statement that partially addresses #103 in `getmonVFATLinkLocal`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Invalid node names introduced.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
