### PR TITLE
New Feature: Updates to DAC & GBT Phase Scans

### DIFF
--- a/include/amc.h
+++ b/include/amc.h
@@ -37,9 +37,18 @@ void getOHVFATMask(const RPCMsg *request, RPCMsg *response);
  *  \brief As getOHVFATMask(...) but for all optical links specified in ohMask on the AMC
  *  \details Here the RPCMsg request should have a "ohMask" word which specifies which OH's to read from, this is a 12 bit number where a 1 in the n^th bit indicates that the n^th OH should be read back.  Additionally there should be a "ohVfatMaskArray" which is an array of size 12 where each element is the standard vfatMask for OH specified by the array index.
  *  \param request RPC request message
- *  \param response RPC responce message
+ *  \param response RPC response message
  */
 void getOHVFATMaskMultiLink(const RPCMsg *request, RPCMsg *response);
+
+/*! \fn void repeatedRegRead(const RPCMsg *request, RPCMsg *response)
+ *  \brief Reads a list of registers for nReads and then counts the number of slow control errors observed.
+ *  \details the RPC request is expected to have the following keys: "regList" which stores a std::vector<std::string> of registers to be read, note the full node name is required; "breakOnFailure" which will indicate if a register in regList should stop being read after the first failure before nReads is reached (see next); "nReads" the number of times each register in "regList" is read.
+ *  \details the RPC response will have the following keys: "CRC_ERROR_CNT", "PACKET_ERROR_CNT", "BITSTUFFING_ERROR_CNT", "TIMEOUT_ERROR_CNT", "AXI_STROBE_ERROR_CNT", and "TRANSACTION_CNT" which correspond to the counters under the node "GEM_AMC.SLOW_CONTROL.VFAT3."; additionally there will be one final key "SUM" which is the sum of all counters (except TRANSACTION_CNT).
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void repeatedRegRead(const RPCMsg *request, RPCMsg *response);
 
 /*! \fn std::vector<uint32_t> sbitReadOutLocal(localArgs *la, uint32_t ohN, uint32_t acquireTime, bool *maxNetworkSizeReached)
  *  \brief reads out sbits from optohybrid ohN for a number of seconds given by acquireTime and returns them to the user.

--- a/include/utils.h
+++ b/include/utils.h
@@ -67,7 +67,10 @@ struct slowCtrlErrCntVFAT{
     uint32_t sum;           //Sum of above counters
     uint32_t nTransactions; //GEM_AMC.SLOW_CONTROL.VFAT3.TRANSACTION_CNT
 
-    slowCtrlErrCntVFAT(){}
+    slowCtrlErrCntVFAT()
+    {
+        crc = packet = bitstuffing = timeout = axi_strobe = sum = nTransactions = 0;
+    }
     slowCtrlErrCntVFAT(uint32_t crc, uint32_t packet, uint32_t bitstuffing, uint32_t timeout, uint32_t axi_strobe, uint32_t sum, unsigned nTransactions) : crc(crc), packet(packet), bitstuffing(bitstuffing), timeout(timeout), axi_strobe(axi_strobe), sum(sum), nTransactions(nTransactions) {}
     slowCtrlErrCntVFAT operator + (const slowCtrlErrCntVFAT &vfatErrs) const
     {

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1178,6 +1178,10 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
     int nDacValues = (dacMax-dacMin+1)/dacStep;
     std::vector<uint32_t> vec_dacScanData(24*nDacValues); //Each element has bits [0:7] as the current dacValue, and bits [8:17] as the ADC read back value
 
+    //Put VFATs into slow control only mode
+    writeReg(la, "GEM_AMC.GEM_SYSTEM.VFAT3.SC_ONLY_MODE", 0x1);
+    broadcastWriteLocal(la, ohN, "CFG_RUN", 0x0, mask);
+
     //Configure the DAC Monitoring on all the VFATs
     configureVFAT3DacMonitorLocal(la, ohN, mask, dacSelect);
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1179,16 +1179,14 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
     std::vector<uint32_t> vec_dacScanData(24*nDacValues); //Each element has bits [0:7] as the current dacValue, and bits [8:17] as the ADC read back value
 
     //Put VFATs into slow control only mode
-    writeReg(la, "GEM_AMC.GEM_SYSTEM.VFAT3.SC_ONLY_MODE", 0x1);
+    writeReg(la, "GEM_AMC.TTC.CTRL.L1A_ENABLE", 0x0);
     broadcastWriteLocal(la, ohN, "CFG_RUN", 0x0, mask);
 
     //Configure the DAC Monitoring on all the VFATs
     configureVFAT3DacMonitorLocal(la, ohN, mask, dacSelect);
 
-    //Take the VFATs out of slow control only mode
-    writeReg(la, "GEM_AMC.GEM_SYSTEM.VFAT3.SC_ONLY_MODE", 0x0);
-
     //Set the VFATs into Run Mode
+    writeReg(la, "GEM_AMC.GEM_SYSTEM.VFAT3.SC_ONLY_MODE", 0x0);
     broadcastWriteLocal(la, ohN, "CFG_RUN", 0x1, mask);
     LOGGER->log_message(LogManager::INFO, stdsprintf("VFATs not in 0x%x were set to run mode", mask));
     std::this_thread::sleep_for(std::chrono::seconds(1)); //I noticed that DAC values behave weirdly immediately after VFAT is placed in run mode (probably voltage/current takes a moment to stabalize)

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -1178,7 +1178,7 @@ std::vector<uint32_t> dacScanLocal(localArgs *la, uint32_t ohN, uint32_t dacSele
     int nDacValues = (dacMax-dacMin+1)/dacStep;
     std::vector<uint32_t> vec_dacScanData(24*nDacValues); //Each element has bits [0:7] as the current dacValue, and bits [8:17] as the ADC read back value
 
-    //Put VFATs into slow control only mode
+    //Block L1A's then take VFATs out of run mode
     writeReg(la, "GEM_AMC.TTC.CTRL.L1A_ENABLE", 0x0);
     broadcastWriteLocal(la, ohN, "CFG_RUN", 0x0, mask);
 

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -75,26 +75,8 @@ bool scanGBTPhasesLocal(localArgs *la, const uint32_t ohN, const uint32_t N, con
             // Check the VFAT status
             slowCtrlErrCntVFAT vfatErrs;
             for (uint32_t vfatN = 0; vfatN < oh::VFATS_PER_OH; vfatN++) {
-                //const bool syncErrCnt = (readReg(la, stdsprintf("GEM_AMC.OH_LINKS.OH%hu.VFAT%hu.SYNC_ERR_CNT", ohN, vfatN)) == 0);
-
-                //bool cfgRun=false, hwID=false, hwIDVer=false;
-                //for(uint32_t scTrial=0; scTrial < 10; ++scTrial)
-                //{
-                //    cfgRun = (readReg(la, stdsprintf("GEM_AMC.OH.OH%hu.GEB.VFAT%hu.CFG_RUN", ohN, vfatN)) != 0xdeaddead);
-                //    std::this_thread::sleep_for(std::chrono::microseconds(20));
-                //    hwID = (readReg(la, stdsprintf("GEM_AMC.OH.OH%hu.GEB.VFAT%hu.HW_ID_VER", ohN, vfatN)) != 0xdeaddead);
-                //    std::this_thread::sleep_for(std::chrono::microseconds(20));
-                //    hwIDVer = (readReg(la, stdsprintf("GEM_AMC.OH.OH%hu.GEB.VFAT%hu.HW_ID", ohN, vfatN)) == 0x56464154); //"VFAT" in ASCII
-                //    std::this_thread::sleep_for(std::chrono::microseconds(20));
-
-                //    // Did any of the above fail?
-                //    // If so break and move on
-                //    if (!cfgRun || !hwID || !hwIDVer)
-                //    {
-                //        break;
-                //    }
-                //}
-                if (readReg(la, stdsprintf("GEM_AMC.OH_LINKS.OH%hu.VFAT%hu.SYNC_ERR_CNT", ohN, vfatN)) == 0){
+                // check SYNC_ERR_CNT
+                if (readReg(la, stdsprintf("GEM_AMC.OH_LINKS.OH%hu.VFAT%hu.SYNC_ERR_CNT", ohN, vfatN)) != 0){
                     continue;
                 }
 
@@ -192,7 +174,7 @@ void writeGBTPhase(const RPCMsg *request, RPCMsg *response)
 
 bool writeGBTPhaseLocal(localArgs *la, const uint32_t ohN, const uint32_t vfatN, const uint8_t phase)
 {
-    LOGGER->log_message(LogManager::INFO, stdsprintf("Writing the VFAT #%u phase of OH #%u.", vfatN, ohN));
+    LOGGER->log_message(LogManager::INFO, stdsprintf("Writing %u to the VFAT #%u phase of OH #%u.", phase, vfatN, ohN));
 
     // ohN check
     const uint32_t ohMax = readReg(la, "GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -389,6 +389,7 @@ slowCtrlErrCntVFAT repeatedRegReadLocal(localArgs * la, const std::string & regN
 
     //Issue a link reset to reset counters under GEM_AMC.SLOW_CONTROL.VFAT3
     writeReg(la,"GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
+    std::this_thread::sleep_for(std::chrono::microseconds(90));
 
     for (uint32_t i=0; i<nReads; i++){
         //Any time a bus error occurs for VFAT slow control the TIMEOUT_ERROR_CNT will increment
@@ -396,7 +397,6 @@ slowCtrlErrCntVFAT repeatedRegReadLocal(localArgs * la, const std::string & regN
         std::this_thread::sleep_for(std::chrono::microseconds(20));
 
         if(!goodRead && breakOnFailure){
-            LOGGER->log_message(LogManager::INFO,stdsprintf("Bad read was encountered after %i reads of %s",i,regName.c_str()));
             break;
         }
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -382,6 +382,37 @@ uint32_t readBlock(const uint32_t& regAddr, uint32_t* result, const uint32_t& si
   return 0;
 }
 
+slowCtrlErrCntVFAT repeatedRegReadLocal(localArgs * la, const std::string & regName, bool breakOnFailure, uint32_t nReads)
+{
+    //Create the output error counter container
+    slowCtrlErrCntVFAT vfatErrs;
+
+    //Issue a link reset to reset counters under GEM_AMC.SLOW_CONTROL.VFAT3
+    writeReg(la,"GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
+
+    for (uint32_t i=0; i<nReads; i++){
+        //Any time a bus error occurs for VFAT slow control the TIMEOUT_ERROR_CNT will increment
+        bool goodRead = (readReg(la, regName) != 0xdeaddead);
+        std::this_thread::sleep_for(std::chrono::microseconds(20));
+
+        if(!goodRead && breakOnFailure){
+            LOGGER->log_message(LogManager::INFO,stdsprintf("Bad read was encountered after %i reads of %s",i,regName.c_str()));
+            break;
+        }
+    }
+
+    std::string baseReg     = "GEM_AMC.SLOW_CONTROL.VFAT3.";
+    vfatErrs.crc            = readReg(la,baseReg+"CRC_ERROR_CNT");
+    vfatErrs.packet         = readReg(la,baseReg+"PACKET_ERROR_CNT");
+    vfatErrs.bitstuffing    = readReg(la,baseReg+"BITSTUFFING_ERROR_CNT");
+    vfatErrs.timeout        = readReg(la,baseReg+"TIMEOUT_ERROR_CNT");
+    vfatErrs.axi_strobe     = readReg(la,baseReg+"AXI_STROBE_ERROR_CNT");
+    vfatErrs.nTransactions  = readReg(la,baseReg+"TRANSACTION_CNT");
+    vfatErrs.sumErrors();
+
+    return vfatErrs;
+} //End repeatedRegReadLocal
+
 void writeReg(localArgs * la, const std::string & regName, uint32_t value)
 {
   lmdb::val key, db_res;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Before a DAC scan is launched L1A's will now be disabled and VFATs will be taken out of run mode before configuring DAC Monitoring on all VFATs.

The GBT phase scan will no longer check the `LINK_GOOD` register as it was largely useless for checking communication status.  Now each GBT phase scan point will attempt several slow control transactions per point before declaring the phase as good.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
During QC7 tests saw that it was possible to generate both bus errors and out of sync states for VFATs in cases where the VFAT was placed into run mode and then subsequent slow control actions were performed.  This caused crashes or unintentional masking of VFATs. 

Also improves reliability of phase scan results.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Extensively on QC7 setup.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
