### PR TITLE
#100 : added 5 modules to read  SCAADC sensors

### DIFF
--- a/include/amc/sca.h
+++ b/include/amc/sca.h
@@ -174,4 +174,60 @@ void readSCAChipID(const RPCMsg *request, RPCMsg *response);
 void readSCASEUCounter(const RPCMsg *request, RPCMsg *response);
 void resetSCASEUCounter(const RPCMsg *request, RPCMsg *response);
 
+/*!
+ *  \fn void readSCAADCSensor(const RPCMsg *request, RPCMsg *response)
+ *  \brief Read the ADC channels
+ *
+ *  - ch : Name of ADC channel to read from SCAADCChannelT
+ *  - ohMask : This specifies which OH's to read from 
+ *
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void readSCAADCSensor(const RPCMsg *request, RPCMsg *response);
+
+/*!
+ *  \fn void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response)
+ *  \brief Read all of temperature sensor channels. They are 00, 04, 07, 08 and 1F.
+ *
+ *  - ohMask : This specifies which OH's to read from 
+ *
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response);
+
+/*!
+ *  \fn void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response)
+ *  \brief Read all the voltages channels. They are 1B, 1E, 11, 0E, 18 and 0F. 
+ *
+ *  - ohMask : This specifies which OH's to read from 
+ *
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response);
+
+/*!
+ *  \fn void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response)
+ *  \brief Read the signal strength channels. They are 15, 13 and 12. 
+ *
+ *  - ohMask : This specifies which OH's to read from 
+ *
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response);
+
+/*!
+ *  \fn void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response)
+ *  \brief Read all connected ADC channels. 
+ *
+ *  - ohMask : This specifies which OH's to read from 
+ *
+ *  \param request RPC request message
+ *  \param response RPC response message
+ */
+void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response);
+
 #endif

--- a/include/amc/sca.h
+++ b/include/amc/sca.h
@@ -177,56 +177,86 @@ void resetSCASEUCounter(const RPCMsg *request, RPCMsg *response);
 /*!
  *  \fn void readSCAADCSensor(const RPCMsg *request, RPCMsg *response)
  *  \brief Read individual SCA ADC sensor
- *  \param[in] request RPC response message
+ *  \param[in] request RPC response message with the following keys:
  *  	- `word ohMask` : This specifies which OH's to read from
  *  	- `word ch` : Name of SCA ADC sensor to read
  *
- *  \param[out] response RPC response message
- *  	- `word_array data` : Array of word contaning the information of masked/unmasked OH, link ID, SCA ADC sensor number and the data. This is formatted like: <OH masked 1, otherwise 0 27><link ID 26:24><0s 23:21><ADC ID 20:16><0's 15:12><data 11:0>
+ *  \param[out] response RPC response message with the following keys:
+ *  	- `word_array data` : ADC data is returned as an array of 32-bit words formatted as:
+ *  			      bit [27]: data present
+ *  			      bits [26:24]: link ID
+ *  			      bits [23:21]: constant 0's
+ *  			      bits [20:16]: ADC channel ID
+ *  			      bits [15:12]: constant 0's
+ *  			      bits [11:0]: ADC data
  */
 void readSCAADCSensor(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response)
  *  \brief Read all SCA ADC temperature sensors. They are 0x00, 0x04, 0x07, and 0x08.
- *  \param[in] request RPC response message
+ *  \param[in] request RPC response message with the following keys:
  *  	- `word ohMask` : This specifies which OH's to read from
  *
- *  \param[out] response RPC response message
- *  	- `word_array data` : Array of word contaning the information of masked/unmasked OH, link ID, SCA ADC sensor number and the data. This is formatted like: <OH masked 1, otherwise 0 27><link ID 26:24><0s 23:21><ADC ID 20:16><0's 15:12><data 11:0>
+ *  \param[out] response RPC response message with the following keys:
+ *  	- `word_array data` : ADC data is returned as an array of 32-bit words formatted as:
+ *  			      bit [27]: data present
+ *  			      bits [26:24]: link ID
+ *  			      bits [23:21]: constant 0's
+ *  			      bits [20:16]: ADC channel ID
+ *  			      bits [15:12]: constant 0's
+ *  			      bits [11:0]: ADC data
  */
 void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response)
  *  \brief Read all SCA ADC voltages sensors. They are 1B, 1E, 11, 0E, 18 and 0F. 
- *  \param[in] request RPC response message
+ *  \param[in] request RPC response message with the following keys:
  *  	- `word ohMask` : This specifies which OH's to read from
  *
- *  \param[out] response RPC response message
- *  	- `word_array data` : Array of word contaning the information of masked/unmasked OH, link ID, SCA ADC sensor number and the data. This is formatted like: <OH masked 1, otherwise 0 27><link ID 26:24><0s 23:21><ADC ID 20:16><0's 15:12><data 11:0>
+ *  \param[out] response RPC response message with the following keys:
+ *  	- `word_array data` : ADC data is returned as an array of 32-bit words formatted as:
+ *  			      bit [27]: data present
+ *  			      bits [26:24]: link ID
+ *  			      bits [23:21]: constant 0's
+ *  			      bits [20:16]: ADC channel ID
+ *  			      bits [15:12]: constant 0's
+ *  			      bits [11:0]: ADC data
  */
 void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response)
  *  \brief Read the SCA ADC signal strength sensors. They are 15, 13 and 12. 
- *  \param[in] request RPC response message
+ *  \param[in] request RPC response message with the following keys:
  *  	- `word ohMask` : This specifies which OH's to read from
  *
- *  \param[out] response RPC response message
- *  	- `word_array data` : Array of word contaning the information of masked/unmasked OH, link ID, SCA ADC sensor number and the data. This is formatted like: <OH masked 1, otherwise 0 27><link ID 26:24><0s 23:21><ADC ID 20:16><0's 15:12><data 11:0>
+ *  \param[out] response RPC response message with the following keys:
+ *  	- `word_array data` : ADC data is returned as an array of 32-bit words formatted as:
+ *  			      bit [27]: data present
+ *  			      bits [26:24]: link ID
+ *  			      bits [23:21]: constant 0's
+ *  			      bits [20:16]: ADC channel ID
+ *  			      bits [15:12]: constant 0's
+ *  			      bits [11:0]: ADC data
  */
 void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response)
  *  \brief Read all connected SCA ADC sensors. 
- *  \param[in] request RPC response message
+ *  \param[in] request RPC response message with the following keys:
  *  	- `word ohMask` : This specifies which OH's to read from
  *
- *  \param[out] response RPC response message
- *  	- `word_array data` : Array of word contaning the information of masked/unmasked OH, link ID, SCA ADC sensor number and the data. This is formatted like: <OH masked 1, otherwise 0 27><link ID 26:24><0s 23:21><ADC ID 20:16><0's 15:12><data 11:0>
+ *  \param[out] response RPC response message with the following keys:
+ *  	- `word_array data` : ADC data is returned as an array of 32-bit words formatted as:
+ *  			      bit [27]: data present
+ *  			      bits [26:24]: link ID
+ *  			      bits [23:21]: constant 0's
+ *  			      bits [20:16]: ADC channel ID
+ *  			      bits [15:12]: constant 0's
+ *  			      bits [11:0]: ADC data
  */
 void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response);
 

--- a/include/amc/sca.h
+++ b/include/amc/sca.h
@@ -176,57 +176,57 @@ void resetSCASEUCounter(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readSCAADCSensor(const RPCMsg *request, RPCMsg *response)
- *  \brief Read the ADC channels
+ *  \brief Read individual SCA ADC sensor
+ *  \param[in] request RPC response message
+ *  	- `word ohMask` : This specifies which OH's to read from
+ *  	- `word ch` : Name of SCA ADC sensor to read
  *
- *  - ch : Name of ADC channel to read from SCAADCChannelT
- *  - ohMask : This specifies which OH's to read from 
- *
- *  \param request RPC request message
- *  \param response RPC response message
+ *  \param[out] response RPC response message
+ *  	- `word_array data` : Array of word contaning the information of masked/unmasked OH, link ID, SCA ADC sensor number and the data. This is formatted like: <OH masked 1, otherwise 0 27><link ID 26:24><0s 23:21><ADC ID 20:16><0's 15:12><data 11:0>
  */
 void readSCAADCSensor(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response)
- *  \brief Read all of temperature sensor channels. They are 00, 04, 07, 08 and 1F.
+ *  \brief Read all SCA ADC temperature sensors. They are 0x00, 0x04, 0x07, and 0x08.
+ *  \param[in] request RPC response message
+ *  	- `word ohMask` : This specifies which OH's to read from
  *
- *  - ohMask : This specifies which OH's to read from 
- *
- *  \param request RPC request message
- *  \param response RPC response message
+ *  \param[out] response RPC response message
+ *  	- `word_array data` : Array of word contaning the information of masked/unmasked OH, link ID, SCA ADC sensor number and the data. This is formatted like: <OH masked 1, otherwise 0 27><link ID 26:24><0s 23:21><ADC ID 20:16><0's 15:12><data 11:0>
  */
 void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response)
- *  \brief Read all the voltages channels. They are 1B, 1E, 11, 0E, 18 and 0F. 
+ *  \brief Read all SCA ADC voltages sensors. They are 1B, 1E, 11, 0E, 18 and 0F. 
+ *  \param[in] request RPC response message
+ *  	- `word ohMask` : This specifies which OH's to read from
  *
- *  - ohMask : This specifies which OH's to read from 
- *
- *  \param request RPC request message
- *  \param response RPC response message
+ *  \param[out] response RPC response message
+ *  	- `word_array data` : Array of word contaning the information of masked/unmasked OH, link ID, SCA ADC sensor number and the data. This is formatted like: <OH masked 1, otherwise 0 27><link ID 26:24><0s 23:21><ADC ID 20:16><0's 15:12><data 11:0>
  */
 void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response)
- *  \brief Read the signal strength channels. They are 15, 13 and 12. 
+ *  \brief Read the SCA ADC signal strength sensors. They are 15, 13 and 12. 
+ *  \param[in] request RPC response message
+ *  	- `word ohMask` : This specifies which OH's to read from
  *
- *  - ohMask : This specifies which OH's to read from 
- *
- *  \param request RPC request message
- *  \param response RPC response message
+ *  \param[out] response RPC response message
+ *  	- `word_array data` : Array of word contaning the information of masked/unmasked OH, link ID, SCA ADC sensor number and the data. This is formatted like: <OH masked 1, otherwise 0 27><link ID 26:24><0s 23:21><ADC ID 20:16><0's 15:12><data 11:0>
  */
 void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response)
- *  \brief Read all connected ADC channels. 
+ *  \brief Read all connected SCA ADC sensors. 
+ *  \param[in] request RPC response message
+ *  	- `word ohMask` : This specifies which OH's to read from
  *
- *  - ohMask : This specifies which OH's to read from 
- *
- *  \param request RPC request message
- *  \param response RPC response message
+ *  \param[out] response RPC response message
+ *  	- `word_array data` : Array of word contaning the information of masked/unmasked OH, link ID, SCA ADC sensor number and the data. This is formatted like: <OH masked 1, otherwise 0 27><link ID 26:24><0s 23:21><ADC ID 20:16><0's 15:12><data 11:0>
  */
 void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response);
 

--- a/include/amc/sca_enums.h
+++ b/include/amc/sca_enums.h
@@ -234,7 +234,7 @@ class SCASettings {
       // SCA ADC temperature sensors
       VTTX_CSC_PT100 = 0x00, ///< Transceiver block next to the CSC VTTX
       VTTX_GEM_PT100 = 0x04, ///< Transceiver block next to the GEM VTTX
-      SCA_PT100      = 0x07, ///< SCA temperature sensor
+      GBT0_PT100      = 0x07, ///< SCA temperature sensor
       V6_FPGA_PT100  = 0x08, ///< Virtex6 temperature sensor
 
       // SCA ADC signal strength sensors
@@ -261,6 +261,18 @@ class SCASettings {
       //ADC_CH28 = 0x1C, ///< ADC channel 28
       //ADC_CH29 = 0x1D, ///< ADC channel 29
     } ADCChannel;
+
+    //static constexpr bool useCurrentSource(EADCChannel sensor)
+    static bool useCurrentSource(EADCChannel sensor)
+    {
+       switch (sensor) {
+          case (VTTX_CSC_PT100): return true;
+	  case (VTTX_GEM_PT100): return true;
+	  case (GBT0_PT100):	 return true;
+	  case (V6_FPGA_PT100):	 return true;
+	  default:		 return false;
+       }
+    }
   };  // struct ADCChannel
 
 };

--- a/include/amc/sca_enums.h
+++ b/include/amc/sca_enums.h
@@ -231,38 +231,35 @@ class SCASettings {
       FPGA_IO_V2P5   = 15, ///< 2.5V used by FPGA I/O and VTRXs/VTTXs
       VTTX_VTRX_V2P5 = 15, ///< 2.5V used by FPGA I/O and VTRXs/VTTXs
 
-      ADC_CH00 = 0x00, ///< ADC channel 00, Temp sensor
-      ADC_CH01 = 0x01, ///< ADC channel 01, NOT CONNECTED
-      ADC_CH02 = 0x02, ///< ADC channel 02, NOT CONNECTED
-      ADC_CH03 = 0x03, ///< ADC channel 03, NOT CONNECTED
-      ADC_CH04 = 0x04, ///< ADC channel 04, Temp sensor
-      ADC_CH05 = 0x05, ///< ADC channel 05, NOT CONNECTED
-      ADC_CH06 = 0x06, ///< ADC channel 06
-      ADC_CH07 = 0x07, ///< ADC channel 07, Temp sensor
-      ADC_CH08 = 0x08, ///< ADC channel 08, Temp sensor
-      ADC_CH09 = 0x09, ///< ADC channel 09
-      ADC_CH10 = 0x0A, ///< ADC channel 10
-      ADC_CH11 = 0x0B, ///< ADC channel 11
-      ADC_CH12 = 0x0C, ///< ADC channel 12, NOT CONNECTED
-      ADC_CH13 = 0x0D, ///< ADC channel 13
-      ADC_CH14 = 0x0E, ///< ADC channel 14, 1.8V
-      ADC_CH15 = 0x0F, ///< ADC channel 15, 2.5V I/O
-      ADC_CH16 = 0x10, ///< ADC channel 16
-      ADC_CH17 = 0x11, ///< ADC channel 17, internal 1.0V
-      ADC_CH18 = 0x12, ///< ADC channel 18, VTRx rssi3
-      ADC_CH19 = 0x13, ///< ADC channel 19, VTRx rssi2
-      ADC_CH20 = 0x14, ///< ADC channel 20
-      ADC_CH21 = 0x15, ///< ADC channel 21, VTRx rssi1
-      ADC_CH22 = 0x16, ///< ADC channel 22
-      ADC_CH23 = 0x17, ///< ADC channel 23
-      ADC_CH24 = 0x18, ///< ADC channel 24, 1.5V
-      ADC_CH25 = 0x19, ///< ADC channel 25
-      ADC_CH26 = 0x1A, ///< ADC channel 26
-      ADC_CH27 = 0x1B, ///< ADC channel 27, AVCCN
-      ADC_CH28 = 0x1C, ///< ADC channel 28
-      ADC_CH29 = 0x1D, ///< ADC channel 29
-      ADC_CH30 = 0x1E, ///< ADC channel 30, AVTTN
-      ADC_CH31 = 0x1F, ///< ADC channel 31
+      // SCA ADC temperature sensors
+      VTTX_CSC 	     = 0x00, ///< Transceiver block next to the CSC VTTX
+      VTTX_GEM       = 0x04, ///< Transceiver block next to the GEM VTTX
+      SCA_PT100      = 0x07, ///< SCA temperature sensor
+      V6_FPGA_PT100  = 0x08, ///< Virtex6 temperature sensor
+
+      // SCA ADC signal strength sensors
+      VTRX_RSSI3     = 0x12, ///< ADC channel 18, VTRx rssi3
+      VTRX_RSSI2     = 0x13, ///< ADC channel 19, VTRx rssi2
+      VTRX_RSSI1     = 0x15, ///< ADC channel 21, VTRx rssi1
+
+      // Not connected SCA ADC sensors
+      //ADC_CH01 = 0x01, ///< ADC channel 01, NOT CONNECTED
+      //ADC_CH02 = 0x02, ///< ADC channel 02, NOT CONNECTED
+      //ADC_CH03 = 0x03, ///< ADC channel 03, NOT CONNECTED
+      //ADC_CH05 = 0x05, ///< ADC channel 05, NOT CONNECTED
+      //ADC_CH09 = 0x09, ///< ADC channel 09
+      //ADC_CH10 = 0x0A, ///< ADC channel 10
+      //ADC_CH11 = 0x0B, ///< ADC channel 11
+      //ADC_CH12 = 0x0C, ///< ADC channel 12, NOT CONNECTED
+      //ADC_CH13 = 0x0D, ///< ADC channel 13
+      //ADC_CH16 = 0x10, ///< ADC channel 16
+      //ADC_CH20 = 0x14, ///< ADC channel 20
+      //ADC_CH22 = 0x16, ///< ADC channel 22
+      //ADC_CH23 = 0x17, ///< ADC channel 23
+      //ADC_CH25 = 0x19, ///< ADC channel 25
+      //ADC_CH26 = 0x1A, ///< ADC channel 26
+      //ADC_CH28 = 0x1C, ///< ADC channel 28
+      //ADC_CH29 = 0x1D, ///< ADC channel 29
     } ADCChannel;
   };  // struct ADCChannel
 

--- a/include/amc/sca_enums.h
+++ b/include/amc/sca_enums.h
@@ -265,13 +265,13 @@ class SCASettings {
     //static constexpr bool useCurrentSource(EADCChannel sensor)
     static bool useCurrentSource(EADCChannel sensor)
     {
-       switch (sensor) {
-          case (VTTX_CSC_PT100): return true;
-	  case (VTTX_GEM_PT100): return true;
-	  case (GBT0_PT100):	 return true;
-	  case (V6_FPGA_PT100):	 return true;
-	  default:		 return false;
-       }
+        switch (sensor) {
+            case (VTTX_CSC_PT100):	return true;
+            case (VTTX_GEM_PT100):	return true;
+            case (GBT0_PT100):		return true;
+            case (V6_FPGA_PT100):	return true;
+            default:			return false;
+        }
     }
   };  // struct ADCChannel
 

--- a/include/amc/sca_enums.h
+++ b/include/amc/sca_enums.h
@@ -232,8 +232,8 @@ class SCASettings {
       VTTX_VTRX_V2P5 = 15, ///< 2.5V used by FPGA I/O and VTRXs/VTTXs
 
       // SCA ADC temperature sensors
-      VTTX_CSC 	     = 0x00, ///< Transceiver block next to the CSC VTTX
-      VTTX_GEM       = 0x04, ///< Transceiver block next to the GEM VTTX
+      VTTX_CSC_PT100 = 0x00, ///< Transceiver block next to the CSC VTTX
+      VTTX_GEM_PT100 = 0x04, ///< Transceiver block next to the GEM VTTX
       SCA_PT100      = 0x07, ///< SCA temperature sensor
       V6_FPGA_PT100  = 0x08, ///< Virtex6 temperature sensor
 

--- a/include/hw_constants.h
+++ b/include/hw_constants.h
@@ -20,6 +20,7 @@ namespace amc {
      */
     namespace ge11 {
         constexpr uint32_t OH_PER_AMC = 12;    ///< The number of OptoHybrids per AMC.
+        constexpr uint32_t FULL_OH_MASK = 0xfff; ///< Reading of all OptoHybrids are enabled.
     }
 
     using namespace GEM_VARIANT;

--- a/include/utils.h
+++ b/include/utils.h
@@ -80,13 +80,13 @@ std::string serialize(xhal::utils::Node n);
     response->set_string("error", message);             \
     return error_code; }
 
-/*! \fn uint32_t bitCheck(uint32_t ohMask, int bit)
- *  \brief return 1 if the particular bit is 1 else 0
+/*! \fn uint32_t bitCheck(uint32_t word, int bit)
+ *  \brief return 1 if the given bit in word is 1 else 0
  *
- *  \param ohMask: This specifies which OH's to read from 
+ *  \param word: an unsigned int of 32 bit 
  *  \param bit: integer that specifies a particular bit position
  */
-uint32_t bitCheck(uint32_t ohMask, int bit);
+uint32_t bitCheck(uint32_t word, int bit);
 
 /*! \fn uint32_t getNumNonzeroBits(uint32_t value)
  *  \brief returns the number of nonzero bits in an integer

--- a/include/utils.h
+++ b/include/utils.h
@@ -80,6 +80,14 @@ std::string serialize(xhal::utils::Node n);
     response->set_string("error", message);             \
     return error_code; }
 
+/*! \fn uint32_t bitCheck(uint32_t ohMask, int bit)
+ *  \brief return 1 if the particular bit is 1 else 0
+ *
+ *  \param ohMask: This specifies which OH's to read from 
+ *  \param bit: integer that specifies a particular bit position
+ */
+uint32_t bitCheck(uint32_t ohMask, int bit);
+
 /*! \fn uint32_t getNumNonzeroBits(uint32_t value)
  *  \brief returns the number of nonzero bits in an integer
  *  \param value integer to check the number of nonzero bits

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -9,6 +9,7 @@
 #include "amc/ttc.h"
 #include "amc/daq.h"
 #include "amc/blaster_ram.h"
+#include "amc/sca.h"
 
 #include <chrono>
 #include <string>
@@ -259,6 +260,11 @@ extern "C" {
 
         // SCA module methods (from amc/sca)
         // modmgr->register_method("amc", "scaHardResetEnable", scaHardResetEnable);
+        modmgr->register_method("amc", "readSCAADCSensor", readSCAADCSensor);
+        modmgr->register_method("amc", "readSCAADCTemperatureSensors", readSCAADCTemperatureSensors);
+        modmgr->register_method("amc", "readSCAADCVoltageSensors", readSCAADCVoltageSensors);
+        modmgr->register_method("amc", "readSCAADCSignalStrengthSensors", readSCAADCSignalStrengthSensors);
+        modmgr->register_method("amc", "readAllSCAADCSensors", readAllSCAADCSensors);
 
         // BLASTER RAM module methods (from amc/blaster_ram)
         modmgr->register_method("amc", "writeConfRAM", writeConfRAM);

--- a/src/amc/sca.cpp
+++ b/src/amc/sca.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "amc/sca.h"
+#include "hw_constants.h"
 
 uint32_t formatSCAData(uint32_t const& data)
 {
@@ -245,7 +246,7 @@ void readSCAADCSensor(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
 
-  uint32_t ohMask = request->get_word("ohMask");
+  const uint32_t ohMask   = request->get_key_exists("ohMask") ? request->get_word("ohMask") : amc::FULL_OH_MASK;
   SCAADCChannelT  ch = static_cast<SCAADCChannelT>(request->get_word("ch"));
   
   std::vector<uint32_t> result;
@@ -257,7 +258,7 @@ void readSCAADCSensor(const RPCMsg *request, RPCMsg *response)
   for(auto const& val : result) {
       LOGGER->log_message(LogManager::DEBUG, stdsprintf("Value for OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, ch, val)); 
       outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (ch<<16) | val);
-      response->set_word_array("data",outData.data(), outData.size());
+      response->set_word_array("data",outData);
       ++ohIdx;
   }
 
@@ -268,7 +269,7 @@ void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
 
-  uint32_t ohMask = request->get_word("ohMask");
+  const uint32_t ohMask   = request->get_key_exists("ohMask") ? request->get_word("ohMask") : amc::FULL_OH_MASK;
 
   SCAADCChannelT chArr[5] = {
   			      SCAADCChannel::VTTX_CSC_PT100,
@@ -290,17 +291,16 @@ void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response)
     }
   }
   
-  response->set_word_array("data", outData.data(), outData.size());
+  response->set_word_array("data", outData);
 
   rtxn.abort();
 }
 
 void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response)
 {
-  // struct localArgs la = getLocalArgs(response);
   GETLOCALARGS(response);
 
-  uint32_t ohMask = request->get_word("ohMask");
+  const uint32_t ohMask   = request->get_key_exists("ohMask") ? request->get_word("ohMask") : amc::FULL_OH_MASK;
 
   SCAADCChannelT chArr[6] = {
   			      SCAADCChannel::PROM_V1P8,
@@ -323,7 +323,7 @@ void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response)
     }
   }
 
-  response->set_word_array("data", outData.data(), outData.size());
+  response->set_word_array("data", outData);
 
   rtxn.abort();
 }
@@ -332,7 +332,7 @@ void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
 
-  uint32_t ohMask = request->get_word("ohMask");
+  const uint32_t ohMask   = request->get_key_exists("ohMask") ? request->get_word("ohMask") : amc::FULL_OH_MASK;
 
   SCAADCChannelT chArr[3] = {
   			      static_cast<SCAADCChannelT>(SCAADCChannel::VTRX_RSSI1),
@@ -353,7 +353,7 @@ void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response)
     }
   }
 
-  response->set_word_array("data", outData.data(), outData.size());
+  response->set_word_array("data", outData);
 
   rtxn.abort();
 }
@@ -362,7 +362,7 @@ void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response)
 {
   GETLOCALARGS(response);
 
-  uint32_t ohMask = request->get_word("ohMask");
+  const uint32_t ohMask   = request->get_key_exists("ohMask") ? request->get_word("ohMask") : amc::FULL_OH_MASK;
 
   int ohIdx;
   std::vector<uint32_t> result;
@@ -377,7 +377,7 @@ void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response)
     }
   }
 
-  response->set_word_array("data", outData.data(), outData.size());
+  response->set_word_array("data", outData);
 
   rtxn.abort();
 }

--- a/src/amc/sca.cpp
+++ b/src/amc/sca.cpp
@@ -120,7 +120,7 @@ std::vector<uint32_t> scaGPIOCommandLocal(localArgs* la, SCAGPIOCommandT const& 
   return reply;
 }
 
-std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, uint8_t const& len, uint32_t data, uint16_t const& ohMask)
+std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, uint16_t const& ohMask)
 {
   uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
   writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
@@ -131,13 +131,13 @@ std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, uin
 
 
   // enable the current sink if reading the temperature ADCs
-  if (ch == SCAADCChannel::VTTX_CSC || ch == SCAADCChannel::VTTX_GEM || ch == SCAADCChannel::SCA_PT100 || ch == SCAADCChannel::V6_FPGA_PT100 )	// Hardcoded channel numbers
+  if (ch == SCAADCChannel::VTTX_CSC_PT100 || ch == SCAADCChannel::VTTX_GEM_PT100 || ch == SCAADCChannel::SCA_PT100 || ch == SCAADCChannel::V6_FPGA_PT100 )	// Hardcoded channel numbers
     sendSCACommand(la, SCAChannel::ADC, SCAADCCommand::ADC_W_CURR, 0x4, 0x1<<ch, ohMask);
   // start the conversion and get the result
   std::vector<uint32_t> result = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_GO, 0x4, 0x1, ohMask);
 
   // disable the current sink if reading the temperature ADCs
-  if (ch == SCAADCChannel::VTTX_CSC || ch == SCAADCChannel::VTTX_GEM || ch == SCAADCChannel::SCA_PT100 || ch == SCAADCChannel::V6_FPGA_PT100 )	// Hardcoded channel numbers
+  if (ch == SCAADCChannel::VTTX_CSC_PT100 || ch == SCAADCChannel::VTTX_GEM_PT100 || ch == SCAADCChannel::SCA_PT100 || ch == SCAADCChannel::V6_FPGA_PT100 )	// Hardcoded channel numbers
     sendSCACommand(la, SCAChannel::ADC, SCAADCCommand::ADC_W_CURR, 0x4, 0x0<<ch, ohMask);
   // // get the last data
   // std::vector<uint32_t> last = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_DATA, 0x1, 0x0, ohMask);
@@ -251,14 +251,14 @@ void readSCAADCSensor(const RPCMsg *request, RPCMsg *response)
   std::vector<uint32_t> result;
   std::vector<uint32_t> outData;
 
-  result = scaADCCommand(&la, ch, 0, 0, ohMask);
+  result = scaADCCommand(&la, ch, ohMask);
 
-  int count = 0;
-  for(auto const& val : result){
-      LOGGER->log_message(LogManager::DEBUG, stdsprintf("Value for OH%i, SCA-ADC channel 0x%x = %i ",count, ch, val)); 
-      outData.push_back((bitCheck(ohMask, count) << 27) | (count<<24) | (ch<<16) | val);
+  int ohIdx = 0;
+  for(auto const& val : result) {
+      LOGGER->log_message(LogManager::DEBUG, stdsprintf("Value for OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, ch, val)); 
+      outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (ch<<16) | val);
       response->set_word_array("data",outData.data(), outData.size());
-      count++;
+      ++ohIdx;
   }
 
   rtxn.abort();
@@ -271,22 +271,22 @@ void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response)
   uint32_t ohMask = request->get_word("ohMask");
 
   SCAADCChannelT chArr[5] = {
-  			      SCAADCChannel::VTTX_CSC,
-  			      SCAADCChannel::VTTX_GEM,
+  			      SCAADCChannel::VTTX_CSC_PT100,
+  			      SCAADCChannel::VTTX_GEM_PT100,
   			      SCAADCChannel::SCA_PT100,
   			      SCAADCChannel::V6_FPGA_PT100,
   			      SCAADCChannel::SCA_TEMP
   			    };
-  int count;
+  int ohIdx;
   std::vector<uint32_t> result;
   std::vector<uint32_t> outData;
-  for(auto const& channelName : chArr){
-    result = scaADCCommand(&la, channelName, 0, 0, ohMask);
-    count = 0;
-    for(auto const& val : result){
-    	LOGGER->log_message(LogManager::DEBUG, stdsprintf("Temperature for OH%i, SCA-ADC channel 0x%x = %i ",count, channelName, val));
-	outData.push_back((bitCheck(ohMask, count) << 27) | (count<<24) | (channelName<<16) | val);
-	count++;
+  for(auto const& channelName : chArr) {
+    result = scaADCCommand(&la, channelName, ohMask);
+    ohIdx = 0;
+    for(auto const& val : result) {
+    	LOGGER->log_message(LogManager::DEBUG, stdsprintf("Temperature for OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, channelName, val));
+	outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (channelName<<16) | val);
+	++ohIdx;
     }
   }
   
@@ -310,16 +310,16 @@ void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response)
   			      SCAADCChannel::FPGA_MGT_V1P0,
   			      SCAADCChannel::FPGA_MGT_V1P2
   			    };
-  int count;
+  int ohIdx;
   std::vector<uint32_t> result;
   std::vector<uint32_t> outData;
-  for(auto const& channelName : chArr){
-    result = scaADCCommand(&la, channelName, 0, 0, ohMask);
-    count = 0;
-    for(auto const& val : result){
-        LOGGER->log_message(LogManager::DEBUG, stdsprintf("Voltage for OH%i, SCA-ADC channel 0x%x = %i ",count, channelName, val));
-	outData.push_back((bitCheck(ohMask, count) << 27) | (count<<24) | (channelName<<16) | val);
-	count++;
+  for(auto const& channelName : chArr) {
+    result = scaADCCommand(&la, channelName, ohMask);
+    ohIdx = 0;
+    for(auto const& val : result) {
+        LOGGER->log_message(LogManager::DEBUG, stdsprintf("Voltage for OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, channelName, val));
+	outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (channelName<<16) | val);
+	++ohIdx;
     }
   }
 
@@ -340,16 +340,16 @@ void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response)
   			      static_cast<SCAADCChannelT>(SCAADCChannel::VTRX_RSSI3)
   			    };
 
-  int count;
+  int ohIdx;
   std::vector<uint32_t> result;
   std::vector<uint32_t> outData;
-  for(auto const& channelName : chArr){
-    result = scaADCCommand(&la, channelName, 0, 0, ohMask);
-    count = 0;
-    for(auto const& val : result){
-        LOGGER->log_message(LogManager::DEBUG, stdsprintf("Signal strength for OH%i, SCA-ADC channel 0x%x = %i ",count, channelName, val));
-	outData.push_back((bitCheck(ohMask, count) << 27) | (count<<24) | (channelName<<16) | val);
-	count++;
+  for(auto const& channelName : chArr) {
+    result = scaADCCommand(&la, channelName, ohMask);
+    ohIdx = 0;
+    for(auto const& val : result) {
+        LOGGER->log_message(LogManager::DEBUG, stdsprintf("Signal strength for OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, channelName, val));
+	outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (channelName<<16) | val);
+	++ohIdx;
     }
   }
 
@@ -364,16 +364,16 @@ void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response)
 
   uint32_t ohMask = request->get_word("ohMask");
 
-  int count;
+  int ohIdx;
   std::vector<uint32_t> result;
   std::vector<uint32_t> outData;
-  for (SCAADCChannelT channelName = SCAADCChannel::VTTX_CSC; channelName<=SCAADCChannel::SCA_TEMP; channelName=SCAADCChannelT(channelName+1)) {
-    result = scaADCCommand(&la, channelName, 0, 0, ohMask);
-    count = 0;
-    for(auto const& val : result){
-      LOGGER->log_message(LogManager::DEBUG, stdsprintf("Reading of OH%i, SCA-ADC channel 0x%x = %i ",count, channelName, val));
-      outData.push_back((bitCheck(ohMask, count) << 27) | (count<<24) | (channelName<<16) | val);
-      count++;
+  for (SCAADCChannelT channelName = SCAADCChannel::VTTX_CSC_PT100; channelName<=SCAADCChannel::SCA_TEMP; channelName=SCAADCChannelT(channelName+1)) {
+    result = scaADCCommand(&la, channelName, ohMask);
+    ohIdx = 0;
+    for(auto const& val : result) {
+      LOGGER->log_message(LogManager::DEBUG, stdsprintf("Reading of OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, channelName, val));
+      outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (channelName<<16) | val);
+      ++ohIdx;
     }
   }
 

--- a/src/amc/sca.cpp
+++ b/src/amc/sca.cpp
@@ -131,13 +131,13 @@ std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, uin
 
 
   // enable the current sink if reading the temperature ADCs
-  if (ch == SCAADCChannel::VTTX_CSC_PT100 || ch == SCAADCChannel::VTTX_GEM_PT100 || ch == SCAADCChannel::SCA_PT100 || ch == SCAADCChannel::V6_FPGA_PT100 )	// Hardcoded channel numbers
+  if (SCAADCChannel::useCurrentSource(ch))
     sendSCACommand(la, SCAChannel::ADC, SCAADCCommand::ADC_W_CURR, 0x4, 0x1<<ch, ohMask);
   // start the conversion and get the result
   std::vector<uint32_t> result = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_GO, 0x4, 0x1, ohMask);
 
   // disable the current sink if reading the temperature ADCs
-  if (ch == SCAADCChannel::VTTX_CSC_PT100 || ch == SCAADCChannel::VTTX_GEM_PT100 || ch == SCAADCChannel::SCA_PT100 || ch == SCAADCChannel::V6_FPGA_PT100 )	// Hardcoded channel numbers
+  if (SCAADCChannel::useCurrentSource(ch))
     sendSCACommand(la, SCAChannel::ADC, SCAADCCommand::ADC_W_CURR, 0x4, 0x0<<ch, ohMask);
   // // get the last data
   // std::vector<uint32_t> last = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_DATA, 0x1, 0x0, ohMask);
@@ -273,7 +273,7 @@ void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response)
   SCAADCChannelT chArr[5] = {
   			      SCAADCChannel::VTTX_CSC_PT100,
   			      SCAADCChannel::VTTX_GEM_PT100,
-  			      SCAADCChannel::SCA_PT100,
+  			      SCAADCChannel::GBT0_PT100,
   			      SCAADCChannel::V6_FPGA_PT100,
   			      SCAADCChannel::SCA_TEMP
   			    };

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -131,12 +131,8 @@ void readRegFromDB(const RPCMsg *request, RPCMsg *response)
 uint32_t bitCheck(uint32_t word, int bit)
 {
   if (bit > 31)
-    throw std::invalid_argument("Invalid request to shift word by more than 31 bits");
-  if ( (word >> bit) & 1 ) {
-    return 1;
-  } else {
-    return 0;
-  }
+    throw std::invalid_argument("Invalid request to shift 32-bit word by more than 31 bits");
+  return (word >> bit) & 0x1;
 }
 
 uint32_t getNumNonzeroBits(uint32_t value)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -128,9 +128,11 @@ void readRegFromDB(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
-uint32_t bitCheck(uint32_t ohMask, int bit)
+uint32_t bitCheck(uint32_t word, int bit)
 {
-  if ( (ohMask >> bit) & 1 ){
+  if (bit > 31)
+    throw std::invalid_argument("Invalid request to shift word by more than 31 bits");
+  if ( (word >> bit) & 1 ) {
     return 1;
   } else {
     return 0;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -128,6 +128,15 @@ void readRegFromDB(const RPCMsg *request, RPCMsg *response)
   rtxn.abort();
 }
 
+uint32_t bitCheck(uint32_t ohMask, int bit)
+{
+  if ( (ohMask >> bit) & 1 ){
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
 uint32_t getNumNonzeroBits(uint32_t value)
 {
   // https://stackoverflow.com/questions/4244274/how-do-i-count-the-number-of-zero-bits-in-an-integer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added modules to read a specific SCA ADC or the similar type of SCA SCA sensors together, like temperature, voltage, etc.

## Description
<!--- Describe your changes in detail -->
There are 31 SCA ADC sensors defined ([here](https://github.com/ram1123/ctp7_modules/blob/f7590d67eeb06326ccaafe0d4aaf28fd1f52ecf8/include/amc/sca_enums.h#L211-L264)).  As requested in issue [#100](https://github.com/cms-gem-daq-project/ctp7_modules/issues/100), to create several function to read each ADC and all ADC, I added five different functions named `readSCAADCSensor`, `readSCAADCTemperatureSensors`, `readSCAADCVoltageSensors`,  `readSCAADCSignalStrengthSensors` and `readAllSCAADCSensors` to read individual sensors,  temperature sensors,  voltage related sensors, signal strength sensors and all sensors, respectively.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All added modules are tested using a macro named `blaster.cxx`.

```cpp
#include <iostream>
#include <fstream>
#include <random>
#include <iomanip>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <limits.h>
#include <errno.h>
#include <xhal/rpc/wiscrpcsvc.h>

using namespace wisc;

int main(int argc, char *argv[])
{
  RPCSvc rpc;
  try {
    rpc.connect(argv[1]);
  } catch (RPCSvc::ConnectionFailedException &e) {
    printf("Caught RPCErrorException: %s\n", e.message.c_str());
    return 1;
  } catch (RPCSvc::RPCException &e) {
    printf("Caught exception: %s\n", e.message.c_str());
    return 1;
  }

#define STANDARD_CATCH                                                  \
  catch (RPCSvc::NotConnectedException &e) {                            \
    printf("Caught NotConnectedException: %s\n", e.message.c_str());    \
    return 1;                                                           \
  } catch (RPCSvc::RPCErrorException &e) {                              \
    printf("Caught RPCErrorException: %s\n", e.message.c_str());        \
    return 1;                                                           \
  } catch (RPCSvc::RPCException &e) {                                   \
    printf("Caught exception: %s\n", e.message.c_str());                \
    return 1;                                                           \
  }

#define ASSERT(x) do {                                                  \
    if (!(x)) {                                                         \
      printf("Assertion Failed on line %u: %s\n", __LINE__, #x);        \
      return 1;                                                         \
    }                                                                   \
  } while (0)

  RPCMsg req, rsp;

  try {
    ASSERT(rpc.load_module("amc", "amc v1.0.1"));
  } STANDARD_CATCH;

  //req = RPCMsg("amc.readSCAADCSensor");
  req = RPCMsg("amc.readSCAADCTemperatureSensors");

  //errno = 0;
  //uint32_t sz = strtoul(argv[2], nullptr, 16);

  //if (errno != 0 /*|| *p != '\0'*/ || sz > INT_MAX) {
  //  errno = 0;
  //  sz = strtoul(argv[2], nullptr, 10);
  //  if (errno != 0 /*|| *p != '\0'*/ || sz > INT_MAX) {
  //    sz = 0;
  //  } else {
  //    // pass
  //  }
  //} else {
  //  // pass
  //}

  errno = 0;
  uint32_t ty = strtoul(argv[2], nullptr, 16);

  if (errno != 0 /*|| *p != '\0'*/ || ty > INT_MAX) {
    ty = 0;
  } else {
    // pass
  }

  //req.set_word("ch", 	sz);
  req.set_word("ohMask",ty);

  try {
    std::cout << "calling amc.readSCAADCTemperatureSensors on " << std::string(argv[1]) << " with " << ty << "...";
    //std::cout << "calling amc.readSCAADCTemperatureSensors on " << std::string(argv[1]) << " with " << sz << " and " << ty << "...";
    rsp = rpc.call_method(req);
    std::cout << "done!" << std::endl;
    if (rsp.get_key_exists("error")) {
      std::cout << "RPC ERROR:" << rsp.get_string("error") << std::endl;
      return 0;
    }

  
  return 0;
}
```

then running its executable after setting the environment and monitoring the log.


### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->