### PR TITLE
[Bug Fix] develop: Change check on ohMask

### DIFF
--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -602,11 +602,11 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     return;
 } //End sbitRateScanLocal(...)
 
-void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg, uint32_t ohMask=0x3FF)
+void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg, uint32_t ohMask=0xFFF)
 {
     char regBuf[200];
-    // Check that OH mask does not exceeds 0x3FF
-    if (ohMask > 0x3FF) {
+    // Check that OH mask does not exceeds 0xFFF
+    if (ohMask > 0xFFF) {
          LOGGER->log_message(LogManager::ERROR, "sbitRateScan supports only up to 12 optohybrids per CTP7");
          sprintf(regBuf,"sbitRateScan supports only up to 12 optohybrids per CTP7");
          la->response->set_string("error",regBuf);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
As https://github.com/cms-gem-daq-project/ctp7_modules/pull/121 but for `develop` branch.

`ohMask` was being called invalid if it was greater than `0x3ff` (10 bits), while the message claimed it was supporting 12 OptoHybrids

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See bug reported by @fsimone91 [here](https://mattermost.web.cern.ch/cms-gem-ops/pl/dufxrh5kofd4jejbcx3ggmfbhe)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
QC8 team was again able to take data, see [result](https://mattermost.web.cern.ch/cms-gem-ops/pl/gy3sqndbtpr55gcw6zgoaixkpc).

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
