### PR TITLE
Added remote callable function for confCalPulseLocal

### DIFF
--- a/include/calibration_routines.h
+++ b/include/calibration_routines.h
@@ -347,4 +347,17 @@ void dacScanMultiLink(const RPCMsg *request, RPCMsg *response);
  */
 void genChannelScan(const RPCMsg *request, RPCMsg *response);
 
+/*! \fn void confCalPulse(const RPCMsg *request, RPCMsg *response)
+ *  \brief Generic method for calibration pulse configuration. Local callable version of confCalPulseLocal.
+ *  \param[in] request RPC response message with the following keys:
+ *     - `word ohN` : optical link number
+ *     - `word mask`: VFAT mask
+ *     - `word ch`  : Channel of interest
+ *     - `word toggleOn`: if true (false) turns the calibration pulse on (off) for channel ch
+ *     - `word currentPulse`: Selects whether to use current or volage pulse
+ *     - `word calScaleFactor`: Scale factor for the calibration pulse height (00 = 25%, 01 = 50%, 10 = 75%, 11 = 100%)
+ *  \param response RPC response message
+ */
+void confCalPulse(const RPCMsg *request, RPCMsg *response);
+
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added remote callable function for confCalPulseLocal as described in Issue #129.

## Description
<!--- Describe your changes in detail -->
Added remote callable function for confCalPulseLocal. Along with it, I also updated the error message of in the local function confCalPulseLocal for the scenario having VFAT channel > 128.  

Previous behaviour

https://github.com/cms-gem-daq-project/ctp7_modules/blob/ab4ddd0019976031c39251b719c698873b978c45/src/calibration_routines.cpp#L45-L48

Current behaviour

```cpp
    else if (ch >= 128) { //Case: Bad Config, asked for OR of all channels
        la->response->set_string("error","confCalPulseLocal(): I was told to calpulse (on/off) channels > 128.");
        return false;
    } //End Case: Bad Config, asked for OR of all channels
```
https://github.com/ram1123/ctp7_modules/blob/ad9d0906773d139067c0b7dc05fbd918e2f17aca/src/calibration_routines.cpp#L56-L59

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by running the script using its various combination of input parameter. Then read the same written register using gem_reg.py tool.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All  tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->