### PR TITLE
Fix introduced regression in resetDAQLinkLocal

### DIFF
--- a/src/amc/daq.cpp
+++ b/src/amc/daq.cpp
@@ -36,7 +36,7 @@ void resetDAQLinkLocal(localArgs* la, uint32_t const& davTO, uint32_t const& tts
   LOGGER->log_message(LogManager::DEBUG, "resetDAQLinkLocal called");
   writeReg(la, "GEM_AMC.DAQ.CONTROL.RESET", 0x1);
   writeReg(la, "GEM_AMC.DAQ.CONTROL.RESET", 0x0);
-  disableDAQLinkLocal(la);
+  // disableDAQLinkLocal(la);
   writeReg(la, "GEM_AMC.DAQ.CONTROL.DAV_TIMEOUT", davTO);
   setDAQLinkInputTimeoutLocal(la);
   // setDAQLinkInputTimeoutLocal(la,davTO);


### PR DESCRIPTION
## Description
`resetDAQLinkLocal` when migrated from `cmsgemos` introduced the bug that it would disable the DAQ link during a reset.
This sequence was not fully validated, and that particular line was commented out in the original `HwGenericAMC.cc` function:

https://github.com/cms-gem-daq-project/cmsgemos/blob/a6a9ac740f30fd902e9f8628c067fde5d8ed2cfb/gemhardware/src/common/HwGenericAMC.cc#L484-L493

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context
DAQ link was being disabled during the `Start` transition

## How Has This Been Tested?
Tested with `feature/gemcalib` branch in 904, on integration stand
