### PR TITLE
[New Feature] variable waitTime for parallel sbitrate scans

### DIFF
--- a/include/calibration_routines.h
+++ b/include/calibration_routines.h
@@ -252,7 +252,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
  *  \param dacMax Maximal value of scan variable
  *  \param dacStep Scan variable change step
  *  \param scanReg DAC register to scan over name
- *  \param waitTime Amount of time to collect data, applies to the per-VFAT rates not the overall rate
+ *  \param waitTime Amount of time to collect data, applies to the per-VFAT rates not the overall rate, maximum is just more than 107 seconds
  */
 void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ohN, uint32_t vfatmask, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg);
 

--- a/include/calibration_routines.h
+++ b/include/calibration_routines.h
@@ -230,7 +230,7 @@ void genScan(const RPCMsg *request, RPCMsg *response);
  */
 void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRate, uint32_t ohN, uint32_t maskOh, bool invertVFATPos, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg, uint32_t waitTime);
 
-/*! \fn void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ohN, uint32_t vfatmask, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg)
+/*! \fn void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ohN, uint32_t vfatmask, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg, uint32_t waitTime)
  *  \brief Parallel SBIT rate scan. Local version of sbitRateScan
  *
  *  * Measures the SBIT rate seen by OHv3 ohN for the non-masked VFATs defined in vfatmask as a function of scanReg
@@ -252,6 +252,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
  *  \param dacMax Maximal value of scan variable
  *  \param dacStep Scan variable change step
  *  \param scanReg DAC register to scan over name
+ *  \param waitTime Amount of time to collect data, applies to the per-VFAT rates not the overall rate
  */
 void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ohN, uint32_t vfatmask, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg);
 

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -697,7 +697,7 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
                 } // End loop over optohybrids
 
                 //wait a little bit longer than the waitTime to allow for delays
-                std::this_thread::sleep_for(std::chrono::milliseconds(waitTime*1000+100));
+                std::this_thread::sleep_for(std::chrono::seconds(2*waitTime));
 
                 //Read the counters
                 for (unsigned int ohN = 0; ohN < amc::OH_PER_AMC; ++ohN) {
@@ -710,7 +710,6 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
                             if ( !( (notmask >> vfat) & 0x1)) continue;
 
                             idx = ohN*oh::VFATS_PER_OH*(dacMax-dacMin+1)/dacStep + vfat*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
-                            //divide by the waitTime in seconds to calculate the rate
                             outDataTrigRatePerVFAT[idx] = readRawAddress(ohTrigRateAddr[ohN][vfat], la->response);
                         } //End Loop Over all VFATs
                     } // End checking whether the OH is masked

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -696,8 +696,7 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
                     } // End checking whether the OH is masked
                 } // End loop over optohybrids
 
-                //wait a little bit longer than the waitTime to allow for delays
-                std::this_thread::sleep_for(std::chrono::seconds(2*waitTime));
+                std::this_thread::sleep_for(std::chrono::seconds(waitTime));
 
                 //Read the counters
                 for (unsigned int ohN = 0; ohN < amc::OH_PER_AMC; ++ohN) {

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -581,7 +581,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
             for (uint32_t dacVal = dacMin; dacVal <= dacMax; dacVal += dacStep) {
                 sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfatN,scanReg.c_str());
                 writeReg(la, regBuf, dacVal);
-                std::this_thread::sleep_for(std::chrono::milliseconds(waitTime));
+                std::this_thread::sleep_for(std::chrono::seconds(waitTime));
 
                 unsigned int idx = (dacVal-dacMin)/dacStep;
                 outDataDacVal[idx] = dacVal;
@@ -607,7 +607,7 @@ void sbitRateScanLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outData
     return;
 } //End sbitRateScanLocal(...)
 
-void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg, uint32_t waitTime, uint32_t ohMask=0xFFF)
+void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t *outDataTrigRatePerVFAT, uint32_t *outDataTrigRateOverall, uint32_t ch, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, std::string scanReg, uint32_t ohMask=0xFFF, uint32_t waitTime=1)
 {
     char regBuf[200];
     // Check that OH mask does not exceeds 0xFFF
@@ -708,7 +708,7 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
 
                             idx = ohN*oh::VFATS_PER_OH*(dacMax-dacMin+1)/dacStep + vfat*(dacMax-dacMin+1)/dacStep+(dacVal-dacMin)/dacStep;
                             //divide by the waitTime in seconds to calculate the rate
-                            outDataTrigRatePerVFAT[idx] = readRawAddress(ohTrigRateAddr[ohN][vfat], la->response)*float(1000)/float(waitTime);
+                            outDataTrigRatePerVFAT[idx] = readRawAddress(ohTrigRateAddr[ohN][vfat], la->response);
                         } //End Loop Over all VFATs
                     } // End checking whether the OH is masked
                 } // End loop over optohybrids
@@ -761,7 +761,7 @@ void sbitRateScan(const RPCMsg *request, RPCMsg *response)
     uint32_t outDataTrigRatePerVFAT[amc::OH_PER_AMC*oh::VFATS_PER_OH*(dacMax-dacMin+1)/dacStep];
     uint32_t outDataDacValPerOH[amc::OH_PER_AMC*(dacMax-dacMin+1)/dacStep];
     uint32_t outDataTrigRatePerOH[amc::OH_PER_AMC*(dacMax-dacMin+1)/dacStep];
-    sbitRateScanParallelLocal(&la, outDataDacValPerOH, outDataTrigRatePerVFAT, outDataTrigRatePerOH, ch, dacMin, dacMax, dacStep, scanReg, waitTime, ohMask);
+    sbitRateScanParallelLocal(&la, outDataDacValPerOH, outDataTrigRatePerVFAT, outDataTrigRatePerOH, ch, dacMin, dacMax, dacStep, scanReg, ohMask, waitTime);
 
     response->set_word_array("outDataVFATRate", outDataTrigRatePerVFAT, amc::OH_PER_AMC*oh::VFATS_PER_OH*(dacMax-dacMin+1)/dacStep);
     response->set_word_array("outDataDacValue", outDataDacValPerOH, amc::OH_PER_AMC*(dacMax-dacMin+1)/dacStep);


### PR DESCRIPTION
This is one of four pull requests to four repositories that make the data collection time for parallel sbitrate scans configurable.

## Description
The time to collect the data was previously hard-coded to 1005 milliseconds. This pull requests sets it to the new argument `waitTime`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This was requested in https://github.com/cms-gem-daq-project/ctp7_modules/issues/154

## How Has This Been Tested?
Yes, I performed an sbitThresh scan with the waitTime set to 1000 and the waitTime set to 10000, and found the rates were very close while the second scan took around 10 times longer.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
