### PR TITLE
[bugfix] SCA readout update

### DIFF
--- a/include/amc/sca.h
+++ b/include/amc/sca.h
@@ -183,12 +183,13 @@ void resetSCASEUCounter(const RPCMsg *request, RPCMsg *response);
  *
  *  \param[out] response RPC response message with the following keys:
  *  	- `word_array data` : ADC data is returned as an array of 32-bit words formatted as:
- *  			      bit [27]: data present
- *  			      bits [26:24]: link ID
+ *  			      bits [31:29]: constant 0's
+ *  			      bit  [28]   : data present
+ *  			      bits [27:24]: link ID
  *  			      bits [23:21]: constant 0's
  *  			      bits [20:16]: ADC channel ID
  *  			      bits [15:12]: constant 0's
- *  			      bits [11:0]: ADC data
+ *  			      bits [11:0] : ADC data
  */
 void readSCAADCSensor(const RPCMsg *request, RPCMsg *response);
 
@@ -200,63 +201,67 @@ void readSCAADCSensor(const RPCMsg *request, RPCMsg *response);
  *
  *  \param[out] response RPC response message with the following keys:
  *  	- `word_array data` : ADC data is returned as an array of 32-bit words formatted as:
- *  			      bit [27]: data present
- *  			      bits [26:24]: link ID
+ *  			      bits [31:29]: constant 0's
+ *  			      bit  [28]   : data present
+ *  			      bits [27:24]: link ID
  *  			      bits [23:21]: constant 0's
  *  			      bits [20:16]: ADC channel ID
  *  			      bits [15:12]: constant 0's
- *  			      bits [11:0]: ADC data
+ *  			      bits [11:0] : ADC data
  */
 void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response)
- *  \brief Read all SCA ADC voltages sensors. They are 1B, 1E, 11, 0E, 18 and 0F. 
+ *  \brief Read all SCA ADC voltages sensors. They are 1B, 1E, 11, 0E, 18 and 0F.
  *  \param[in] request RPC response message with the following keys:
  *  	- `word ohMask` : This specifies which OH's to read from
  *
  *  \param[out] response RPC response message with the following keys:
  *  	- `word_array data` : ADC data is returned as an array of 32-bit words formatted as:
- *  			      bit [27]: data present
- *  			      bits [26:24]: link ID
+ *  			      bits [31:29]: constant 0's
+ *  			      bit  [28]   : data present
+ *  			      bits [27:24]: link ID
  *  			      bits [23:21]: constant 0's
  *  			      bits [20:16]: ADC channel ID
  *  			      bits [15:12]: constant 0's
- *  			      bits [11:0]: ADC data
+ *  			      bits [11:0] : ADC data
  */
 void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response)
- *  \brief Read the SCA ADC signal strength sensors. They are 15, 13 and 12. 
+ *  \brief Read the SCA ADC signal strength sensors. They are 15, 13 and 12.
  *  \param[in] request RPC response message with the following keys:
  *  	- `word ohMask` : This specifies which OH's to read from
  *
  *  \param[out] response RPC response message with the following keys:
  *  	- `word_array data` : ADC data is returned as an array of 32-bit words formatted as:
- *  			      bit [27]: data present
- *  			      bits [26:24]: link ID
+ *  			      bits [31:29]: constant 0's
+ *  			      bit  [28]   : data present
+ *  			      bits [27:24]: link ID
  *  			      bits [23:21]: constant 0's
  *  			      bits [20:16]: ADC channel ID
  *  			      bits [15:12]: constant 0's
- *  			      bits [11:0]: ADC data
+ *  			      bits [11:0] : ADC data
  */
 void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response);
 
 /*!
  *  \fn void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response)
- *  \brief Read all connected SCA ADC sensors. 
+ *  \brief Read all connected SCA ADC sensors.
  *  \param[in] request RPC response message with the following keys:
  *  	- `word ohMask` : This specifies which OH's to read from
  *
  *  \param[out] response RPC response message with the following keys:
  *  	- `word_array data` : ADC data is returned as an array of 32-bit words formatted as:
- *  			      bit [27]: data present
- *  			      bits [26:24]: link ID
+ *  			      bits [31:29]: constant 0's
+ *  			      bit  [28]   : data present
+ *  			      bits [27:24]: link ID
  *  			      bits [23:21]: constant 0's
  *  			      bits [20:16]: ADC channel ID
  *  			      bits [15:12]: constant 0's
- *  			      bits [11:0]: ADC data
+ *  			      bits [11:0] : ADC data
  */
 void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response);
 

--- a/include/amc/sca_enums.h
+++ b/include/amc/sca_enums.h
@@ -212,7 +212,7 @@ class SCASettings {
     enum EADCChannel { //ADCChannel settings
       // ADC 12-bit range
       // * Voltage 0-1V (1V/0xfff) LSB, offset 0V
-      // * Temperature -30-80C (110C/0xfff) LSB, offset -30Cbusiness/SitePages/Fermilab%20Official%20Travel.aspx
+      // * Temperature -30-80C (110C/0xfff) LSB, offset -30C
       AVCCN_V1P0     = 27, ///< FPGA MGT 1.0V
       AVTTN_V1P2     = 30, ///< FPGA MGT 1.2V
       INT_V1P0       = 17, ///< 1.0V FPGA core voltage
@@ -234,7 +234,7 @@ class SCASettings {
       // SCA ADC temperature sensors
       VTTX_CSC_PT100 = 0x00, ///< Transceiver block next to the CSC VTTX
       VTTX_GEM_PT100 = 0x04, ///< Transceiver block next to the GEM VTTX
-      GBT0_PT100      = 0x07, ///< SCA temperature sensor
+      GBT0_PT100     = 0x07, ///< SCA temperature sensor
       V6_FPGA_PT100  = 0x08, ///< Virtex6 temperature sensor
 
       // SCA ADC signal strength sensors

--- a/include/utils.h
+++ b/include/utils.h
@@ -143,6 +143,15 @@ uint32_t bitCheck(uint32_t word, int bit);
  */
 uint32_t getNumNonzeroBits(uint32_t value);
 
+
+/*! \fn bool regExists(LocalArgs * la, const std::string & regName)
+ *  \brief Returns whether or not a named register can be found in the LMDB
+ *  \param la Local arguments structure
+ *  \param regName Register name
+ *  \param db_res pointer to a lmdb::val result that the calling function requires
+ */
+bool regExists(LocalArgs * la, const std::string & regName, lmdb::val * db_res=nullptr);
+
 /*! \fn uint32_t getMask(LocalArgs * la, const std::string & regName)
  *  \brief Returns the mask for a given register
  *  \param la Local arguments structure

--- a/src/amc/sca.cpp
+++ b/src/amc/sca.cpp
@@ -18,7 +18,10 @@ uint32_t formatSCAData(uint32_t const& data)
 
 void sendSCACommand(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask)
 {
-  // FIXME: DECIDE WHETHER TO HAVE HERE // writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",         0xffffffff);
+  // FIXME: DECIDE WHETHER TO HAVE HERE // if (regExists(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  // FIXME: DECIDE WHETHER TO HAVE HERE //   writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",         0xffffffff);
+  // FIXME: DECIDE WHETHER TO HAVE HERE // }
+
   writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.LINK_ENABLE_MASK",       ohMask);
   writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_CHANNEL",ch);
   writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_COMMAND",cmd);
@@ -29,8 +32,10 @@ void sendSCACommand(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_
 
 std::vector<uint32_t> sendSCACommandWithReply(localArgs* la, uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask)
 {
-  // FIXME: DECIDE WHETHER TO HAVE HERE // uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
-  // FIXME: DECIDE WHETHER TO HAVE HERE // writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+  // FIXME: DECIDE WHETHER TO HAVE HERE // if (regExists(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  // FIXME: DECIDE WHETHER TO HAVE HERE //   uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
+  // FIXME: DECIDE WHETHER TO HAVE HERE //   writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+  // FIXME: DECIDE WHETHER TO HAVE HERE // }
 
   sendSCACommand(la, ch, cmd, len, data, ohMask);
 
@@ -54,8 +59,11 @@ std::vector<uint32_t> sendSCACommandWithReply(localArgs* la, uint8_t const& ch, 
 
 std::vector<uint32_t> scaCTRLCommand(localArgs* la, SCACTRLCommandT const& cmd, uint16_t const& ohMask, uint8_t const& len, uint32_t const& data)
 {
-  uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
-  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+  uint32_t monMask = 0xffffffff;
+  if (regExists(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+    monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
+    writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+  }
 
   std::vector<uint32_t> result;
   switch (cmd) {
@@ -84,7 +92,10 @@ std::vector<uint32_t> scaCTRLCommand(localArgs* la, SCACTRLCommandT const& cmd, 
     result = sendSCACommandWithReply(la, SCAChannel::CTRL, SCACTRLCommand::GET_DATA, len, data, ohMask);
   }
 
-  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
+  if (regExists(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+    writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
+  }
+
   return result;
 }
 
@@ -99,12 +110,17 @@ std::vector<uint32_t> scaI2CCommand(localArgs* la, SCAI2CChannelT const& ch, SCA
 
   std::vector<uint32_t> result;
 
-  uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
-  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+  uint32_t monMask = 0xffffffff;
+  if (regExists(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+    monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
+    writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+  }
 
   sendSCACommand(la, ch, cmd, len, data, ohMask);
 
-  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
+  if (regExists(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+    writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
+  }
 
   return result;
 }
@@ -112,19 +128,28 @@ std::vector<uint32_t> scaI2CCommand(localArgs* la, SCAI2CChannelT const& ch, SCA
 std::vector<uint32_t> scaGPIOCommandLocal(localArgs* la, SCAGPIOCommandT const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask)
 {
   // enable the GPIO bus through the CTRL CRB register, bit 2
-  uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
-  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+  uint32_t monMask = 0xffffffff;
+  if (regExists(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+    monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
+    writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+  }
 
   std::vector<uint32_t> reply = sendSCACommandWithReply(la, SCAChannel::GPIO, cmd, len, data, ohMask);
 
-  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
+  if (regExists(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+    writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
+  }
+
   return reply;
 }
 
 std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, uint16_t const& ohMask)
 {
-  uint32_t monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
-  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+  uint32_t monMask = 0xffffffff;
+  if (regExists(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+    monMask = readReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
+    writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
+  }
 
   // enable the ADC bus through the CTRL CRD register, bit 4
   // select the ADC channel
@@ -147,7 +172,9 @@ std::vector<uint32_t> scaADCCommand(localArgs* la, SCAADCChannelT const& ch, uin
   // // get the offset
   // std::vector<uint32_t> raw  = sendSCACommandWithReply(la, SCAChannel::ADC, SCAADCCommand::ADC_R_OFS, 0x1, 0x0, ohMask);
 
-  writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
+  if (regExists(la, "GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+    writeReg(la,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
+  }
 
   return result;
 }
@@ -248,7 +275,7 @@ void readSCAADCSensor(const RPCMsg *request, RPCMsg *response)
 
   const uint32_t ohMask   = request->get_key_exists("ohMask") ? request->get_word("ohMask") : amc::FULL_OH_MASK;
   SCAADCChannelT  ch = static_cast<SCAADCChannelT>(request->get_word("ch"));
-  
+
   std::vector<uint32_t> result;
   std::vector<uint32_t> outData;
 
@@ -256,7 +283,7 @@ void readSCAADCSensor(const RPCMsg *request, RPCMsg *response)
 
   int ohIdx = 0;
   for(auto const& val : result) {
-      LOGGER->log_message(LogManager::DEBUG, stdsprintf("Value for OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, ch, val)); 
+      LOGGER->log_message(LogManager::DEBUG, stdsprintf("Value for OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, ch, val));
       outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (ch<<16) | val);
       response->set_word_array("data",outData);
       ++ohIdx;
@@ -290,7 +317,7 @@ void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response)
 	++ohIdx;
     }
   }
-  
+
   response->set_word_array("data", outData);
 
   rtxn.abort();
@@ -381,4 +408,3 @@ void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response)
 
   rtxn.abort();
 }
-

--- a/src/amc/sca.cpp
+++ b/src/amc/sca.cpp
@@ -284,7 +284,7 @@ void readSCAADCSensor(const RPCMsg *request, RPCMsg *response)
   int ohIdx = 0;
   for(auto const& val : result) {
       LOGGER->log_message(LogManager::DEBUG, stdsprintf("Value for OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, ch, val));
-      outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (ch<<16) | val);
+      outData.push_back((bitCheck(ohMask, ohIdx)<<28) | (ohIdx<<24) | (ch<<16) | val);
       response->set_word_array("data",outData);
       ++ohIdx;
   }
@@ -313,7 +313,7 @@ void readSCAADCTemperatureSensors(const RPCMsg *request, RPCMsg *response)
     ohIdx = 0;
     for(auto const& val : result) {
     	LOGGER->log_message(LogManager::DEBUG, stdsprintf("Temperature for OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, channelName, val));
-	outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (channelName<<16) | val);
+	outData.push_back((bitCheck(ohMask, ohIdx)<<28) | (ohIdx<<24) | (channelName<<16) | val);
 	++ohIdx;
     }
   }
@@ -345,7 +345,7 @@ void readSCAADCVoltageSensors(const RPCMsg *request, RPCMsg *response)
     ohIdx = 0;
     for(auto const& val : result) {
         LOGGER->log_message(LogManager::DEBUG, stdsprintf("Voltage for OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, channelName, val));
-	outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (channelName<<16) | val);
+	outData.push_back((bitCheck(ohMask, ohIdx)<<28) | (ohIdx<<24) | (channelName<<16) | val);
 	++ohIdx;
     }
   }
@@ -375,7 +375,7 @@ void readSCAADCSignalStrengthSensors(const RPCMsg *request, RPCMsg *response)
     ohIdx = 0;
     for(auto const& val : result) {
         LOGGER->log_message(LogManager::DEBUG, stdsprintf("Signal strength for OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, channelName, val));
-	outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (channelName<<16) | val);
+	outData.push_back((bitCheck(ohMask, ohIdx)<<28) | (ohIdx<<24) | (channelName<<16) | val);
 	++ohIdx;
     }
   }
@@ -399,7 +399,7 @@ void readAllSCAADCSensors(const RPCMsg *request, RPCMsg *response)
     ohIdx = 0;
     for(auto const& val : result) {
       LOGGER->log_message(LogManager::DEBUG, stdsprintf("Reading of OH%i, SCA-ADC channel 0x%x = %i ",ohIdx, channelName, val));
-      outData.push_back((bitCheck(ohMask, ohIdx) << 27) | (ohIdx<<24) | (channelName<<16) | val);
+      outData.push_back((bitCheck(ohMask, ohIdx)<<28) | (ohIdx<<24) | (channelName<<16) | val);
       ++ohIdx;
     }
   }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -148,14 +148,23 @@ uint32_t getNumNonzeroBits(uint32_t value)
   return numNonzeroBits;
 }
 
+bool regExists(localArgs * la, const std::string & regName, lmdb::val * db_res)
+{
+  lmdb::val key;
+  key.assign(regName.c_str());
+  if (db_res != nullptr) {
+    return la->dbi.get(la->rtxn,key, *db_res);
+  } else {
+    lmdb::val db_res_loc;
+    return la->dbi.get(la->rtxn,key,db_res_loc);
+  }
+}
+
 uint32_t getMask(localArgs * la, const std::string & regName)
 {
-  lmdb::val key, db_res;
-  bool found=false;
-  key.assign(regName.c_str());
-  found = la->dbi.get(la->rtxn,key,db_res);
+  lmdb::val db_res;
   uint32_t rmask = 0x0;
-  if (found) {
+  if (regExists(la, regName, &db_res)) {
     std::string t_db_res = std::string(db_res.data());
     t_db_res = t_db_res.substr(0,db_res.size());
     std::vector<std::string> tmp = split(t_db_res,'|');
@@ -189,12 +198,9 @@ uint32_t readRawAddress(uint32_t address, RPCMsg* response)
 
 uint32_t getAddress(localArgs * la, const std::string & regName)
 {
-  lmdb::val key, db_res;
-  bool found;
-  key.assign(regName.c_str());
-  found = la->dbi.get(la->rtxn,key,db_res);
   uint32_t raddr;
-  if (found){
+  lmdb::val db_res;
+  if (regExists(la, regName, &db_res)) {
     std::string t_db_res = std::string(db_res.data());
     t_db_res = t_db_res.substr(0,db_res.size());
     std::vector<std::string> tmp = split(t_db_res,'|');
@@ -248,10 +254,8 @@ uint32_t readAddress(lmdb::val & db_res, RPCMsg *response)
 
 void writeRawReg(localArgs * la, const std::string & regName, uint32_t value)
 {
-  lmdb::val key, db_res;
-  key.assign(regName.c_str());
-  bool found = la->dbi.get(la->rtxn,key,db_res);
-  if (found) {
+  lmdb::val db_res;
+  if (regExists(la, regName, &db_res)) {
     writeAddress(db_res, value, la->response);
   } else {
     LOGGER->log_message(LogManager::ERROR, stdsprintf("Key: %s is NOT found", regName.c_str()));
@@ -261,10 +265,8 @@ void writeRawReg(localArgs * la, const std::string & regName, uint32_t value)
 
 uint32_t readRawReg(localArgs * la, const std::string & regName)
 {
-  lmdb::val key, db_res;
-  key.assign(regName.c_str());
-  bool found = la->dbi.get(la->rtxn,key,db_res);
-  if (found) {
+  lmdb::val db_res;
+  if (regExists(la, regName, &db_res)) {
     return readAddress(db_res, la->response);
   } else {
     LOGGER->log_message(LogManager::ERROR, stdsprintf("Key: %s is NOT found", regName.c_str()));
@@ -289,10 +291,8 @@ uint32_t applyMask(uint32_t data, uint32_t mask)
 
 uint32_t readReg(localArgs * la, const std::string & regName)
 {
-  lmdb::val key, db_res;
-  key.assign(regName.c_str());
-  bool found = la->dbi.get(la->rtxn,key,db_res);
-  if (found) {
+  lmdb::val db_res;
+  if (regExists(la, regName, &db_res)) {
     std::string t_db_res = std::string(db_res.data());
     t_db_res = t_db_res.substr(0,db_res.size());
     std::vector<std::string> tmp = split(t_db_res,'|');
@@ -324,10 +324,8 @@ uint32_t readReg(localArgs * la, const std::string & regName)
 
 uint32_t readBlock(localArgs* la, const std::string& regName, uint32_t* result, const uint32_t& size, const uint32_t& offset)
 {
-  lmdb::val key, db_res;
-  key.assign(regName.c_str());
-  bool found = la->dbi.get(la->rtxn,key,db_res);
-  if (found) {
+  lmdb::val db_res;
+  if (regExists(la, regName, &db_res)) {
     std::string t_db_res = std::string(db_res.data());
     t_db_res = t_db_res.substr(0,db_res.size());
     std::vector<std::string> tmp = split(t_db_res,'|');
@@ -422,10 +420,8 @@ slowCtrlErrCntVFAT repeatedRegReadLocal(localArgs * la, const std::string & regN
 
 void writeReg(localArgs * la, const std::string & regName, uint32_t value)
 {
-  lmdb::val key, db_res;
-  key.assign(regName.c_str());
-  bool found = la->dbi.get(la->rtxn,key,db_res);
-  if (found) {
+  lmdb::val db_res;
+  if (regExists(la, regName, &db_res)) {
     std::string t_db_res = std::string(db_res.data());
     t_db_res = t_db_res.substr(0,db_res.size());
     std::vector<std::string> tmp = split(t_db_res,'|');
@@ -465,10 +461,8 @@ void writeReg(localArgs * la, const std::string & regName, uint32_t value)
 
 void writeBlock(localArgs* la, const std::string& regName, const uint32_t* values, const uint32_t& size, const uint32_t& offset)
 {
-  lmdb::val key, db_res;
-  key.assign(regName.c_str());
-  bool found = la->dbi.get(la->rtxn,key,db_res);
-  if (found) {
+  lmdb::val db_res;
+  if (regExists(la, regName, &db_res)) {
     std::string t_db_res = std::string(db_res.data());
     t_db_res = t_db_res.substr(0,db_res.size());
     std::vector<std::string> tmp = split(t_db_res,'|');


### PR DESCRIPTION
## Description
Several issues were present with the SCA readout:
* The changes to the `.ADC_MONITORING.MONITORING_OFF` register had not been forward propagated
  * Added a new function in `utils` ` bool regExists(localArgs * la, const std::string & regName, lmdb::val * db_res)` that is called in all the read/write functions in place of the register name lookup, as this allows other code to check whether the register exists in the LMDB, even if they don't need to create a valid `lmdb::val` object
* The output data format was not tested for 12 OptoHybrids, and was truncating

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context
Needed to reliably monitor the sensors from the SCA

## How Has This Been Tested?
Problem discovered and tested at P5
