### PR TITLE
[Bugfix] Fix channel masking in the per-channel Sbit rate scans

### DIFF
--- a/include/calibration_routines.h
+++ b/include/calibration_routines.h
@@ -54,22 +54,22 @@ struct vfat3DACAndSize{
     }
 };
 
-/*! \fn std::unordered_map<uint32_t, uint32_t> setSingleChanMask(unsigned int ohN, int vfatN, unsigned int ch, localArgs *la)
+/*! \fn std::unordered_map<std::string, uint32_t> setSingleChanMask(unsigned int ohN, int vfatN, unsigned int ch, localArgs *la)
  *  \brief Unmask the channel of interest and masks all the other
  *  \param ohN Optical link number
  *  \param vfatN VFAT position
  *  \param ch Channel of interest
  *  \param la Local arguments structure
- *  \return Original channel mask in a form of an unordered map <chanMaskAddr, mask>
+ *  \return Original channel mask in a form of an unordered map <chanMaskRegName, mask>
  */
-std::unordered_map<uint32_t, uint32_t> setSingleChanMask(unsigned int ohN, int vfatN, unsigned int ch, localArgs *la);
+std::unordered_map<std::string, uint32_t> setSingleChanMask(unsigned int ohN, int vfatN, unsigned int ch, localArgs *la);
 
-/*! \fn void applyChanMask(std::unordered_map<uint32_t, uint32_t> map_chanOrigMask, localArgs *la)
+/*! \fn void applyChanMask(std::unordered_map<std::string, uint32_t> map_chanOrigMask, localArgs *la)
  *  \brief Applies channel mask
  *  \param map_chanOrigMask Original channel mask as obtained from setSingleChanMask mehod
  *  \param la Local arguments structure
  */
-void applyChanMask(std::unordered_map<uint32_t, uint32_t> map_chanOrigMask, localArgs *la);
+void applyChanMask(std::unordered_map<std::string, uint32_t> map_chanOrigMask, localArgs *la);
 
 /*! \fn void confCalPulseLocal(localArgs *la, uint32_t ohN, uint32_t mask, uint32_t ch, bool toggleOn, bool currentPulse, uint32_t calScaleFactor)
  *  \brief Configures the calibration pulse for channel ch on all VFATs of ohN that are not in mask to either be on (toggleOn==true) or off (toggleOn==false).  If ch == 128 and toggleOn == False will write the CALPULSE_ENABLE bit for all channels of all vfats that are not masked on ohN to 0x0.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR fixes an issue in the per-channel Sbit rate vs `THR_ARM_DAC` scan reported by @mexanick and discussed in a separate email thread.

Here is the relevant quote:

>  I have been digging the per-channel Sbit rate scan issue and I believe to have found the issue. Indeed, the VFAT channels are **not** actually masked. For example, these are the VFAT channel masks set **during** a per-channel Sbit rate scan:
>
> eagle63 > rwc GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL*.MASK
0x6568019c rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL103.MASK
0x00000000
0x656801a0 rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL104.MASK
0x00000000
0x656801a4 rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL105.MASK
0x00000000
0x656801a8 rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL106.MASK
0x00000000
0x656801ac rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL107.MASK
0x00000000
[...]
>
> i.e. the channels are not masked. In fact, this is even worse. The scan routine corrupts the VFAT per-channel registers:
>
> eagle63 > kw GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL100
0x65680190 rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL100 0x00000001
0x65680190 rw GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL100.CALPULSE_ENABLE 0x00000000
0x65680190 rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL100.MASK 0x00000000
0x65680190 rw
GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL100.ZCC_TRIM_POLARITY 0x00000000
0x65680190 rw
GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL100.ZCC_TRIM_AMPLITUDE
0x00000000
0x65680190 rw
GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL100.ARM_TRIM_POLARITY
0x00000000
0x65680190 rw
GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL100.ARM_TRIM_AMPLITUDE
0x00000001
>
> As you have probably understood by now, this is a register mask issue in the software. After a quick and dirty fix, I get the desired behavior:
>
> eagle63 > rwc GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL*.MASK
0x6568019c rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL103.MASK
0x00000001
0x656801a0 rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL104.MASK
0x00000001
0x656801a4 rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL105.MASK
0x00000001
0x656801a8 rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL106.MASK
0x00000001
0x656801ac rw   GEM_AMC.OH.OH10.GEB.VFAT0.VFAT_CHANNELS.CHANNEL107.MASK
0x00000001
[...]

## Description
<!--- Describe your changes in detail -->

Before this PR, the `setSingleChanMask` and `applyChanMask` functions were using the raw register write method `writeRawAddress` which does perform an **unmasked** write. Since the mask bit is not the LSB in the per-channel VFAT configuration, the channels were not masked. As a side effect, the per-channel configuration was corrupted (even after the channel mask restoration).

The fix uses the method `writeReg` which performs a masked write which the appropriate mask (from the LMDB). The `setSingleChanMask` and `applyChanMask` signatures had to be changed to use a `std::map` indexed by `std::string`s rather than `std::uin32_t`s. All the calls in the code base have been adapted.

The bugfix targets only the `release/v1.1.X` branch. Indeed, the behavior is not exception-safe so that a different, and more versatile method, should be used in the `feature/remplated-rpc-methods` branch.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

See first paragraphs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The per-channel Sbit rate vs `THR_ARM_DAC` scan runs seamlessly and shows varying behavior across the VFAT channels (see the screenshots).

### Screenshots (if appropriate):

Before the fix all the channels present the same Sbit rate vs `THR_ARM_DAC` behavior:

![canv_Summary_Rate2D_vs_THR_ARM_DAC_GE11-TestStand10](https://user-images.githubusercontent.com/33247723/71903294-0c3c7200-3164-11ea-88cd-8a5798e9b5b1.png)

After the fix the channels present varying Sbit rate vs `THR_ARM_DAC` behaviors:

![canv_Summary_Rate2D_vs_THR_ARM_DAC_GE11-TestStand10](https://user-images.githubusercontent.com/33247723/71903302-12325300-3164-11ea-9c2f-6104019b3480.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->