### PR TITLE
Minimal working version of the templated RPC methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-TARGETS := arm \
-	x86_64
+TARGETS := arm #x86_64
 
 TARGETS.RPM        := $(patsubst %,%.rpm,         $(TARGETS))
 TARGETS.CLEAN      := $(patsubst %,%.clean,       $(TARGETS))

--- a/include/ctp7_modules/common/amc/ttc.h
+++ b/include/ctp7_modules/common/amc/ttc.h
@@ -67,7 +67,7 @@ namespace amc {
      */
     struct checkPLLLock : public xhal::common::rpc::Method
     {
-      int operator()(int readAttempts) const;
+      std::uint32_t operator()(const std::uint32_t readAttempts) const;
     };
 
     /*!
@@ -81,7 +81,7 @@ namespace amc {
      */
     struct getMMCMPhaseMean : public xhal::common::rpc::Method
     {
-      float operator()(int readAttempts) const;
+      float operator()(const std::uint32_t readAttempts) const;
     };
 
     /*!
@@ -95,7 +95,7 @@ namespace amc {
      */
     struct getGTHPhaseMean : public xhal::common::rpc::Method
     {
-      float operator()(int readAttempts) const;
+      float operator()(const std::uint32_t readAttempts) const;
     };
 
     /*!
@@ -107,7 +107,7 @@ namespace amc {
      */
     struct getMMCMPhaseMedian : public xhal::common::rpc::Method
     {
-      float operator()(int readAttempts) const;
+      float operator()(const std::uint32_t readAttempts) const;
     };
 
     /*!
@@ -119,7 +119,7 @@ namespace amc {
      */
     struct getGTHPhaseMedian : public xhal::common::rpc::Method
     {
-      float operator()(int readAttempts) const;
+      float operator()(const std::uint32_t readAttempts) const;
     };
 
     /*!

--- a/include/ctp7_modules/common/utils.h
+++ b/include/ctp7_modules/common/utils.h
@@ -16,47 +16,6 @@
 #include <iomanip>
 #include <string>
 
-namespace xhal {
-  namespace common {
-    namespace rpc {
-      template<typename Message>
-      inline void serialize(Message &msg, int &value) {
-        msg & value;
-      }
-
-      template<typename Message>
-      inline void serialize(Message &msg, bool &value) {
-        msg & value;
-      }
-
-      template<typename Message>
-      inline void serialize(Message &msg, uint8_t &value) {
-        msg & value;
-      }
-
-      template<typename Message>
-      inline void serialize(Message &msg, uint16_t &value) {
-        msg & value;
-      }
-
-      template<typename Message>
-      inline void serialize(Message &msg, size_t &value) {
-        msg & value;
-      }
-
-      template<typename Message>
-      inline void serialize(Message &msg, float &value) {
-        msg & *(reinterpret_cast<uint32_t*>(&value));
-      }
-
-      /* template<typename Message> */
-      /* inline void serialize(Message &msg, double &value) { */
-      /*   msg & *(reinterpret_cast<uint32_t*>(&value)); */
-      /* } */
-    }
-  }
-}
-
 namespace utils {
 
     /*!

--- a/include/ctp7_modules/server/utils.h
+++ b/include/ctp7_modules/server/utils.h
@@ -78,18 +78,6 @@ namespace utils {
     void initLogging();
 
     /*!
-     *  \brief This macro is used to terminate a function if an error occurs.
-     *         It logs the message  and returns the \c error_code value.
-     *
-     *  \param \c message The \c std::string error message.
-     *  \param \c error_code Value that is passed to the \c return statement.
-     */
-#define EMIT_RPC_ERROR(message, error_code) {           \
-      LOG4CPLUS_ERROR(logger, message);                 \
-      return error_code;                                \
-    }
-
-    /*!
      *  \brief return 1 if the given bit in word is 1 else 0
      *
      *  \param \c word: an unsigned int of 32 bit

--- a/include/ctp7_modules/server/utils.h
+++ b/include/ctp7_modules/server/utils.h
@@ -35,15 +35,6 @@ log4cplus.appender.syslog.layout.ConversionPattern= %h[%i] - %M - %m
 
 namespace utils {
 
-    /*!
-     *  \brief Contains arguments required to execute an LMDB transaction
-     */
-    struct LocalArgs
-    {
-        lmdb::txn &rtxn; ///< LMDB transaction handle
-        lmdb::dbi &dbi;  ///< LMDB individual database handle
-    };
-
     static constexpr uint32_t LMDB_SIZE = 1UL * 1024UL * 1024UL * 50UL; ///< Maximum size of the LMDB object, currently 50 MiB
 
     /*!

--- a/include/ctp7_modules/server/utils.h
+++ b/include/ctp7_modules/server/utils.h
@@ -11,7 +11,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-#include <experimental/optional>
 
 extern memsvc_handle_t memsvc; /// \var global memory service handle required for registers read/write operations
 /* extern log4cplus logger; /// \var global logger */
@@ -104,9 +103,9 @@ namespace utils {
      *
      *  \param \c regName Register name
      *
-     *  \return An optional \c std::string containing the content of the LMDB register, if it exists
+     *  \return A \c std::vector<std::string> containing the parsed content of the LMDB register. Is empty if the register does not exist.
      */
-    std::experimental::optional<std::string> regExists(const std::string &regName);
+    std::vector<std::string> regExists(const std::string &regName);
 
     /*!
      *  \brief Returns an address of a given register

--- a/include/ctp7_modules/server/utils.h
+++ b/include/ctp7_modules/server/utils.h
@@ -200,7 +200,7 @@ namespace utils {
      *  \param \c breakOnFailure stop attempting to read regName before nReads is reached if a failed read occurs
      *  \param \c nReads number of times to attempt to read regName
      */
-    SlowCtrlErrCntVFAT repeatedRegRead(const std::string & regName, bool breakOnFailure=true, uint32_t nReads=1000);
+    SlowCtrlErrCntVFAT repeatedRegRead(const std::string & regName, const bool breakOnFailure=true, const uint32_t nReads=1000);
 
     /*!
      *  \brief Writes a value to a register. Register mask is applied. An \c std::runtime_error is thrown if the register cannot be read.

--- a/include/ctp7_modules/server/utils.h
+++ b/include/ctp7_modules/server/utils.h
@@ -3,14 +3,15 @@
 
 #include "ctp7_modules/server/memhub.h"
 
-#include <libmemsvc.h>
-
 #include "xhal/common/utils/XHALXMLParser.h"
 #include "xhal/extern/lmdb++.h"
+
+#include <libmemsvc.h>
 
 #include <sstream>
 #include <string>
 #include <vector>
+#include <experimental/optional>
 
 extern memsvc_handle_t memsvc; /// \var global memory service handle required for registers read/write operations
 /* extern log4cplus logger; /// \var global logger */
@@ -122,11 +123,18 @@ namespace utils {
     /*!
      *  \brief Returns whether or not a named register can be found in the LMDB
      *
-     *  \param \c la Local arguments structure
      *  \param \c regName Register name
-     *  \param \c db_res pointer to a lmdb::val result that the calling function requires
+     *
+     *  \return An optional \c std::string containing the content of the LMDB register, if it exists
      */
-    bool regExists(const std::string & regName, lmdb::val *db_res=nullptr);
+    std::experimental::optional<std::string> regExists(const std::string &regName);
+
+    /*!
+     *  \brief Returns an address of a given register
+     *
+     *  \param \c regName Register name
+     */
+    uint32_t getAddress(const std::string &regName);
 
     /*!
      *  \brief Returns the mask for a given register
@@ -141,36 +149,14 @@ namespace utils {
      *  \param \c address Register address
      *  \param \c value Value to write
      */
-    void writeRawAddress(uint32_t address, uint32_t value);
+    void writeRawAddress(const uint32_t address, const uint32_t value);
 
     /*!
      *  \brief Reads a value from raw register address. Register mask is not applied
      *
      *  \param \c address Register address
      */
-    uint32_t readRawAddress(uint32_t address);
-
-    /*!
-     *  \brief Returns an address of a given register
-     *
-     *  \param \c regName Register name
-     */
-    uint32_t getAddress(const std::string &regName);
-
-    /*!
-     *  \brief Writes given value to the address. Register mask is not applied
-     *
-     *  \param \c db_res LMDB call result
-     *  \param \c value Value to write
-     */
-    void writeAddress(lmdb::val &db_res, uint32_t value);
-
-    /*!
-     *  \brief Reads given value to the address. Register mask is not applied
-     *
-     *  \param \c db_res LMDB call result
-     */
-    uint32_t readAddress(lmdb::val &db_res);
+    uint32_t readRawAddress(const uint32_t address);
 
     /*!
      *  \brief Writes a value to a raw register. Register mask is not applied
@@ -178,7 +164,7 @@ namespace utils {
      *  \param \c regName Register name
      *  \param \c value Value to write
      */
-    void writeRawReg(const std::string &regName, uint32_t value);
+    void writeRawReg(const std::string &regName, const uint32_t value);
 
     /*!
      *  \brief Reads a value from raw register. Register mask is not applied
@@ -196,7 +182,7 @@ namespace utils {
     uint32_t applyMask(uint32_t data, uint32_t mask);
 
     /*!
-     *  \brief Reads a value from register. Register mask is applied. Will return 0xdeaddead if register is no accessible
+     *  \brief Reads a value from register. Register mask is applied. An \c std::runtime_error is thrown if the register cannot be read.
      *
      *  \param \c regName Register name
      */
@@ -238,12 +224,12 @@ namespace utils {
     SlowCtrlErrCntVFAT repeatedRegRead(const std::string & regName, bool breakOnFailure=true, uint32_t nReads=1000);
 
     /*!
-     *  \brief Writes a value to a register. Register mask is applied
+     *  \brief Writes a value to a register. Register mask is applied. An \c std::runtime_error is thrown if the register cannot be read.
      *
      *  \param \c regName Register name
      *  \param \c value Value to write
      */
-    void writeReg(const std::string &regName, uint32_t value);
+    void writeReg(const std::string &regName, const uint32_t value);
 
     /*!
      *  \brief Writes a block of values to a contiguous address space.

--- a/src/amc/sca.cpp
+++ b/src/amc/sca.cpp
@@ -31,7 +31,7 @@ uint32_t amc::sca::formatSCAData(uint32_t const& data)
 
 void amc::sca::sendSCACommand::operator()(uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask) const
 {
-  // FIXME: DECIDE WHETHER TO HAVE HERE // if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  // FIXME: DECIDE WHETHER TO HAVE HERE // if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
   // FIXME: DECIDE WHETHER TO HAVE HERE //   utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",         0xffffffff);
   // FIXME: DECIDE WHETHER TO HAVE HERE // }
 
@@ -45,7 +45,7 @@ void amc::sca::sendSCACommand::operator()(uint8_t const& ch, uint8_t const& cmd,
 
 std::vector<uint32_t> amc::sca::sendSCACommandWithReply::operator()(uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask) const
 {
-  // FIXME: DECIDE WHETHER TO HAVE HERE // if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  // FIXME: DECIDE WHETHER TO HAVE HERE // if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
   // FIXME: DECIDE WHETHER TO HAVE HERE //   uint32_t monMask = utils::readReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
   // FIXME: DECIDE WHETHER TO HAVE HERE //   utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
   // FIXME: DECIDE WHETHER TO HAVE HERE // }
@@ -73,7 +73,7 @@ std::vector<uint32_t> amc::sca::sendSCACommandWithReply::operator()(uint8_t cons
 std::vector<uint32_t> amc::sca::scaCTRLCommand::operator()(sca::CTRLCommand const& cmd, uint16_t const& ohMask, uint8_t const& len, uint32_t const& data) const
 {
   uint32_t monMask = 0xffffffff;
-  if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
     monMask = utils::readReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
     utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
   }
@@ -105,7 +105,7 @@ std::vector<uint32_t> amc::sca::scaCTRLCommand::operator()(sca::CTRLCommand cons
     result = amc::sca::sendSCACommandWithReply{}(static_cast<uint8_t>(SCAChannel::CTRL), static_cast<uint8_t>(sca::CTRLCommand::GET_DATA), len, data, ohMask);
   }
 
-  if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
     utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
   }
 
@@ -124,14 +124,14 @@ std::vector<uint32_t> amc::sca::scaI2CCommand::operator()(sca::I2CChannel const&
   std::vector<uint32_t> result;
 
   uint32_t monMask = 0xffffffff;
-  if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
     monMask = utils::readReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
     utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
   }
 
   amc::sca::sendSCACommand{}(static_cast<uint8_t>(ch), static_cast<uint8_t>(cmd), len, data, ohMask);
 
-  if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
     utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
   }
 
@@ -142,14 +142,14 @@ std::vector<uint32_t> amc::sca::scaGPIOCommand::operator()(sca::GPIOCommand cons
 {
   // enable the GPIO bus through the CTRL CRB register, bit 2
   uint32_t monMask = 0xffffffff;
-  if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
     monMask = utils::readReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
     utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
   }
 
   std::vector<uint32_t> reply = amc::sca::sendSCACommandWithReply{}(static_cast<uint8_t>(SCAChannel::GPIO), static_cast<uint8_t>(cmd), len, data, ohMask);
 
-  if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
     utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
   }
 
@@ -159,7 +159,7 @@ std::vector<uint32_t> amc::sca::scaGPIOCommand::operator()(sca::GPIOCommand cons
 std::vector<uint32_t> amc::sca::scaADCCommand::operator()(sca::ADCChannel const& ch, uint16_t const& ohMask) const
 {
   uint32_t monMask = 0xffffffff;
-  if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
     monMask = utils::readReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
     utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",       0xffffffff);
   }
@@ -184,7 +184,7 @@ std::vector<uint32_t> amc::sca::scaADCCommand::operator()(sca::ADCChannel const&
   // // get the offset
   // std::vector<uint32_t> raw  = amc::sca::sendSCACommandWithReply{}(SCAChannel::ADC, sca::ADCCommand::ADC_R_OFS, 0x1, 0x0, ohMask);
 
-  if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
     utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", monMask);
   }
 

--- a/src/amc/ttc.cpp
+++ b/src/amc/ttc.cpp
@@ -89,7 +89,7 @@ void amc::ttc::ttcMMCMPhaseShift::operator()(bool relock, bool modeBC0, bool sca
 
   uint32_t mmcmShiftCnt = utils::readReg("GEM_AMC.TTC.STATUS.CLK.PA_MANUAL_SHIFT_CNT");
   uint32_t gthShiftCnt  = utils::readReg("GEM_AMC.TTC.STATUS.CLK.PA_MANUAL_GTH_SHIFT_CNT");
-  int  pllLockCnt = amc::ttc::checkPLLLock{}(readAttempts);
+  std::uint32_t pllLockCnt = amc::ttc::checkPLLLock{}(readAttempts);
   bool firstUnlockFound = false;
   bool nextLockFound    = false;
   bool bestLockFound    = false;
@@ -549,7 +549,7 @@ void amc::ttc::ttcMMCMPhaseShift::operator()(bool relock, bool modeBC0, bool sca
   return;
 }
 
-int amc::ttc::checkPLLLock::operator()(int readAttempts) const
+std::uint32_t amc::ttc::checkPLLLock::operator()(const std::uint32_t readAttempts) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
 
@@ -557,7 +557,7 @@ int amc::ttc::checkPLLLock::operator()(int readAttempts) const
   std::stringstream msg;
   msg << "Executing checkPLLLock with " << readAttempts << " attempted relocks";
   LOG4CPLUS_DEBUG(logger, msg.str());
-  for (int i = 0; i < readAttempts; ++i ) {
+  for (std::uint32_t i = 0; i < readAttempts; ++i ) {
     utils::writeReg("GEM_AMC.TTC.CTRL.PA_MANUAL_PLL_RESET", 0x1);
 
     // wait 100us to allow the PLL to lock
@@ -572,7 +572,7 @@ int amc::ttc::checkPLLLock::operator()(int readAttempts) const
 }
 
 // FIXME: can maybe abstract this to amc::ttc::getPhase(clk, mode, reads)
-float amc::ttc::getMMCMPhaseMean::operator()(int readAttempts) const
+float amc::ttc::getMMCMPhaseMean::operator()(const std::uint32_t readAttempts) const
 {
   if (readAttempts < 1) {
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.TTC_PM_PHASE_MEAN"));
@@ -580,14 +580,14 @@ float amc::ttc::getMMCMPhaseMean::operator()(int readAttempts) const
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.TTC_PM_PHASE"));
   } else {
     float mean = 0.;
-    for (int read = 0; read < readAttempts; ++read) {
+    for (std::uint32_t read = 0; read < readAttempts; ++read) {
       mean += utils::readReg("GEM_AMC.TTC.STATUS.CLK.TTC_PM_PHASE");
     }
     return mean/readAttempts;
   }
 }
 
-float amc::ttc::getGTHPhaseMean::operator()(int readAttempts) const
+float amc::ttc::getGTHPhaseMean::operator()(const std::uint32_t readAttempts) const
 {
   if (readAttempts < 1) {
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.GTH_PM_PHASE_MEAN"));
@@ -595,14 +595,14 @@ float amc::ttc::getGTHPhaseMean::operator()(int readAttempts) const
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.GTH_PM_PHASE"));
   } else {
     float mean = 0.;
-    for (int read = 0; read < readAttempts; ++read) {
+    for (std::uint32_t read = 0; read < readAttempts; ++read) {
       mean += utils::readReg("GEM_AMC.TTC.STATUS.CLK.GTH_PM_PHASE");
     }
     return mean/readAttempts;
   }
 }
 
-float amc::ttc::getMMCMPhaseMedian::operator()(int readAttempts) const
+float amc::ttc::getMMCMPhaseMedian::operator()(const std::uint32_t readAttempts) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
 
@@ -613,14 +613,14 @@ float amc::ttc::getMMCMPhaseMedian::operator()(int readAttempts) const
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.TTC_PM_PHASE"));
   } else {
     float mean = 0.;
-    for (int read = 0; read < readAttempts; ++read) {
+    for (std::uint32_t read = 0; read < readAttempts; ++read) {
       mean += utils::readReg("GEM_AMC.TTC.STATUS.CLK.TTC_PM_PHASE");
     }
     return mean/readAttempts;
   }
 }
 
-float amc::ttc::getGTHPhaseMedian::operator()(int readAttempts) const
+float amc::ttc::getGTHPhaseMedian::operator()(const std::uint32_t readAttempts) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
 
@@ -631,7 +631,7 @@ float amc::ttc::getGTHPhaseMedian::operator()(int readAttempts) const
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.GTH_PM_PHASE"));
   } else {
     float mean = 0.;
-    for (int read = 0; read < readAttempts; ++read) {
+    for (std::uint32_t read = 0; read < readAttempts; ++read) {
       mean += utils::readReg("GEM_AMC.TTC.STATUS.CLK.GTH_PM_PHASE");
     }
     return mean/readAttempts;

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -19,7 +19,7 @@ namespace calibration {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 }
 
-std::unordered_map<uint32_t, uint32_t> setSingleChanMask(const uint16_t ohN, const uint8_t vfatN, const uint8_t ch)
+std::unordered_map<uint32_t, uint32_t> calibration::setSingleChanMask(const uint8_t &ohN, const uint8_t &vfatN, const uint8_t &ch)
 {
   std::unordered_map<uint32_t, uint32_t> map_chanOrigMask;
   uint32_t chanMaskAddr;
@@ -37,7 +37,7 @@ std::unordered_map<uint32_t, uint32_t> setSingleChanMask(const uint16_t ohN, con
   return map_chanOrigMask;
 }
 
-void applyChanMask(std::unordered_map<uint32_t, uint32_t> chMasks)
+void calibration::applyChanMask(const std::unordered_map<uint32_t, uint32_t> &chMasks)
 {
   for (auto const& chMask : chMasks) {
     utils::writeRawAddress(chMask.first, chMask.second);

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -978,7 +978,7 @@ std::vector<uint32_t> calibration::dacScan::operator()(const uint16_t &ohN,
 
     if (useExtRefADC) {
       // for backward compatibility, use ADC1 instead of ADC1_CACHED if it exists
-      foundADCCached = utils::regExists(regBase + ".ADC1_CACHED");
+      foundADCCached = bool(utils::regExists(regBase + ".ADC1_CACHED"));
       if (foundADCCached) {
         adcAddr[vfatN]            = utils::getAddress(regBase + ".ADC1_CACHED");
         adcCacheUpdateAddr[vfatN] = utils::getAddress(regBase + ".ADC1_UPDATE");
@@ -987,7 +987,7 @@ std::vector<uint32_t> calibration::dacScan::operator()(const uint16_t &ohN,
       }
     } else {
       // for backward compatibility, use ADC0 instead of ADC0_CACHED if it exists
-      foundADCCached = utils::regExists(regBase + ".ADC0_CACHED");
+      foundADCCached = bool(utils::regExists(regBase + ".ADC0_CACHED"));
       if (foundADCCached) {
         adcAddr[vfatN]            = utils::getAddress(regBase + ".ADC0_CACHED");
         adcCacheUpdateAddr[vfatN] = utils::getAddress(regBase + ".ADC0_UPDATE");

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -978,7 +978,7 @@ std::vector<uint32_t> calibration::dacScan::operator()(const uint16_t &ohN,
 
     if (useExtRefADC) {
       // for backward compatibility, use ADC1 instead of ADC1_CACHED if it exists
-      foundADCCached = bool(utils::regExists(regBase + ".ADC1_CACHED"));
+      foundADCCached = !utils::regExists(regBase + ".ADC1_CACHED").empty();
       if (foundADCCached) {
         adcAddr[vfatN]            = utils::getAddress(regBase + ".ADC1_CACHED");
         adcCacheUpdateAddr[vfatN] = utils::getAddress(regBase + ".ADC1_UPDATE");
@@ -987,7 +987,7 @@ std::vector<uint32_t> calibration::dacScan::operator()(const uint16_t &ohN,
       }
     } else {
       // for backward compatibility, use ADC0 instead of ADC0_CACHED if it exists
-      foundADCCached = bool(utils::regExists(regBase + ".ADC0_CACHED"));
+      foundADCCached = !utils::regExists(regBase + ".ADC0_CACHED").empty();
       if (foundADCCached) {
         adcAddr[vfatN]            = utils::getAddress(regBase + ".ADC0_CACHED");
         adcCacheUpdateAddr[vfatN] = utils::getAddress(regBase + ".ADC0_UPDATE");

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -235,7 +235,7 @@ std::map<std::string, uint32_t> daqmon::getmonOHmain::operator()(const uint16_t 
 std::map<std::string, uint32_t> daqmon::getmonOHSCAmain::operator()(const uint16_t &ohMask) const
 {
   uint32_t initSCAMonOffMask = 0xffffffff;
-  if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
     initSCAMonOffMask = utils::readReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
     utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", (~ohMask) & 0x3ff);
   }
@@ -289,7 +289,7 @@ std::map<std::string, uint32_t> daqmon::getmonOHSCAmain::operator()(const uint16
       scaMon[keyName + "." + sensor] = utils::readReg(regName+ "." + sensor);
   }
 
-  if (utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")) {
+  if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
     utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF", initSCAMonOffMask);
   }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -40,7 +40,7 @@ std::string utils::serialize(xhal::common::utils::Node n)
   return node.str();
 }
 
-void initLogging()
+void utils::initLogging()
 {
     log4cplus::initialize();
 
@@ -621,7 +621,7 @@ extern "C" {
 
     void module_init(ModuleManager *modmgr)
     {
-        initLogging();
+        utils::initLogging();
 
         if (memhub_open(&memsvc) != 0) {
             auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,15 +13,6 @@
 
 memsvc_handle_t memsvc;
 
-// lmdb::env env = lmdb::env::create();
-// env.set_mapsize(utils::LMDB_SIZE);
-// std::string gem_path       = std::getenv("GEM_PATH");
-// std::string lmdb_data_file = gem_path+"/address_table.mdb";
-// env.open(lmdb_data_file.c_str(), 0, 0664);
-// static utils::LocalArgs utils::la = std::make_unique({.rtxn = lmdb::txn::begin(env, nullptr, MDB_RDONLY),
-//       .dbi  = lmdb::dbi::open(rtxn, nullptr)});
-
-
 std::vector<std::string> utils::split(const std::string &s, char delim)
 {
   std::vector<std::string> elems;

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -26,7 +26,7 @@ namespace vfat3 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 }
 
-uint16_t decodeChipID(const uint32_t &encChipID)
+uint16_t vfat3::decodeChipID(const uint32_t &encChipID)
 {
   // can the generator be static to limit creation/destruction of resources?
   static reedmuller rm = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR aims at providing a minimal working set of templated RPC methods.

The following changes were made:

* Remove the (de)serializers which are going to be implemented as part of https://github.com/cms-gem-daq-project/xhal/issues/138 (PR https://github.com/cms-gem-daq-project/xhal/pull/144 in progress);
* Fix missing namespaces in `src/vfat3.cpp`, `src/utils.cpp` and `src/calibration_routines.cpp` leading to link failure at run-time;
* Fix incorrect usage of LMDB leading to SIGV as soon as the `db_res` parameter of `utils::regExists` was used. Please read the commit message if more information is required. Note that since the templated RPC migration, the LMDB database is opened and closed for every LMDB register read;
* Delete the now useless `LocalArgs` structure;
* Delete the now useless `EMIT_RPC_ERROR` macro;
* Fix #170 by removing all references to `0xdeaddead` from `src/utils.cpp`;
* Disable the `x84_64` target since the GLIB sysroot is not yet ready;
* Update the `config` submodule to get proper compilation;
* Replace `int` by `std::uint32_t` in `amc/ttc` since the former is not a (de)serializable type.

[Requires https://github.com/cms-gem-daq-project/xhal/pull/144 so it is probably better to wait before merging.]

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

Port `cmsgemos` to the templated RPC modules in order to, at first, remove the direct IPBus dependency.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Can successfully run a basic RPC call (i.e., `vfat3::getVFAT3ChipIDs`):
``` bash
$ cat test.cpp
#include "xhal/common/rpc/call.h"
#include "ctp7_modules/common/vfat3.h"
#include <iostream>

int main(int argc, char **argv)
{
        wisc::RPCSvc conn;
        conn.connect("eagle48");
        conn.load_module("vfat3", "vfat3 v1.0.1");

        for (auto &i: xhal::common::rpc::call<vfat3::getVFAT3ChipIDs>(conn, 0, 0x0, false))
                std::cout << i << std::endl;

        return 0;
}
$ ./run.sh
6241
6415
6210
6185
6534
[...]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
