### PR TITLE
Adopting uniform style in args passing

### DIFF
--- a/include/ctp7_modules/common/amc.h
+++ b/include/ctp7_modules/common/amc.h
@@ -28,7 +28,7 @@ namespace amc {
    */
   struct getOHVFATMask : public xhal::common::rpc::Method
   {
-    uint32_t operator()(const uint32_t &ohN) const;
+    uint32_t operator()(const uint32_t& ohN) const;
   };
 
   /*!
@@ -40,7 +40,7 @@ namespace amc {
    */
   struct getOHVFATMaskMultiLink : public xhal::common::rpc::Method
   {
-    std::vector<uint32_t> operator()(const uint32_t &ohMask=0xfff) const;
+    std::vector<uint32_t> operator()(const uint32_t& ohMask=0xfff) const;
   };
 
   /*!
@@ -79,7 +79,7 @@ namespace amc {
    */
   struct sbitReadOut : public xhal::common::rpc::Method
   {
-    std::vector<uint32_t> operator()(const uint32_t &ohN, const uint32_t &acquireTime) const;
+    std::vector<uint32_t> operator()(const uint32_t& ohN, const uint32_t& acquireTime) const;
   };
 
   /*!
@@ -100,7 +100,7 @@ namespace amc {
    */
   struct repeatedRegRead : public xhal::common::rpc::Method
   {
-    std::map<std::string,uint32_t> operator()(const std::vector<std::string> &regList, const bool &breakOnFailure=false, const uint32_t &nReads=100) const;
+    std::map<std::string,uint32_t> operator()(const std::vector<std::string>& regList, const bool& breakOnFailure=false, const uint32_t& nReads=100) const;
   };
 }
 

--- a/include/ctp7_modules/common/amc/blaster_ram.h
+++ b/include/ctp7_modules/common/amc/blaster_ram.h
@@ -160,7 +160,7 @@ namespace amc {
          */
         struct writeConfRAM : public xhal::common::rpc::Method
         {
-            void operator()(BLASTERType const& type, std::vector<uint32_t> blob) const;
+            void operator()(BLASTERType const& type, const std::vector<uint32_t>& blob) const;
         };
 
         /*!
@@ -186,7 +186,7 @@ namespace amc {
          */
         struct writeGBTConfRAM : public xhal::common::rpc::Method
         {
-          void operator()(const std::vector<uint32_t> &gbtblob, const uint16_t &ohMask=0xfff) const;
+          void operator()(const std::vector<uint32_t>& gbtblob, const uint16_t& ohMask=0xfff) const;
         };
 
         /*!
@@ -210,7 +210,7 @@ namespace amc {
          */
         struct writeOptoHybridConfRAM : public xhal::common::rpc::Method
         {
-            void operator()(const std::vector<uint32_t> &ohblob, const uint16_t &ohMask=0xfff) const;
+            void operator()(const std::vector<uint32_t>& ohblob, const uint16_t& ohMask=0xfff) const;
         };
 
 
@@ -236,7 +236,7 @@ namespace amc {
          */
         struct writeVFATConfRAM : public xhal::common::rpc::Method
         {
-          void operator()(const std::vector<uint32_t> &vfatblob, const uint16_t &ohMask=0xfff) const;
+          void operator()(const std::vector<uint32_t>& vfatblob, const uint16_t& ohMask=0xfff) const;
         };
     }
 }

--- a/include/ctp7_modules/common/amc/blaster_ram.h
+++ b/include/ctp7_modules/common/amc/blaster_ram.h
@@ -160,7 +160,7 @@ namespace amc {
          */
         struct writeConfRAM : public xhal::common::rpc::Method
         {
-            void operator()(BLASTERType const& type, const std::vector<uint32_t>& blob) const;
+            void operator()(const BLASTERType& type, const std::vector<uint32_t>& blob) const;
         };
 
         /*!

--- a/include/ctp7_modules/common/amc/daq.h
+++ b/include/ctp7_modules/common/amc/daq.h
@@ -22,7 +22,7 @@ namespace amc {
      */
     struct  enableDAQLink : public xhal::common::rpc::Method
     {
-      void operator()(uint32_t const& enableMask=0x1) const;
+      void operator()(const uint32_t& enableMask=0x1) const;
     };
 
     /*!
@@ -40,7 +40,7 @@ namespace amc {
      */
     struct setZS : public xhal::common::rpc::Method
     {
-      void operator()(bool enable=true) const;
+      void operator()(const bool& enable=true) const;
     };
     /*!
      * \brief Disable zero suppression of VFAT data
@@ -62,7 +62,7 @@ namespace amc {
      */
     struct resetDAQLink : public xhal::common::rpc::Method
     {
-      void operator()(uint32_t const& davTO=0x500, uint32_t const& ttsOverride=0x0) const;
+      void operator()(const uint32_t& davTO=0x500, const uint32_t& ttsOverride=0x0) const;
     };
 
     /*!
@@ -216,7 +216,7 @@ namespace amc {
      */
     struct getDAQLinkDAVTimer : public xhal::common::rpc::Method
     {
-      uint32_t operator()(bool const& max) const;
+      uint32_t operator()(const bool& max) const;
     };
 
     /*!
@@ -226,7 +226,7 @@ namespace amc {
      */
     struct getLinkDAQStatus : public xhal::common::rpc::Method
     {
-      uint32_t operator()(uint8_t const& gtx) const;
+      uint32_t operator()(const uint8_t& gtx) const;
     };
 
     /*!
@@ -237,7 +237,7 @@ namespace amc {
      */
     struct getLinkDAQCounters : public xhal::common::rpc::Method
     {
-      uint32_t operator()(uint8_t const& gtx, uint8_t const& mode) const;
+      uint32_t operator()(const uint8_t& gtx, const uint8_t& mode) const;
     };
 
     /*!
@@ -247,7 +247,7 @@ namespace amc {
      */
     struct getLinkLastDAQBlock : public xhal::common::rpc::Method
     {
-      uint32_t operator()(uint8_t const& gtx) const;
+      uint32_t operator()(const uint8_t& gtx) const;
     };
 
     /*!
@@ -279,7 +279,7 @@ namespace amc {
      */
     struct getDAQLinkRunParameter : public xhal::common::rpc::Method
     {
-      uint32_t operator()(uint8_t const& parameter) const;
+      uint32_t operator()(const uint8_t& parameter) const;
     };
 
 
@@ -292,7 +292,7 @@ namespace amc {
      */
     struct setDAQLinkInputTimeout : public xhal::common::rpc::Method
     {
-      void operator()(uint32_t const& inputTO=0x100) const;
+      void operator()(const uint32_t& inputTO=0x100) const;
     };
 
     /*!
@@ -302,7 +302,7 @@ namespace amc {
      */
     struct setDAQLinkRunType : public xhal::common::rpc::Method
     {
-      void operator()(uint32_t const& rtype) const;
+      void operator()(const uint32_t& rtype) const;
     };
 
     /*!
@@ -312,7 +312,7 @@ namespace amc {
      */
     struct setDAQLinkRunParameters : public xhal::common::rpc::Method
     {
-      void operator()(uint32_t const& value) const;
+      void operator()(const uint32_t& value) const;
     };
     /*!
      * \param \c parameter is the number of parameter to be written (1-3)
@@ -322,18 +322,18 @@ namespace amc {
      */
     struct setDAQLinkRunParameter : public xhal::common::rpc::Method
     {
-      void operator()(uint8_t const& parameter, uint8_t const& value) const;
+      void operator()(const uint8_t& parameter, const uint8_t& value) const;
     };
 
     /** Composite functions, no specific "local" function defined */
     struct configureDAQModule : public xhal::common::rpc::Method
     {
-      void operator()(bool enableZS=false, uint32_t runType=0x1, bool doPhaseShift=false, bool relock=false, bool bc0LockPSMode=false) const;
+      void operator()(const bool& enableZS=false, const uint32_t& runType=0x1, const bool& doPhaseShift=false, const bool& relock=false, const bool& bc0LockPSMode=false) const;
     };
 
     struct enableDAQModule : public xhal::common::rpc::Method
     {
-      void operator()(bool enableZS=false) const;
+      void operator()(const bool& enableZS=false) const;
     };
   }
 }

--- a/include/ctp7_modules/common/amc/sca.h
+++ b/include/ctp7_modules/common/amc/sca.h
@@ -31,7 +31,7 @@ namespace amc {
      */
     struct sendSCACommand : public xhal::common::rpc::Method
     {
-      void operator()(uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask=0xfff) const;
+      void operator()(const uint8_t& ch, const uint8_t& cmd, const uint8_t& len, const uint32_t& data, const uint16_t& ohMask=0xfff) const;
     };
 
     /*!
@@ -45,7 +45,7 @@ namespace amc {
      */
     struct sendSCACommandWithReply : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask=0xfff) const;
+      std::vector<uint32_t> operator()(const uint8_t& ch, const uint8_t& cmd, const uint8_t& len, const uint32_t&, const uint16_t& ohMask=0xfff) const;
     };
 
     /*!
@@ -63,7 +63,7 @@ namespace amc {
      */
     struct scaCTRLCommand : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(sca::CTRLCommand const& cmd, uint16_t const& ohMask=0xfff, uint8_t const& len=0x1, uint32_t const& data=0x0) const;
+      std::vector<uint32_t> operator()(const sca::CTRLCommand& cmd, const uint16_t& ohMask=0xfff, const uint8_t& len=0x1, const uint32_t& data=0x0) const;
     };
 
     /** Locally executed methods */
@@ -80,7 +80,7 @@ namespace amc {
      */
     struct scaI2CCommand : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(sca::I2CChannel const& ch, sca::I2CCommand const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask=0xfff) const;
+      std::vector<uint32_t> operator()(const sca::I2CChannel& ch, const sca::I2CCommand& cmd, const uint8_t& len, const uint32_t& data, const uint16_t& ohMask=0xfff) const;
     };
 
     /*!
@@ -96,7 +96,7 @@ namespace amc {
      */
     struct scaGPIOCommand : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(sca::GPIOCommand const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask=0xfff) const;
+      std::vector<uint32_t> operator()(const sca::GPIOCommand& cmd, const uint8_t& len, const uint32_t& data, const uint16_t& ohMask=0xfff) const;
     };
 
     /*!
@@ -109,7 +109,7 @@ namespace amc {
      */
     struct scaADCCommand : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(sca::ADCChannel const& ch, uint16_t const& ohMask=0xfff) const;
+      std::vector<uint32_t> operator()(const sca::ADCChannel& ch, const uint16_t& ohMask=0xfff) const;
     };
 
     /*** CTRL submodule ***/
@@ -118,7 +118,7 @@ namespace amc {
      */
     struct scaModuleReset : public xhal::common::rpc::Method
     {
-      void operator()(uint16_t const& ohMask) const;
+      void operator()(const uint16_t& ohMask) const;
     };
 
     /*!
@@ -128,7 +128,7 @@ namespace amc {
      */
     struct scaHardResetEnable : public xhal::common::rpc::Method
     {
-      void operator()(bool en) const;
+      void operator()(const bool& en) const;
     };
 
     /*!
@@ -139,7 +139,7 @@ namespace amc {
      */
     struct readSCAChipID : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(uint16_t const& ohMask=0xfff, bool scaV1=false) const;
+      std::vector<uint32_t> operator()(const uint16_t& ohMask=0xfff, const bool& scaV1=false) const;
     };
 
     /*!
@@ -150,7 +150,7 @@ namespace amc {
      */
     struct readSCASEUCounter : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(uint16_t const& ohMask=0xfff, bool reset=false) const;
+      std::vector<uint32_t> operator()(const uint16_t& ohMask=0xfff, const bool& reset=false) const;
     };
 
     /*!
@@ -160,7 +160,7 @@ namespace amc {
      */
     struct resetSCASEUCounter : public xhal::common::rpc::Method
     {
-      void operator()(uint16_t const& ohMask=0xfff) const;
+      void operator()(const uint16_t& ohMask=0xfff) const;
     };
 
     /* /\*** SCA ADC submodule ***\/ */
@@ -213,7 +213,7 @@ namespace amc {
      */
     struct readSCAADCSensor : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(sca::ADCChannel const& ch, uint16_t const& ohMask=0xfff) const;
+      std::vector<uint32_t> operator()(const sca::ADCChannel& ch, const uint16_t& ohMask=0xfff) const;
     };
 
     /*!
@@ -233,7 +233,7 @@ namespace amc {
      */
     struct readSCAADCTemperatureSensors : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(uint16_t const& ohMask=0xfff) const;
+      std::vector<uint32_t> operator()(const uint16_t& ohMask=0xfff) const;
     };
 
     /*!
@@ -253,7 +253,7 @@ namespace amc {
      */
     struct readSCAADCVoltageSensors : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(uint16_t const& ohMask=0xfff) const;
+      std::vector<uint32_t> operator()(const uint16_t& ohMask=0xfff) const;
     };
 
     /*!
@@ -273,7 +273,7 @@ namespace amc {
      */
     struct readSCAADCSignalStrengthSensors : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(uint16_t const& ohMask=0xfff) const;
+      std::vector<uint32_t> operator()(const uint16_t& ohMask=0xfff) const;
     };
 
     /*!
@@ -293,7 +293,7 @@ namespace amc {
      */
     struct readAllSCAADCSensors : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(uint16_t const& ohMask=0xfff) const;
+      std::vector<uint32_t> operator()(const uint16_t& ohMask=0xfff) const;
     };
 
   }

--- a/include/ctp7_modules/common/amc/sca.h
+++ b/include/ctp7_modules/common/amc/sca.h
@@ -45,7 +45,7 @@ namespace amc {
      */
     struct sendSCACommandWithReply : public xhal::common::rpc::Method
     {
-      std::vector<uint32_t> operator()(const uint8_t& ch, const uint8_t& cmd, const uint8_t& len, const uint32_t&, const uint16_t& ohMask=0xfff) const;
+      std::vector<uint32_t> operator()(const uint8_t& ch, const uint8_t& cmd, const uint8_t& len, const uint32_t& data, const uint16_t& ohMask=0xfff) const;
     };
 
     /*!

--- a/include/ctp7_modules/common/amc/ttc.h
+++ b/include/ctp7_modules/common/amc/ttc.h
@@ -55,7 +55,7 @@ namespace amc {
      */
     struct ttcMMCMPhaseShift : public xhal::common::rpc::Method
     {
-      void operator()(bool relock=false, bool modeBC0=false, bool scan=false) const;
+      void operator()(const bool& relock=false, const bool& modeBC0=false, const bool& scan=false) const;
     };
 
     /*!
@@ -67,7 +67,7 @@ namespace amc {
      */
     struct checkPLLLock : public xhal::common::rpc::Method
     {
-      std::uint32_t operator()(const std::uint32_t readAttempts) const;
+      uint32_t operator()(const uint32_t& readAttempts) const;
     };
 
     /*!
@@ -81,7 +81,7 @@ namespace amc {
      */
     struct getMMCMPhaseMean : public xhal::common::rpc::Method
     {
-      float operator()(const std::uint32_t readAttempts) const;
+      float operator()(const uint32_t& readAttempts) const;
     };
 
     /*!
@@ -95,7 +95,7 @@ namespace amc {
      */
     struct getGTHPhaseMean : public xhal::common::rpc::Method
     {
-      float operator()(const std::uint32_t readAttempts) const;
+      float operator()(const uint32_t& readAttempts) const;
     };
 
     /*!
@@ -107,7 +107,7 @@ namespace amc {
      */
     struct getMMCMPhaseMedian : public xhal::common::rpc::Method
     {
-      float operator()(const std::uint32_t readAttempts) const;
+      float operator()(const uint32_t& readAttempts) const;
     };
 
     /*!
@@ -119,7 +119,7 @@ namespace amc {
      */
     struct getGTHPhaseMedian : public xhal::common::rpc::Method
     {
-      float operator()(const std::uint32_t readAttempts) const;
+      float operator()(const uint32_t& readAttempts) const;
     };
 
     /*!
@@ -143,7 +143,7 @@ namespace amc {
      */
     struct setL1AEnable : public xhal::common::rpc::Method
     {
-      void operator()(bool enable=true) const;
+      void operator()(const bool& enable=true) const;
     };
 
     /*** CONFIG submodule ***/
@@ -154,7 +154,7 @@ namespace amc {
      */
     struct getTTCConfig : public xhal::common::rpc::Method
     {
-      uint32_t operator()(uint8_t const& cmd) const;
+      uint32_t operator()(const uint8_t& cmd) const;
     };
 
     /*!
@@ -162,7 +162,7 @@ namespace amc {
      */
     struct setTTCConfig : public xhal::common::rpc::Method
     {
-      void operator()(uint8_t const& cmd, uint8_t const& value) const;
+      void operator()(const uint8_t& cmd, const uint8_t& value) const;
     };
 
     /*** STATUS submodule ***/
@@ -181,7 +181,7 @@ namespace amc {
      */
     struct getTTCErrorCount : public xhal::common::rpc::Method
     {
-      uint32_t operator()(bool const& single=true) const;
+      uint32_t operator()(const bool& single=true) const;
     };
 
     /*** CMD_COUNTERS submodule ***/
@@ -192,7 +192,7 @@ namespace amc {
      */
     struct getTTCCounter : public xhal::common::rpc::Method
     {
-      uint32_t operator()(uint8_t const& cmd) const;
+      uint32_t operator()(const uint8_t& cmd) const;
     };
 
     /*!

--- a/include/ctp7_modules/common/calibration_routines.h
+++ b/include/ctp7_modules/common/calibration_routines.h
@@ -72,12 +72,12 @@ namespace calibration {
    */
   struct confCalPulse : xhal::common::rpc::Method
   {
-    void operator()(const uint16_t &ohN,
-                    const uint32_t &mask,
-                    const uint8_t &ch,
-                    const bool &toggleOn,
-                    const bool &currentPulse,
-                    const uint32_t &calScaleFactor) const;
+    void operator()(const uint16_t& ohN,
+                    const uint32_t& mask,
+                    const uint8_t& ch,
+                    const bool& toggleOn,
+                    const bool& currentPulse,
+                    const uint32_t& calScaleFactor) const;
   };
 
   /*!
@@ -88,7 +88,7 @@ namespace calibration {
    */
   struct dacMonConf : xhal::common::rpc::Method
   {
-    void operator()(const uint16_t &ohN, const uint8_t &ch) const;
+    void operator()(const uint16_t& ohN, const uint8_t& ch) const;
   };
 
   /*!
@@ -100,7 +100,7 @@ namespace calibration {
    */
   struct ttcGenToggle : xhal::common::rpc::Method
   {
-    void operator()(const bool &enable) const;
+    void operator()(const bool& enable) const;
   };
 
   /*!
@@ -116,8 +116,8 @@ namespace calibration {
    */
   struct ttcGenConf : xhal::common::rpc::Method
   {
-    void operator()(const uint32_t &pulseDelay, const uint32_t &L1Ainterval,
-                    const bool &enable) const;
+    void operator()(const uint32_t& pulseDelay, const uint32_t& L1Ainterval,
+                    const bool& enable) const;
   };
 
   /*!
@@ -141,19 +141,19 @@ namespace calibration {
    */
   struct genScan : xhal::common::rpc::Method
   {
-    std::vector<uint32_t> operator()(const uint16_t &ohN,
-                                     const uint32_t &vfatMask,
-                                     const uint8_t &ch,
-                                     const bool &useCalPulse,
-                                     const bool &currentPulse,
-                                     const uint32_t &calScaleFactor,
-                                     const uint32_t &nevts,
-                                     const uint32_t &dacMin,
-                                     const uint32_t &dacMax,
-                                     const uint32_t &dacStep,
-                                     const std::string &scanReg,
-                                     const bool &useUltra=false,
-                                     const bool &useExtTrig=false) const;
+    std::vector<uint32_t> operator()(const uint16_t& ohN,
+                                     const uint32_t& vfatMask,
+                                     const uint8_t& ch,
+                                     const bool& useCalPulse,
+                                     const bool& currentPulse,
+                                     const uint32_t& calScaleFactor,
+                                     const uint32_t& nevts,
+                                     const uint32_t& dacMin,
+                                     const uint32_t& dacMax,
+                                     const uint32_t& dacStep,
+                                     const std::string& scanReg,
+                                     const bool& useUltra=false,
+                                     const bool& useExtTrig=false) const;
   };
 
   /*!
@@ -176,18 +176,18 @@ namespace calibration {
    */
   struct genChannelScan : xhal::common::rpc::Method
   {
-    std::map<uint32_t, std::vector<uint32_t>> operator()(const uint16_t &ohN,
-                                                         const uint32_t &vfatMask,
-                                                         const bool &useCalPulse,
-                                                         const bool &currentPulse,
-                                                         const uint32_t &calScaleFactor,
-                                                         const uint32_t &nevts,
-                                                         const uint32_t &dacMin,
-                                                         const uint32_t &dacMax,
-                                                         const uint32_t &dacStep,
-                                                         const std::string &scanReg,
-                                                         const bool &useUltra,
-                                                         const bool &useExtTrig) const;
+    std::map<uint32_t, std::vector<uint32_t>> operator()(const uint16_t& ohN,
+                                                         const uint32_t& vfatMask,
+                                                         const bool& useCalPulse,
+                                                         const bool& currentPulse,
+                                                         const uint32_t& calScaleFactor,
+                                                         const uint32_t& nevts,
+                                                         const uint32_t& dacMin,
+                                                         const uint32_t& dacMax,
+                                                         const uint32_t& dacStep,
+                                                         const std::string& scanReg,
+                                                         const bool& useUltra,
+                                                         const bool& useExtTrig) const;
   };
 
   /*!
@@ -217,15 +217,15 @@ namespace calibration {
    */
   struct sbitRateScan : xhal::common::rpc::Method
   {
-    std::map<uint32_t, uint32_t> operator()(const uint16_t &ohN,
-                                            const uint32_t &vfatMask,
-                                            const uint8_t &ch,
-                                            const uint16_t &dacMin,
-                                            const uint16_t &dacMax,
-                                            const uint16_t &dacStep,
-                                            const std::string &scanReg,
-                                            const uint32_t &waitTime,
-                                            const bool &invertVFATPos=false) const;
+    std::map<uint32_t, uint32_t> operator()(const uint16_t& ohN,
+                                            const uint32_t& vfatMask,
+                                            const uint8_t& ch,
+                                            const uint16_t& dacMin,
+                                            const uint16_t& dacMax,
+                                            const uint16_t& dacStep,
+                                            const std::string& scanReg,
+                                            const uint32_t& waitTime,
+                                            const bool& invertVFATPos=false) const;
   };
 
   /*!
@@ -252,13 +252,13 @@ namespace calibration {
    */
   struct sbitRateScanParallel : xhal::common::rpc::Method
   {
-    std::map<uint32_t, std::vector<uint32_t>> operator()(const uint8_t &ch,
-                                                         const uint16_t &dacMin,
-                                                         const uint16_t &dacMax,
-                                                         const uint16_t &dacStep,
-                                                         const std::string &scanReg,
-                                                         const uint16_t &ohMask=0xfff,
-                                                         const uint32_t &waitTime=1) const;
+    std::map<uint32_t, std::vector<uint32_t>> operator()(const uint8_t& ch,
+                                                         const uint16_t& dacMin,
+                                                         const uint16_t& dacMax,
+                                                         const uint16_t& dacStep,
+                                                         const std::string& scanReg,
+                                                         const uint16_t& ohMask=0xfff,
+                                                         const uint32_t& waitTime=1) const;
   };
 
   /*!
@@ -305,15 +305,15 @@ namespace calibration {
    */
   struct checkSbitMappingWithCalPulse : xhal::common::rpc::Method
   {
-    std::vector<uint32_t> operator()(const uint16_t &ohN,
-                                     const uint32_t &vfatN,
-                                     const uint32_t &vfatMask,
-                                     const bool &useCalPulse,
-                                     const bool &currentPulse,
-                                     const uint32_t &calScaleFactor,
-                                     const uint32_t &nevts,
-                                     const uint32_t &L1Ainterval,
-                                     const uint32_t &pulseDelay) const;
+    std::vector<uint32_t> operator()(const uint16_t& ohN,
+                                     const uint32_t& vfatN,
+                                     const uint32_t& vfatMask,
+                                     const bool& useCalPulse,
+                                     const bool& currentPulse,
+                                     const uint32_t& calScaleFactor,
+                                     const uint32_t& nevts,
+                                     const uint32_t& L1Ainterval,
+                                     const uint32_t& pulseDelay) const;
   };
 
   /*!
@@ -338,15 +338,15 @@ namespace calibration {
    */
   struct checkSbitRateWithCalPulse : xhal::common::rpc::Method
   {
-    std::map<std::string, std::vector<uint32_t>> operator()(const uint16_t &ohN,
-                                                            const uint32_t &vfatN,
-                                                            const uint32_t &vfatMask,
-                                                            const bool &useCalPulse,
-                                                            const bool &currentPulse,
-                                                            const uint32_t &calScaleFactor,
-                                                            const uint32_t &waitTime,
-                                                            const uint32_t &pulseRate,
-                                                            const uint32_t &pulseDelay) const;
+    std::map<std::string, std::vector<uint32_t>> operator()(const uint16_t& ohN,
+                                                            const uint32_t& vfatN,
+                                                            const uint32_t& vfatMask,
+                                                            const bool& useCalPulse,
+                                                            const bool& currentPulse,
+                                                            const uint32_t& calScaleFactor,
+                                                            const uint32_t& waitTime,
+                                                            const uint32_t& pulseRate,
+                                                            const uint32_t& pulseDelay) const;
   };
 
   /*!
@@ -368,11 +368,11 @@ namespace calibration {
    */
   struct dacScan : xhal::common::rpc::Method
   {
-    std::vector<uint32_t> operator()(const uint16_t &ohN,
-                                     const uint16_t &dacSelect,
-                                     const uint16_t &dacStep=1,
-                                     const uint32_t &vfatMask=0xff000000,
-                                     const bool &useExtRefADC=false) const;
+    std::vector<uint32_t> operator()(const uint16_t& ohN,
+                                     const uint16_t& dacSelect,
+                                     const uint16_t& dacStep=1,
+                                     const uint32_t& vfatMask=0xff000000,
+                                     const bool& useExtRefADC=false) const;
   };
 
   /*!
@@ -385,11 +385,11 @@ namespace calibration {
    */
   struct dacScanMultiLink : xhal::common::rpc::Method
   {
-    std::map<uint32_t, std::vector<uint32_t>> operator()(const uint16_t &ohMask,
-                                                         const uint16_t &dacSelect,
-                                                         const uint16_t &dacStep=1,
-                                                         const uint32_t &vfatMask=0xff000000,
-                                                         const bool &useExtRefADC=false) const;
+    std::map<uint32_t, std::vector<uint32_t>> operator()(const uint16_t& ohMask,
+                                                         const uint16_t& dacSelect,
+                                                         const uint16_t& dacStep=1,
+                                                         const uint32_t& vfatMask=0xff000000,
+                                                         const bool& useExtRefADC=false) const;
   };
 }
 

--- a/include/ctp7_modules/common/daq_monitor.h
+++ b/include/ctp7_modules/common/daq_monitor.h
@@ -35,7 +35,7 @@ namespace daqmon {
    */
   struct getmonTRIGGERmain : xhal::common::rpc::Method
   {
-    std::map<std::string, uint32_t> operator()(const uint16_t &ohMask=0xfff) const;
+    std::map<std::string, uint32_t> operator()(const uint16_t& ohMask=0xfff) const;
   };
 
   /*!
@@ -61,7 +61,7 @@ namespace daqmon {
    */
   struct getmonTRIGGEROHmain : xhal::common::rpc::Method
   {
-    std::map<std::string, uint32_t> operator()(const uint16_t &ohMask=0xfff) const;
+    std::map<std::string, uint32_t> operator()(const uint16_t& ohMask=0xfff) const;
   };
 
   /*!
@@ -84,7 +84,7 @@ namespace daqmon {
    */
   struct getmonDAQOHmain : xhal::common::rpc::Method
   {
-    std::map<std::string, uint32_t> operator()(const uint16_t &ohMask=0xfff) const;
+    std::map<std::string, uint32_t> operator()(const uint16_t& ohMask=0xfff) const;
   };
 
   /*!
@@ -96,7 +96,7 @@ namespace daqmon {
    */
   struct getmonGBTLink : xhal::common::rpc::Method
   {
-    std::map<std::string, uint32_t> operator()(const bool &doReset=false) const;
+    std::map<std::string, uint32_t> operator()(const bool& doReset=false) const;
   };
 
   /*!
@@ -109,7 +109,7 @@ namespace daqmon {
    */
   struct getmonOHmain : xhal::common::rpc::Method
   {
-    std::map<std::string, uint32_t> operator()(const uint16_t &ohMask=0xfff) const;
+    std::map<std::string, uint32_t> operator()(const uint16_t& ohMask=0xfff) const;
   };
 
   /*!
@@ -125,7 +125,7 @@ namespace daqmon {
   struct [[deprecated]] getmonOHSCAmain : xhal::common::rpc::Method
   {
     // __attribute__((__deprecated__))
-    std::map<std::string, uint32_t> operator()(const uint16_t &ohMask=0xfff) const;
+    std::map<std::string, uint32_t> operator()(const uint16_t& ohMask=0xfff) const;
   };
 
   /*!
@@ -144,7 +144,7 @@ namespace daqmon {
    */
   struct getmonOHSysmon : xhal::common::rpc::Method
   {
-    std::map<std::string, uint32_t> operator()(const uint16_t &ohMask=0xfff, const bool &doReset=false) const;
+    std::map<std::string, uint32_t> operator()(const uint16_t& ohMask=0xfff, const bool& doReset=false) const;
   };
 
   /*!
@@ -166,7 +166,7 @@ namespace daqmon {
    */
   struct getmonVFATLink : xhal::common::rpc::Method
   {
-    std::map<std::string, uint32_t> operator()(const bool &doReset=false) const;
+    std::map<std::string, uint32_t> operator()(const bool& doReset=false) const;
   };
 
   /*!

--- a/include/ctp7_modules/common/expert_tools.h
+++ b/include/ctp7_modules/common/expert_tools.h
@@ -13,11 +13,11 @@ namespace expert {
      *  \brief Reads a value from remote address. An \c std::runtime_error is thrown if the register cannot be read.
      *
      *  \param \c address Register address
-     *  \returns \c std::uint32_t register value
+     *  \returns \c uint32_t register value
      */
     struct readRawAddress : public xhal::common::rpc::Method
     {
-        std::uint32_t operator()(const std::uint32_t &address) const;
+        uint32_t operator()(const uint32_t& address) const;
     };
 
     /*!
@@ -28,7 +28,7 @@ namespace expert {
      */
     struct writeRawAddress : public xhal::common::rpc::Method
     {
-        void operator()(const std::uint32_t &address, const std::uint32_t &value) const;
+        void operator()(const uint32_t& address, const uint32_t& value) const;
     };
 }
 #endif

--- a/include/ctp7_modules/common/gbt.h
+++ b/include/ctp7_modules/common/gbt.h
@@ -47,12 +47,12 @@ namespace gbt {
    */
   struct scanGBTPhases : public xhal::common::rpc::Method
   {
-    std::map<uint32_t, std::vector<uint32_t>> operator()(const uint32_t &ohN,
-                                                         const uint32_t &nResets=1,
-                                                         const uint8_t &phaseMin=gbt::PHASE_MIN,
-                                                         const uint8_t &phaseMax=gbt::PHASE_MAX,
-                                                         const uint8_t &phaseStep=1,
-                                                         const uint32_t &nVerificationReads=10) const;
+    std::map<uint32_t, std::vector<uint32_t>> operator()(const uint32_t& ohN,
+                                                         const uint32_t& nResets=1,
+                                                         const uint8_t& phaseMin=gbt::PHASE_MIN,
+                                                         const uint8_t& phaseMax=gbt::PHASE_MAX,
+                                                         const uint8_t& phaseStep=1,
+                                                         const uint32_t& nVerificationReads=10) const;
   };
 
   /*!
@@ -86,7 +86,7 @@ namespace gbt {
    */
   struct writeGBTConfig : public xhal::common::rpc::Method
   {
-    void operator()(const uint32_t &ohN, const uint32_t &gbtN, const config_t &config) const;
+    void operator()(const uint32_t& ohN, const uint32_t& gbtN, const config_t& config) const;
   };
 
   /*!
@@ -120,7 +120,7 @@ namespace gbt {
    */
   struct writeGBTPhase : public xhal::common::rpc::Method
   {
-    void operator()(const uint32_t &ohN, const uint32_t &vfatN, const uint8_t &phase) const;
+    void operator()(const uint32_t& ohN, const uint32_t& vfatN, const uint8_t& phase) const;
   };
 
 }

--- a/include/ctp7_modules/common/optohybrid.h
+++ b/include/ctp7_modules/common/optohybrid.h
@@ -25,7 +25,7 @@ namespace oh {
    */
   struct broadcastWrite : public xhal::common::rpc::Method
   {
-    void operator()(const uint32_t &ohN, const std::string &regName, const uint32_t &value, const uint32_t &mask=0xff000000) const;
+    void operator()(const uint32_t& ohN, const std::string& regName, const uint32_t& value, const uint32_t& mask=0xff000000) const;
   };
 
   /*!
@@ -39,7 +39,7 @@ namespace oh {
    */
   struct broadcastRead : public xhal::common::rpc::Method
   {
-    std::vector<uint32_t> operator()(const uint32_t &ohN, const std::string &regName, const uint32_t &mask=0xff000000) const;
+    std::vector<uint32_t> operator()(const uint32_t& ohN, const std::string& regName, const uint32_t& mask=0xff000000) const;
   };
 
   /*!
@@ -50,7 +50,7 @@ namespace oh {
    */
   struct biasAllVFATs : public xhal::common::rpc::Method
   {
-    void operator()(const uint32_t &ohN, const uint32_t &mask=0xff000000) const;
+    void operator()(const uint32_t& ohN, const uint32_t& mask=0xff000000) const;
   };
 
   /*!
@@ -61,7 +61,7 @@ namespace oh {
    */
   struct setAllVFATsToRunMode : public xhal::common::rpc::Method
   {
-    void operator()(const uint32_t &ohN, const uint32_t &mask=0xff000000) const;
+    void operator()(const uint32_t& ohN, const uint32_t& mask=0xff000000) const;
   };
 
   /*!
@@ -72,7 +72,7 @@ namespace oh {
    */
   struct setAllVFATsToSleepMode : public xhal::common::rpc::Method
   {
-    void operator()(const uint32_t &ohN, const uint32_t &mask=0xff000000) const;
+    void operator()(const uint32_t& ohN, const uint32_t& mask=0xff000000) const;
   };
 
   /*!
@@ -85,7 +85,7 @@ namespace oh {
    */
   struct statusOH : public xhal::common::rpc::Method
   {
-    std::map<std::string, std::vector<uint32_t>> operator()(const uint32_t &ohMask) const;
+    std::map<std::string, std::vector<uint32_t>> operator()(const uint32_t& ohMask) const;
   };
 
   /*!
@@ -98,7 +98,7 @@ namespace oh {
    */
   struct stopCalPulse2AllChannels : public xhal::common::rpc::Method
   {
-    void operator()(const uint32_t &ohN, const uint32_t &mask, const uint32_t &ch_min, const uint32_t &ch_max) const;
+    void operator()(const uint32_t& ohN, const uint32_t& mask, const uint32_t& ch_min, const uint32_t& ch_max) const;
   };
 
 }

--- a/include/ctp7_modules/common/utils.h
+++ b/include/ctp7_modules/common/utils.h
@@ -49,7 +49,7 @@ namespace utils {
      */
     struct update_address_table : public xhal::common::rpc::Method
     {
-        void operator()(const std::string &at_xml) const;
+        void operator()(const std::string& at_xml) const;
     };
 
     /*!
@@ -61,7 +61,7 @@ namespace utils {
      */
     struct readRegFromDB : public xhal::common::rpc::Method
     {
-        RegInfo operator()(const std::string &regName) const;
+        RegInfo operator()(const std::string& regName) const;
     };
 
     /*!
@@ -73,7 +73,7 @@ namespace utils {
      */
     struct [[deprecated]] readRemoteReg : public xhal::common::rpc::Method
     {
-        uint32_t operator()(const std::string &regName) const;
+        uint32_t operator()(const std::string& regName) const;
     };
 
     /*!
@@ -85,7 +85,7 @@ namespace utils {
      */
     struct [[deprecated]] writeRemoteReg : public xhal::common::rpc::Method
     {
-        void operator()(const std::string &regName, const uint32_t value) const;
+        void operator()(const std::string& regName, const uint32_t& value) const;
     };
 }
 #endif

--- a/include/ctp7_modules/common/vfat3.h
+++ b/include/ctp7_modules/common/vfat3.h
@@ -52,7 +52,7 @@ namespace vfat3 {
    */
   struct configureVFAT3DACMonitorMultiLink : public xhal::common::rpc::Method
   {
-    void operator()(const uint16_t& ohMask, const std::array<uint32_t, amc::OH_PER_AMC> & vfatMasks, const uint32_t& dacSelect) const;
+    void operator()(const uint16_t& ohMask, const std::array<uint32_t, amc::OH_PER_AMC>& vfatMasks, const uint32_t& dacSelect) const;
   };
 
   /*!
@@ -122,7 +122,7 @@ namespace vfat3 {
    */
   struct setChannelRegistersVFAT3Simple : public xhal::common::rpc::Method
   {
-    void operator()(const uint16_t& ohN, const std::vector<uint32_t> &chanRegData, const uint32_t& vfatMask=0xff000000) const;
+    void operator()(const uint16_t& ohN, const std::vector<uint32_t>& chanRegData, const uint32_t& vfatMask=0xff000000) const;
   };
 
   /*!
@@ -176,7 +176,7 @@ namespace vfat3 {
    */
   struct getVFAT3ChipIDs : public xhal::common::rpc::Method
   {
-    std::vector<uint32_t> operator()(const uint16_t& ohN, const uint32_t& vfatMask=0xff000000, const bool &rawID=false) const;
+    std::vector<uint32_t> operator()(const uint16_t& ohN, const uint32_t& vfatMask=0xff000000, const bool& rawID=false) const;
   };
 
 }

--- a/include/ctp7_modules/common/vfat3.h
+++ b/include/ctp7_modules/common/vfat3.h
@@ -28,7 +28,7 @@ namespace vfat3 {
    */
   struct vfatSyncCheck : public xhal::common::rpc::Method
   {
-    uint32_t operator()(const uint16_t &ohN, const uint32_t &mask=0xff000000) const;
+    uint32_t operator()(const uint16_t& ohN, const uint32_t& mask=0xff000000) const;
   };
 
   /*!
@@ -40,7 +40,7 @@ namespace vfat3 {
    */
   struct configureVFAT3DACMonitor : public xhal::common::rpc::Method
   {
-    void operator()(const uint16_t &ohN, const uint32_t &mask, const uint32_t &dacSelect) const;
+    void operator()(const uint16_t& ohN, const uint32_t& mask, const uint32_t& dacSelect) const;
   };
 
   /*!
@@ -52,7 +52,7 @@ namespace vfat3 {
    */
   struct configureVFAT3DACMonitorMultiLink : public xhal::common::rpc::Method
   {
-    void operator()(const uint16_t &ohMask, const std::array<uint32_t, amc::OH_PER_AMC> & vfatMasks, const uint32_t &dacSelect) const;
+    void operator()(const uint16_t& ohMask, const std::array<uint32_t, amc::OH_PER_AMC> & vfatMasks, const uint32_t& dacSelect) const;
   };
 
   /*!
@@ -65,7 +65,7 @@ namespace vfat3 {
    */
   struct configureVFAT3s : public xhal::common::rpc::Method
   {
-    void operator()(const uint16_t &ohN, const uint32_t &vfatMask=0xff000000) const;
+    void operator()(const uint16_t& ohN, const uint32_t& vfatMask=0xff000000) const;
   };
 
   /*!
@@ -78,7 +78,7 @@ namespace vfat3 {
    */
   struct getChannelRegistersVFAT3 : public xhal::common::rpc::Method
   {
-    std::vector<uint32_t> operator()(const uint16_t &ohN, const uint32_t &vfatMask=0xff000000) const;
+    std::vector<uint32_t> operator()(const uint16_t& ohN, const uint32_t& vfatMask=0xff000000) const;
   };
 
   /*!
@@ -92,7 +92,7 @@ namespace vfat3 {
    */
   struct readVFAT3ADC : public xhal::common::rpc::Method
   {
-    std::vector<uint32_t> operator()(const uint16_t &ohN, const bool &useExtRefADC=false, const uint32_t &vfatMask=0xff000000) const;
+    std::vector<uint32_t> operator()(const uint16_t& ohN, const bool &useExtRefADC=false, const uint32_t& vfatMask=0xff000000) const;
   };
 
 
@@ -107,7 +107,7 @@ namespace vfat3 {
    */
   struct readVFAT3ADCMultiLink : public xhal::common::rpc::Method
   {
-    std::map<uint32_t,std::vector<uint32_t>> operator()(const uint16_t &ohMask, const bool &useExtRefADC) const;
+    std::map<uint32_t,std::vector<uint32_t>> operator()(const uint16_t& ohMask, const bool &useExtRefADC) const;
   };
 
   /*!
@@ -122,7 +122,7 @@ namespace vfat3 {
    */
   struct setChannelRegistersVFAT3Simple : public xhal::common::rpc::Method
   {
-    void operator()(const uint16_t &ohN, const std::vector<uint32_t> &chanRegData, const uint32_t &vfatMask=0xff000000) const;
+    void operator()(const uint16_t& ohN, const std::vector<uint32_t> &chanRegData, const uint32_t& vfatMask=0xff000000) const;
   };
 
   /*!
@@ -142,14 +142,14 @@ namespace vfat3 {
    */
   struct setChannelRegistersVFAT3 : public xhal::common::rpc::Method
   {
-    void operator()(const uint16_t &ohN,
+    void operator()(const uint16_t& ohN,
                     const std::vector<uint32_t> &calEnable,
                     const std::vector<uint32_t> &masks,
                     const std::vector<uint32_t> &trimARM,
                     const std::vector<uint32_t> &trimARMPol,
                     const std::vector<uint32_t> &trimZCC,
                     const std::vector<uint32_t> &trimZCCPol,
-                    const uint32_t &vfatMask=0xff000000)
+                    const uint32_t& vfatMask=0xff000000)
       const;
   };
 
@@ -162,7 +162,7 @@ namespace vfat3 {
    */
   struct statusVFAT3s : public xhal::common::rpc::Method
   {
-    std::map<std::string, std::vector<uint32_t>> operator()(const uint16_t &ohN) const;
+    std::map<std::string, std::vector<uint32_t>> operator()(const uint16_t& ohN) const;
   };
 
   /*!
@@ -176,7 +176,7 @@ namespace vfat3 {
    */
   struct getVFAT3ChipIDs : public xhal::common::rpc::Method
   {
-    std::vector<uint32_t> operator()(const uint16_t &ohN, const uint32_t &vfatMask=0xff000000, const bool &rawID=false) const;
+    std::vector<uint32_t> operator()(const uint16_t& ohN, const uint32_t& vfatMask=0xff000000, const bool &rawID=false) const;
   };
 
 }

--- a/src/amc.cpp
+++ b/src/amc.cpp
@@ -43,7 +43,7 @@ uint32_t amc::fw_version_check(const char* caller_name)
     return fw_maj;
 }
 
-uint32_t amc::getOHVFATMask::operator()(const uint32_t &ohN) const
+uint32_t amc::getOHVFATMask::operator()(const uint32_t& ohN) const
 {
     uint32_t mask = 0x0;
     std::stringstream regName;
@@ -61,7 +61,7 @@ uint32_t amc::getOHVFATMask::operator()(const uint32_t &ohN) const
     return mask;
 }
 
-std::vector<uint32_t> amc::getOHVFATMaskMultiLink::operator()(const uint32_t &ohMask) const
+std::vector<uint32_t> amc::getOHVFATMaskMultiLink::operator()(const uint32_t& ohMask) const
 {
     const uint32_t supOH = utils::readReg("GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
 
@@ -95,7 +95,7 @@ std::vector<uint32_t> amc::getOHVFATMaskMultiLink::operator()(const uint32_t &oh
     return vfatMasks;
 }
 
-std::vector<uint32_t> amc::sbitReadOut::operator()(const uint32_t &ohN, const uint32_t &acquireTime) const
+std::vector<uint32_t> amc::sbitReadOut::operator()(const uint32_t& ohN, const uint32_t& acquireTime) const
 {
     const int nclusters = 8;
     utils::writeReg("GEM_AMC.TRIGGER.SBIT_MONITOR.OH_SELECT", ohN);
@@ -159,7 +159,7 @@ std::vector<uint32_t> amc::sbitReadOut::operator()(const uint32_t &ohN, const ui
     return storedSbits;
 }
 
-std::map<std::string, uint32_t> amc::repeatedRegRead::operator()(const std::vector<std::string> &regList, const bool &breakOnFailure, const uint32_t &nReads) const
+std::map<std::string, uint32_t> amc::repeatedRegRead::operator()(const std::vector<std::string>& regList, const bool& breakOnFailure, const uint32_t& nReads) const
 {
     utils::SlowCtrlErrCntVFAT vfatErrs;
     for (auto const & regIter : regList) {

--- a/src/amc/blaster_ram.cpp
+++ b/src/amc/blaster_ram.cpp
@@ -20,7 +20,7 @@ namespace amc {
   }
 }
 
-uint32_t amc::blaster::getRAMMaxSize::operator()(BLASTERType const& type) const
+uint32_t amc::blaster::getRAMMaxSize::operator()(const BLASTERType& type) const
 {
   uint32_t ram_size = 0x0;
   switch (type) {
@@ -48,14 +48,14 @@ uint32_t amc::blaster::getRAMMaxSize::operator()(BLASTERType const& type) const
   // return ram_size;
 }
 
-bool amc::blaster::checkBLOBSize(BLASTERType const& type, size_t const& sz)
+bool amc::blaster::checkBLOBSize(const BLASTERType& type, const size_t& sz)
 {
   uint32_t ram_sz = getRAMMaxSize{}(type);
   bool valid = (sz == ram_sz) ? true : false;
   return valid;
 }
 
-uint32_t amc::blaster::getRAMBaseAddr(BLASTERType const& type, uint8_t const& ohN, uint8_t const& partN)
+uint32_t amc::blaster::getRAMBaseAddr(const BLASTERType& type, const uint8_t& ohN, const uint8_t& partN)
 {
   uint32_t base = 0x0;
   std::string regName;
@@ -106,7 +106,7 @@ uint32_t amc::blaster::getRAMBaseAddr(BLASTERType const& type, uint8_t const& oh
   throw std::runtime_error(errmsg.str());
 }
 
-std::vector<uint32_t> amc::blaster::readConfRAM::operator()(BLASTERType const& type, size_t const& blob_sz) const
+std::vector<uint32_t> amc::blaster::readConfRAM::operator()(const BLASTERType& type, const size_t& blob_sz) const
 {
   uint32_t nwords = 0x0;
   // uint32_t offset = 0x0;
@@ -172,7 +172,7 @@ std::vector<uint32_t> amc::blaster::readConfRAM::operator()(BLASTERType const& t
   return blob;
 }
 
-std::vector<uint32_t> amc::blaster::readGBTConfRAM::operator()(const uint16_t &ohMask) const
+std::vector<uint32_t> amc::blaster::readGBTConfRAM::operator()(const uint16_t& ohMask) const
 {
   LOG4CPLUS_DEBUG(logger, "readGBTConfRAM called");
 
@@ -202,7 +202,7 @@ std::vector<uint32_t> amc::blaster::readGBTConfRAM::operator()(const uint16_t &o
   }
 }
 
-std::vector<uint32_t> amc::blaster::readOptoHybridConfRAM::operator()(const uint16_t &ohMask) const
+std::vector<uint32_t> amc::blaster::readOptoHybridConfRAM::operator()(const uint16_t& ohMask) const
 {
   LOG4CPLUS_DEBUG(logger, "readOptoHybridConfRAM called");
 
@@ -232,7 +232,7 @@ std::vector<uint32_t> amc::blaster::readOptoHybridConfRAM::operator()(const uint
   }
 }
 
-std::vector<uint32_t> amc::blaster::readVFATConfRAM::operator()(const uint16_t &ohMask) const
+std::vector<uint32_t> amc::blaster::readVFATConfRAM::operator()(const uint16_t& ohMask) const
 {
   LOG4CPLUS_DEBUG(logger, "readVFATConfRAM called");
 
@@ -262,7 +262,7 @@ std::vector<uint32_t> amc::blaster::readVFATConfRAM::operator()(const uint16_t &
   }
 }
 
-void amc::blaster::writeConfRAM::operator()(BLASTERType const& type, std::vector<uint32_t> blob) const
+void amc::blaster::writeConfRAM::operator()(const BLASTERType& type, const std::vector<uint32_t>& blob) const
 {
   if (!checkBLOBSize(type, blob.size())) {
     std::stringstream errmsg;
@@ -324,7 +324,7 @@ void amc::blaster::writeConfRAM::operator()(BLASTERType const& type, std::vector
   }
 }
 
-void amc::blaster::writeGBTConfRAM::operator()(const std::vector<uint32_t> &gbtblob, const uint16_t &ohMask) const
+void amc::blaster::writeGBTConfRAM::operator()(const std::vector<uint32_t>& gbtblob, const uint16_t& ohMask) const
 {
   LOG4CPLUS_DEBUG(logger, "writeGBTConfRAM called");
 
@@ -353,7 +353,7 @@ void amc::blaster::writeGBTConfRAM::operator()(const std::vector<uint32_t> &gbtb
   return;
 }
 
-void amc::blaster::writeOptoHybridConfRAM::operator()(const std::vector<uint32_t> &ohblob, const uint16_t &ohMask) const
+void amc::blaster::writeOptoHybridConfRAM::operator()(const std::vector<uint32_t>& ohblob, const uint16_t& ohMask) const
 {
   LOG4CPLUS_DEBUG(logger, "writeOptoHybridConfRAM called");
 
@@ -382,7 +382,7 @@ void amc::blaster::writeOptoHybridConfRAM::operator()(const std::vector<uint32_t
   return;
 }
 
-void amc::blaster::writeVFATConfRAM::operator()(const std::vector<uint32_t> &vfatblob, const uint16_t &ohMask) const
+void amc::blaster::writeVFATConfRAM::operator()(const std::vector<uint32_t>& vfatblob, const uint16_t& ohMask) const
 {
   LOG4CPLUS_DEBUG(logger, "writeVFATConfRAM called");
 

--- a/src/amc/daq.cpp
+++ b/src/amc/daq.cpp
@@ -9,7 +9,7 @@
 #include "ctp7_modules/common/utils.h"
 #include "ctp7_modules/server/utils.h"
 
-void amc::daq::enableDAQLink::operator()(uint32_t const& enableMask) const
+void amc::daq::enableDAQLink::operator()(const uint32_t& enableMask) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
   LOG4CPLUS_DEBUG(logger, "enableDAQLinkLocal called");
@@ -24,7 +24,7 @@ void amc::daq::disableDAQLink::operator()() const
   utils::writeReg("GEM_AMC.DAQ.CONTROL.DAQ_ENABLE",        0x0);
 }
 
-void amc::daq::setZS::operator()(bool en) const
+void amc::daq::setZS::operator()(const bool& en) const
 {
   utils::writeReg("GEM_AMC.DAQ.CONTROL.ZERO_SUPPRESSION_EN", uint32_t(en));
 }
@@ -34,7 +34,7 @@ void amc::daq::disableZS::operator()() const
   utils::writeReg("GEM_AMC.DAQ.CONTROL.ZERO_SUPPRESSION_EN", 0x0);
 }
 
-void amc::daq::resetDAQLink::operator()(uint32_t const& davTO, uint32_t const& ttsOverride) const
+void amc::daq::resetDAQLink::operator()(const uint32_t& davTO, const uint32_t& ttsOverride) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
   LOG4CPLUS_DEBUG(logger, "resetDAQLinkLocal called");
@@ -157,21 +157,21 @@ uint32_t amc::daq::getDAQLinkDAVTimer::operator()(bool const& max) const
     return lasttimer;
 }
 
-uint32_t amc::daq::getLinkDAQStatus::operator()(uint8_t const& gtx) const
+uint32_t amc::daq::getLinkDAQStatus::operator()(const uint8_t& gtx) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
   LOG4CPLUS_WARN(logger,"getLinkDAQStatus not implemented");
   return 0x0;
 }
 
-uint32_t amc::daq::getLinkDAQCounters::operator()(uint8_t const& gtx, uint8_t const& mode) const
+uint32_t amc::daq::getLinkDAQCounters::operator()(const uint8_t& gtx, const uint8_t& mode) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
   LOG4CPLUS_WARN(logger,"getLinkDAQCounters not implemented");
   return 0x0;
 }
 
-uint32_t amc::daq::getLinkLastDAQBlock::operator()(uint8_t const& gtx) const
+uint32_t amc::daq::getLinkLastDAQBlock::operator()(const uint8_t& gtx) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
   LOG4CPLUS_WARN(logger,"getLinkLastDAQBlock not implemented");
@@ -193,7 +193,7 @@ uint32_t amc::daq::getDAQLinkRunParameters::operator()() const
   return utils::readReg("GEM_AMC.DAQ.EXT_CONTROL.RUN_PARAMS");
 }
 
-uint32_t amc::daq::getDAQLinkRunParameter::operator()(uint8_t const& parameter) const
+uint32_t amc::daq::getDAQLinkRunParameter::operator()(const uint8_t& parameter) const
 {
   std::stringstream regname;
   regname << "GEM_AMC.DAQ.EXT_CONTROL.RUN_PARAM" << static_cast<int>(parameter);
@@ -201,18 +201,18 @@ uint32_t amc::daq::getDAQLinkRunParameter::operator()(uint8_t const& parameter) 
 }
 
 
-void amc::daq::setDAQLinkInputTimeout::operator()(uint32_t const& inputTO) const
+void amc::daq::setDAQLinkInputTimeout::operator()(const uint32_t& inputTO) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
   LOG4CPLUS_WARN(logger,"setDAQLinkInputTimeout not implemented");
 }
 
-void amc::daq::setDAQLinkRunType::operator()(uint32_t const& rtype) const
+void amc::daq::setDAQLinkRunType::operator()(const uint32_t& rtype) const
 {
   utils::writeReg("GEM_AMC.DAQ.EXT_CONTROL.RUN_TYPE", rtype);
 }
 
-void amc::daq::setDAQLinkRunParameter::operator()(uint8_t const& parN, uint8_t const& rparam) const
+void amc::daq::setDAQLinkRunParameter::operator()(const uint8_t& parN, const uint8_t& rparam) const
 {
   if (parN < 1 || parN > 3) {
     std::stringstream errmsg;
@@ -225,14 +225,14 @@ void amc::daq::setDAQLinkRunParameter::operator()(uint8_t const& parN, uint8_t c
   utils::writeReg(regBase.str(), rparam);
 }
 
-void amc::daq::setDAQLinkRunParameters::operator()(uint32_t const& rparams) const
+void amc::daq::setDAQLinkRunParameters::operator()(const uint32_t& rparams) const
 {
   utils::writeReg("GEM_AMC.DAQ.EXT_CONTROL.RUN_PARAMS", rparams);
 }
 
 
 /** Composite methods */
-void amc::daq::configureDAQModule::operator()(bool enableZS, uint32_t runType, bool doPhaseShift, bool relock, bool bc0LockPSMode) const
+void amc::daq::configureDAQModule::operator()(const bool& enableZS, const uint32_t& runType, const bool& doPhaseShift, const bool& relock, const bool& bc0LockPSMode) const
 {
   // FIXME: Should the full routine be run in the event of an error?
   // Curently none of these calls will throw/error directly, could handle that here?
@@ -253,7 +253,7 @@ void amc::daq::configureDAQModule::operator()(bool enableZS, uint32_t runType, b
   amc::daq::setDAQLinkRunParameters{}(0xfaac);
 }
 
-void amc::daq::enableDAQModule::operator()(bool enableZS) const
+void amc::daq::enableDAQModule::operator()(const bool& enableZS) const
 {
   // FIXME: Should the full routine be run in the event of an error?
   // Curently none of these calls will throw/error directly, could handle that here?

--- a/src/amc/sca.cpp
+++ b/src/amc/sca.cpp
@@ -19,7 +19,7 @@ namespace amc {
   }
 }
 
-uint32_t amc::sca::formatSCAData(uint32_t const& data)
+uint32_t amc::sca::formatSCAData(const uint32_t& data)
 {
   return (
           ((data&0xff000000)>>24) +
@@ -29,7 +29,7 @@ uint32_t amc::sca::formatSCAData(uint32_t const& data)
           );
 }
 
-void amc::sca::sendSCACommand::operator()(uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask) const
+void amc::sca::sendSCACommand::operator()(const uint8_t& ch, const uint8_t& cmd, const uint8_t& len, const uint32_t& data, const uint16_t& ohMask) const
 {
   // FIXME: DECIDE WHETHER TO HAVE HERE // if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
   // FIXME: DECIDE WHETHER TO HAVE HERE //   utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",         0xffffffff);
@@ -43,7 +43,7 @@ void amc::sca::sendSCACommand::operator()(uint8_t const& ch, uint8_t const& cmd,
   utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.MANUAL_CONTROL.SCA_CMD.SCA_CMD_EXECUTE",0x1);
 }
 
-std::vector<uint32_t> amc::sca::sendSCACommandWithReply::operator()(uint8_t const& ch, uint8_t const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask) const
+std::vector<uint32_t> amc::sca::sendSCACommandWithReply::operator()(const uint8_t& ch, const uint8_t& cmd, const uint8_t& len, const uint32_t& data, const uint16_t& ohMask) const
 {
   // FIXME: DECIDE WHETHER TO HAVE HERE // if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
   // FIXME: DECIDE WHETHER TO HAVE HERE //   uint32_t monMask = utils::readReg("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF");
@@ -70,7 +70,7 @@ std::vector<uint32_t> amc::sca::sendSCACommandWithReply::operator()(uint8_t cons
   return reply;
 }
 
-std::vector<uint32_t> amc::sca::scaCTRLCommand::operator()(sca::CTRLCommand const& cmd, uint16_t const& ohMask, uint8_t const& len, uint32_t const& data) const
+std::vector<uint32_t> amc::sca::scaCTRLCommand::operator()(const sca::CTRLCommand& cmd, const uint16_t& ohMask, const uint8_t& len, const uint32_t& data) const
 {
   uint32_t monMask = 0xffffffff;
   if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
@@ -112,7 +112,7 @@ std::vector<uint32_t> amc::sca::scaCTRLCommand::operator()(sca::CTRLCommand cons
   return result;
 }
 
-std::vector<uint32_t> amc::sca::scaI2CCommand::operator()(sca::I2CChannel const& ch, sca::I2CCommand const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask) const
+std::vector<uint32_t> amc::sca::scaI2CCommand::operator()(const sca::I2CChannel& ch, const sca::I2CCommand& cmd, const uint8_t& len, const uint32_t& data, const uint16_t& ohMask) const
 {
 
   // enable the I2C bus through the CTRL CR{B,C,D} registers
@@ -138,7 +138,7 @@ std::vector<uint32_t> amc::sca::scaI2CCommand::operator()(sca::I2CChannel const&
   return result;
 }
 
-std::vector<uint32_t> amc::sca::scaGPIOCommand::operator()(sca::GPIOCommand const& cmd, uint8_t const& len, uint32_t data, uint16_t const& ohMask) const
+std::vector<uint32_t> amc::sca::scaGPIOCommand::operator()(const sca::GPIOCommand& cmd, const uint8_t& len, const uint32_t& data, const uint16_t& ohMask) const
 {
   // enable the GPIO bus through the CTRL CRB register, bit 2
   uint32_t monMask = 0xffffffff;
@@ -156,7 +156,7 @@ std::vector<uint32_t> amc::sca::scaGPIOCommand::operator()(sca::GPIOCommand cons
   return reply;
 }
 
-std::vector<uint32_t> amc::sca::scaADCCommand::operator()(sca::ADCChannel const& ch, uint16_t const& ohMask) const
+std::vector<uint32_t> amc::sca::scaADCCommand::operator()(const sca::ADCChannel& ch, const uint16_t& ohMask) const
 {
   uint32_t monMask = 0xffffffff;
   if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
@@ -191,7 +191,7 @@ std::vector<uint32_t> amc::sca::scaADCCommand::operator()(sca::ADCChannel const&
   return result;
 }
 
-std::vector<uint32_t> amc::sca::readSCAChipID::operator()(uint16_t const& ohMask, bool scaV1) const
+std::vector<uint32_t> amc::sca::readSCAChipID::operator()(const uint16_t& ohMask, const bool& scaV1) const
 {
   if (scaV1)
     return amc::sca::scaCTRLCommand{}(sca::CTRLCommand::CTRL_R_ID_V1, ohMask);
@@ -201,7 +201,7 @@ std::vector<uint32_t> amc::sca::readSCAChipID::operator()(uint16_t const& ohMask
   // ID = DATA[23:0], need to have this set up in the reply function somehow?
 }
 
-std::vector<uint32_t> amc::sca::readSCASEUCounter::operator()(uint16_t const& ohMask, bool reset) const
+std::vector<uint32_t> amc::sca::readSCASEUCounter::operator()(const uint16_t& ohMask, const bool& reset) const
 {
   if (reset)
     amc::sca::resetSCASEUCounter{}(ohMask);
@@ -211,12 +211,12 @@ std::vector<uint32_t> amc::sca::readSCASEUCounter::operator()(uint16_t const& oh
   // SEU count = DATA[31:0]
 }
 
-void amc::sca::resetSCASEUCounter::operator()(uint16_t const& ohMask) const
+void amc::sca::resetSCASEUCounter::operator()(const uint16_t& ohMask) const
 {
   amc::sca::scaCTRLCommand{}(sca::CTRLCommand::CTRL_C_SEU, ohMask);
 }
 
-void amc::sca::scaModuleReset::operator()(uint16_t const& ohMask) const
+void amc::sca::scaModuleReset::operator()(const uint16_t& ohMask) const
 {
   // Does this need to be protected, or do all versions of FW have this register?
   uint32_t origMask = utils::readReg("GEM_AMC.SLOW_CONTROL.SCA.CTRL.SCA_RESET_ENABLE_MASK");
@@ -228,12 +228,12 @@ void amc::sca::scaModuleReset::operator()(uint16_t const& ohMask) const
   utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.CTRL.SCA_RESET_ENABLE_MASK", origMask);
 }
 
-void amc::sca::scaHardResetEnable::operator()(bool en) const
+void amc::sca::scaHardResetEnable::operator()(const bool& en) const
 {
   utils::writeReg("GEM_AMC.SLOW_CONTROL.SCA.CTRL.TTC_HARD_RESET_EN", uint32_t(en));
 }
 
-std::vector<uint32_t> amc::sca::readSCAADCSensor::operator()(sca::ADCChannel const& ch, uint16_t const& ohMask) const
+std::vector<uint32_t> amc::sca::readSCAADCSensor::operator()(const sca::ADCChannel& ch, const uint16_t& ohMask) const
 {
   std::vector<uint32_t> result;
   std::vector<uint32_t> outData;
@@ -250,7 +250,7 @@ std::vector<uint32_t> amc::sca::readSCAADCSensor::operator()(sca::ADCChannel con
   return outData;
 }
 
-std::vector<uint32_t> amc::sca::readSCAADCTemperatureSensors::operator()(uint16_t const& ohMask) const
+std::vector<uint32_t> amc::sca::readSCAADCTemperatureSensors::operator()(const uint16_t& ohMask) const
 {
   sca::ADCChannel chArr[5] = {
     sca::ADCChannel::VTTX_CSC_PT100,
@@ -275,7 +275,7 @@ std::vector<uint32_t> amc::sca::readSCAADCTemperatureSensors::operator()(uint16_
   return outData;
 }
 
-std::vector<uint32_t> amc::sca::readSCAADCVoltageSensors::operator()(uint16_t const& ohMask) const
+std::vector<uint32_t> amc::sca::readSCAADCVoltageSensors::operator()(const uint16_t& ohMask) const
 {
   sca::ADCChannel chArr[6] = {
     sca::ADCChannel::PROM_V1P8,
@@ -301,7 +301,7 @@ std::vector<uint32_t> amc::sca::readSCAADCVoltageSensors::operator()(uint16_t co
   return outData;
 }
 
-std::vector<uint32_t> amc::sca::readSCAADCSignalStrengthSensors::operator()(uint16_t const& ohMask) const
+std::vector<uint32_t> amc::sca::readSCAADCSignalStrengthSensors::operator()(const uint16_t& ohMask) const
 {
   sca::ADCChannel chArr[3] = {
     static_cast<sca::ADCChannel>(sca::ADCChannel::VTRX_RSSI1),
@@ -325,7 +325,7 @@ std::vector<uint32_t> amc::sca::readSCAADCSignalStrengthSensors::operator()(uint
   return outData;
 }
 
-std::vector<uint32_t> amc::sca::readAllSCAADCSensors::operator()(uint16_t const& ohMask) const
+std::vector<uint32_t> amc::sca::readAllSCAADCSensors::operator()(const uint16_t& ohMask) const
 {
   int ohIdx;
   std::vector<uint32_t> result;

--- a/src/amc/ttc.cpp
+++ b/src/amc/ttc.cpp
@@ -26,7 +26,7 @@ void amc::ttc::ttcMMCMReset::operator()() const
   utils::writeReg("GEM_AMC.TTC.CTRL.MMCM_RESET", 0x1);
 }
 
-void amc::ttc::ttcMMCMPhaseShift::operator()(bool relock, bool modeBC0, bool scan) const
+void amc::ttc::ttcMMCMPhaseShift::operator()(const bool& relock, const bool& modeBC0, const bool& scan) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
 
@@ -89,7 +89,7 @@ void amc::ttc::ttcMMCMPhaseShift::operator()(bool relock, bool modeBC0, bool sca
 
   uint32_t mmcmShiftCnt = utils::readReg("GEM_AMC.TTC.STATUS.CLK.PA_MANUAL_SHIFT_CNT");
   uint32_t gthShiftCnt  = utils::readReg("GEM_AMC.TTC.STATUS.CLK.PA_MANUAL_GTH_SHIFT_CNT");
-  std::uint32_t pllLockCnt = amc::ttc::checkPLLLock{}(readAttempts);
+  uint32_t pllLockCnt = amc::ttc::checkPLLLock{}(readAttempts);
   bool firstUnlockFound = false;
   bool nextLockFound    = false;
   bool bestLockFound    = false;
@@ -549,7 +549,7 @@ void amc::ttc::ttcMMCMPhaseShift::operator()(bool relock, bool modeBC0, bool sca
   return;
 }
 
-std::uint32_t amc::ttc::checkPLLLock::operator()(const std::uint32_t readAttempts) const
+uint32_t amc::ttc::checkPLLLock::operator()(const uint32_t& readAttempts) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
 
@@ -557,7 +557,7 @@ std::uint32_t amc::ttc::checkPLLLock::operator()(const std::uint32_t readAttempt
   std::stringstream msg;
   msg << "Executing checkPLLLock with " << readAttempts << " attempted relocks";
   LOG4CPLUS_DEBUG(logger, msg.str());
-  for (std::uint32_t i = 0; i < readAttempts; ++i ) {
+  for (uint32_t i = 0; i < readAttempts; ++i ) {
     utils::writeReg("GEM_AMC.TTC.CTRL.PA_MANUAL_PLL_RESET", 0x1);
 
     // wait 100us to allow the PLL to lock
@@ -572,7 +572,7 @@ std::uint32_t amc::ttc::checkPLLLock::operator()(const std::uint32_t readAttempt
 }
 
 // FIXME: can maybe abstract this to amc::ttc::getPhase(clk, mode, reads)
-float amc::ttc::getMMCMPhaseMean::operator()(const std::uint32_t readAttempts) const
+float amc::ttc::getMMCMPhaseMean::operator()(const uint32_t& readAttempts) const
 {
   if (readAttempts < 1) {
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.TTC_PM_PHASE_MEAN"));
@@ -580,14 +580,14 @@ float amc::ttc::getMMCMPhaseMean::operator()(const std::uint32_t readAttempts) c
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.TTC_PM_PHASE"));
   } else {
     float mean = 0.;
-    for (std::uint32_t read = 0; read < readAttempts; ++read) {
+    for (uint32_t read = 0; read < readAttempts; ++read) {
       mean += utils::readReg("GEM_AMC.TTC.STATUS.CLK.TTC_PM_PHASE");
     }
     return mean/readAttempts;
   }
 }
 
-float amc::ttc::getGTHPhaseMean::operator()(const std::uint32_t readAttempts) const
+float amc::ttc::getGTHPhaseMean::operator()(const uint32_t& readAttempts) const
 {
   if (readAttempts < 1) {
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.GTH_PM_PHASE_MEAN"));
@@ -595,14 +595,14 @@ float amc::ttc::getGTHPhaseMean::operator()(const std::uint32_t readAttempts) co
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.GTH_PM_PHASE"));
   } else {
     float mean = 0.;
-    for (std::uint32_t read = 0; read < readAttempts; ++read) {
+    for (uint32_t read = 0; read < readAttempts; ++read) {
       mean += utils::readReg("GEM_AMC.TTC.STATUS.CLK.GTH_PM_PHASE");
     }
     return mean/readAttempts;
   }
 }
 
-float amc::ttc::getMMCMPhaseMedian::operator()(const std::uint32_t readAttempts) const
+float amc::ttc::getMMCMPhaseMedian::operator()(const uint32_t& readAttempts) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
 
@@ -613,14 +613,14 @@ float amc::ttc::getMMCMPhaseMedian::operator()(const std::uint32_t readAttempts)
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.TTC_PM_PHASE"));
   } else {
     float mean = 0.;
-    for (std::uint32_t read = 0; read < readAttempts; ++read) {
+    for (uint32_t read = 0; read < readAttempts; ++read) {
       mean += utils::readReg("GEM_AMC.TTC.STATUS.CLK.TTC_PM_PHASE");
     }
     return mean/readAttempts;
   }
 }
 
-float amc::ttc::getGTHPhaseMedian::operator()(const std::uint32_t readAttempts) const
+float amc::ttc::getGTHPhaseMedian::operator()(const uint32_t& readAttempts) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
 
@@ -631,7 +631,7 @@ float amc::ttc::getGTHPhaseMedian::operator()(const std::uint32_t readAttempts) 
     return static_cast<float>(utils::readReg("GEM_AMC.TTC.STATUS.CLK.GTH_PM_PHASE"));
   } else {
     float mean = 0.;
-    for (std::uint32_t read = 0; read < readAttempts; ++read) {
+    for (uint32_t read = 0; read < readAttempts; ++read) {
       mean += utils::readReg("GEM_AMC.TTC.STATUS.CLK.GTH_PM_PHASE");
     }
     return mean/readAttempts;
@@ -648,13 +648,13 @@ bool amc::ttc::getL1AEnable::operator()() const
   return utils::readReg("GEM_AMC.TTC.CTRL.L1A_ENABLE");
 }
 
-void amc::ttc::setL1AEnable::operator()(bool enable) const
+void amc::ttc::setL1AEnable::operator()(const bool& enable) const
 {
   utils::writeReg("GEM_AMC.TTC.CTRL.L1A_ENABLE", int(enable));
 }
 
 /*** CONFIG submodule ***/
-uint32_t amc::ttc::getTTCConfig::operator()(uint8_t const& cmd) const
+uint32_t amc::ttc::getTTCConfig::operator()(const uint8_t& cmd) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
 
@@ -663,7 +663,7 @@ uint32_t amc::ttc::getTTCConfig::operator()(uint8_t const& cmd) const
   return 0x0;
 }
 
-void amc::ttc::setTTCConfig::operator()(uint8_t const& cmd, uint8_t const& value) const
+void amc::ttc::setTTCConfig::operator()(const uint8_t& cmd, const uint8_t& value) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
 
@@ -685,7 +685,7 @@ uint32_t amc::ttc::getTTCStatus::operator()() const
   return retval;
 }
 
-uint32_t amc::ttc::getTTCErrorCount::operator()(bool const& single) const
+uint32_t amc::ttc::getTTCErrorCount::operator()(const bool& single) const
 {
   if (single)
     return utils::readReg("GEM_AMC.TTC.STATUS.TTC_SINGLE_ERROR_CNT");
@@ -694,7 +694,7 @@ uint32_t amc::ttc::getTTCErrorCount::operator()(bool const& single) const
 }
 
 /*** CMD_COUNTERS submodule ***/
-uint32_t amc::ttc::getTTCCounter::operator()(uint8_t const& cmd) const
+uint32_t amc::ttc::getTTCCounter::operator()(const uint8_t& cmd) const
 {
   switch(cmd) {
   case(0x1) :

--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -19,7 +19,7 @@ namespace calibration {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 }
 
-std::unordered_map<uint32_t, uint32_t> calibration::setSingleChanMask(const uint8_t &ohN, const uint8_t &vfatN, const uint8_t &ch)
+std::unordered_map<uint32_t, uint32_t> calibration::setSingleChanMask(const uint8_t& ohN, const uint8_t& vfatN, const uint8_t& ch)
 {
   std::unordered_map<uint32_t, uint32_t> map_chanOrigMask;
   uint32_t chanMaskAddr;
@@ -44,12 +44,12 @@ void calibration::applyChanMask(const std::unordered_map<uint32_t, uint32_t> &ch
   }
 }
 
-void calibration::confCalPulse::operator()(const uint16_t &ohN,
-                                           const uint32_t &vfatMask,
-                                           const uint8_t &ch,
-                                           const bool &toggleOn,
-                                           const bool &currentPulse,
-                                           const uint32_t &calScaleFactor) const
+void calibration::confCalPulse::operator()(const uint16_t& ohN,
+                                           const uint32_t& vfatMask,
+                                           const uint8_t& ch,
+                                           const bool& toggleOn,
+                                           const bool& currentPulse,
+                                           const uint32_t& calScaleFactor) const
 {
   const uint32_t notmask = (~vfatMask)&0xffffff;
 
@@ -99,7 +99,7 @@ void calibration::confCalPulse::operator()(const uint16_t &ohN,
   return;
 }
 
-void calibration::dacMonConf::operator()(const uint16_t &ohN, const uint8_t &ch) const
+void calibration::dacMonConf::operator()(const uint16_t& ohN, const uint8_t& ch) const
 {
   utils::writeReg("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.ENABLE", 0x0);
   utils::writeReg("GEM_AMC.GEM_TESTS.VFAT_DAQ_MONITOR.CTRL.RESET", 0x1);
@@ -112,7 +112,7 @@ void calibration::dacMonConf::operator()(const uint16_t &ohN, const uint8_t &ch)
   }
 }
 
-void calibration::ttcGenToggle::operator()(const bool &enable) const
+void calibration::ttcGenToggle::operator()(const bool& enable) const
 {
   if (enable) {
     // Internal TTC generator enabled, TTC cmds from backplane are ignored
@@ -123,8 +123,8 @@ void calibration::ttcGenToggle::operator()(const bool &enable) const
   }
 }
 
-void calibration::ttcGenConf::operator()(const uint32_t &pulseDelay, const uint32_t &L1Ainterval,
-                                         const bool &enable) const
+void calibration::ttcGenConf::operator()(const uint32_t& pulseDelay, const uint32_t& L1Ainterval,
+                                         const bool& enable) const
 {
   LOG4CPLUS_INFO(logger, "Entering ttcGenConf");
 
@@ -135,19 +135,19 @@ void calibration::ttcGenConf::operator()(const uint32_t &pulseDelay, const uint3
   ttcGenToggle{}(enable);
 }
 
-std::vector<uint32_t> calibration::genScan::operator()(const uint16_t &ohN,
-                                                       const uint32_t &vfatMask,
-                                                       const uint8_t &ch,
-                                                       const bool &useCalPulse,
-                                                       const bool &currentPulse,
-                                                       const uint32_t &calScaleFactor,
-                                                       const uint32_t &nevts,
-                                                       const uint32_t &dacMin,
-                                                       const uint32_t &dacMax,
-                                                       const uint32_t &dacStep,
-                                                       const std::string &scanReg,
-                                                       const bool &useUltra,
-                                                       const bool &useExtTrig) const
+std::vector<uint32_t> calibration::genScan::operator()(const uint16_t& ohN,
+                                                       const uint32_t& vfatMask,
+                                                       const uint8_t& ch,
+                                                       const bool& useCalPulse,
+                                                       const bool& currentPulse,
+                                                       const uint32_t& calScaleFactor,
+                                                       const uint32_t& nevts,
+                                                       const uint32_t& dacMin,
+                                                       const uint32_t& dacMax,
+                                                       const uint32_t& dacStep,
+                                                       const std::string& scanReg,
+                                                       const bool& useUltra,
+                                                       const bool& useExtTrig) const
 {
   const uint32_t notmask = (~vfatMask)&0xffffff;
 
@@ -280,18 +280,18 @@ std::vector<uint32_t> calibration::genScan::operator()(const uint16_t &ohN,
   return outData;
 }
 
-std::map<uint32_t, std::vector<uint32_t>> calibration::genChannelScan::operator()(const uint16_t &ohN,
-                                                                                  const uint32_t &vfatMask,
-                                                                                  const bool &useCalPulse,
-                                                                                  const bool &currentPulse,
-                                                                                  const uint32_t &calScaleFactor,
-                                                                                  const uint32_t &nevts,
-                                                                                  const uint32_t &dacMin,
-                                                                                  const uint32_t &dacMax,
-                                                                                  const uint32_t &dacStep,
-                                                                                  const std::string &scanReg,
-                                                                                  const bool &useUltra=false,
-                                                                                  const bool &useExtTrig=false) const
+std::map<uint32_t, std::vector<uint32_t>> calibration::genChannelScan::operator()(const uint16_t& ohN,
+                                                                                  const uint32_t& vfatMask,
+                                                                                  const bool& useCalPulse,
+                                                                                  const bool& currentPulse,
+                                                                                  const uint32_t& calScaleFactor,
+                                                                                  const uint32_t& nevts,
+                                                                                  const uint32_t& dacMin,
+                                                                                  const uint32_t& dacMax,
+                                                                                  const uint32_t& dacStep,
+                                                                                  const std::string& scanReg,
+                                                                                  const bool& useUltra=false,
+                                                                                  const bool& useExtTrig=false) const
 {
   std::map<uint32_t, std::vector<uint32_t>> outData;
 
@@ -301,15 +301,15 @@ std::map<uint32_t, std::vector<uint32_t>> calibration::genChannelScan::operator(
   return outData;
 }
 
-std::map<uint32_t, uint32_t> calibration::sbitRateScan::operator()(const uint16_t &ohN,
-                                                                   const uint32_t &vfatMask,
-                                                                   const uint8_t &ch,
-                                                                   const uint16_t &dacMin,
-                                                                   const uint16_t &dacMax,
-                                                                   const uint16_t &dacStep,
-                                                                   const std::string &scanReg,
-                                                                   const uint32_t &waitTime,
-                                                                   const bool &invertVFATPos) const
+std::map<uint32_t, uint32_t> calibration::sbitRateScan::operator()(const uint16_t& ohN,
+                                                                   const uint32_t& vfatMask,
+                                                                   const uint8_t& ch,
+                                                                   const uint16_t& dacMin,
+                                                                   const uint16_t& dacMax,
+                                                                   const uint16_t& dacStep,
+                                                                   const std::string& scanReg,
+                                                                   const uint32_t& waitTime,
+                                                                   const bool& invertVFATPos) const
 {
   std::map<uint32_t, uint32_t> outData;
 
@@ -377,13 +377,13 @@ std::map<uint32_t, uint32_t> calibration::sbitRateScan::operator()(const uint16_
   return outData;
 }
 
-std::map<uint32_t, std::vector<uint32_t>> calibration::sbitRateScanParallel::operator()(const uint8_t &ch,
-                                                                                        const uint16_t &dacMin,
-                                                                                        const uint16_t &dacMax,
-                                                                                        const uint16_t &dacStep,
-                                                                                        const std::string &scanReg,
-                                                                                        const uint16_t &ohMask,
-                                                                                        const uint32_t &waitTime) const
+std::map<uint32_t, std::vector<uint32_t>> calibration::sbitRateScanParallel::operator()(const uint8_t& ch,
+                                                                                        const uint16_t& dacMin,
+                                                                                        const uint16_t& dacMax,
+                                                                                        const uint16_t& dacStep,
+                                                                                        const std::string& scanReg,
+                                                                                        const uint16_t& ohMask,
+                                                                                        const uint32_t& waitTime) const
 {
   if (ohMask > 0xfff) {
     std::stringstream errmsg;
@@ -515,15 +515,15 @@ std::map<uint32_t, std::vector<uint32_t>> calibration::sbitRateScanParallel::ope
   return outData;
 }
 
-std::vector<uint32_t> calibration::checkSbitMappingWithCalPulse::operator()(const uint16_t &ohN,
-                                                                      const uint32_t &vfatN,
-                                                                      const uint32_t &vfatMask,
-                                                                      const bool &useCalPulse,
-                                                                      const bool &currentPulse,
-                                                                      const uint32_t &calScaleFactor,
-                                                                      const uint32_t &nevts,
-                                                                      const uint32_t &L1Ainterval,
-                                                                      const uint32_t &pulseDelay) const
+std::vector<uint32_t> calibration::checkSbitMappingWithCalPulse::operator()(const uint16_t& ohN,
+                                                                      const uint32_t& vfatN,
+                                                                      const uint32_t& vfatMask,
+                                                                      const bool& useCalPulse,
+                                                                      const bool& currentPulse,
+                                                                      const uint32_t& calScaleFactor,
+                                                                      const uint32_t& nevts,
+                                                                      const uint32_t& L1Ainterval,
+                                                                      const uint32_t& pulseDelay) const
 {
   const uint32_t notmask   = ~vfatMask & 0xffffff;
   const uint32_t goodVFATs = vfat3::vfatSyncCheck{}(ohN);
@@ -684,15 +684,15 @@ std::vector<uint32_t> calibration::checkSbitMappingWithCalPulse::operator()(cons
   return outData;
 }
 
-std::map<std::string, std::vector<uint32_t>> calibration::checkSbitRateWithCalPulse::operator()(const uint16_t &ohN,
-                                                                                                const uint32_t &vfatN,
-                                                                                                const uint32_t &vfatMask,
-                                                                                                const bool &useCalPulse,
-                                                                                                const bool &currentPulse,
-                                                                                                const uint32_t &calScaleFactor,
-                                                                                                const uint32_t &waitTime,
-                                                                                                const uint32_t &pulseRate,
-                                                                                                const uint32_t &pulseDelay) const
+std::map<std::string, std::vector<uint32_t>> calibration::checkSbitRateWithCalPulse::operator()(const uint16_t& ohN,
+                                                                                                const uint32_t& vfatN,
+                                                                                                const uint32_t& vfatMask,
+                                                                                                const bool& useCalPulse,
+                                                                                                const bool& currentPulse,
+                                                                                                const uint32_t& calScaleFactor,
+                                                                                                const uint32_t& waitTime,
+                                                                                                const uint32_t& pulseRate,
+                                                                                                const uint32_t& pulseDelay) const
 {
   const uint32_t notmask   = ~vfatMask & 0xffffff;
   const uint32_t goodVFATs = vfat3::vfatSyncCheck{}(ohN);
@@ -866,11 +866,11 @@ std::map<std::string, std::vector<uint32_t>> calibration::checkSbitRateWithCalPu
   return outData;
 }
 
-std::vector<uint32_t> calibration::dacScan::operator()(const uint16_t &ohN,
-                                                       const uint16_t &dacSelect,
-                                                       const uint16_t &dacStep,
-                                                       const uint32_t &vfatMask,
-                                                       const bool &useExtRefADC) const
+std::vector<uint32_t> calibration::dacScan::operator()(const uint16_t& ohN,
+                                                       const uint16_t& dacSelect,
+                                                       const uint16_t& dacStep,
+                                                       const uint32_t& vfatMask,
+                                                       const bool& useExtRefADC) const
 {
   if (calibration::vfat3DACAndSize.count(dacSelect) == 0) {
     std::string errmsg = "Monitoring Select value " + std::to_string(dacSelect) + " not found, possible values are:\n";
@@ -987,11 +987,11 @@ std::vector<uint32_t> calibration::dacScan::operator()(const uint16_t &ohN,
   return dacScanData;
 }
 
-std::map<uint32_t, std::vector<uint32_t>> calibration::dacScanMultiLink::operator()(const uint16_t &ohMask,
-                                                                                    const uint16_t &dacSelect,
-                                                                                    const uint16_t &dacStep,
-                                                                                    const uint32_t &mask,
-                                                                                    const bool &useExtRefADC) const
+std::map<uint32_t, std::vector<uint32_t>> calibration::dacScanMultiLink::operator()(const uint16_t& ohMask,
+                                                                                    const uint16_t& dacSelect,
+                                                                                    const uint16_t& dacStep,
+                                                                                    const uint32_t& mask,
+                                                                                    const bool& useExtRefADC) const
 {
   const uint32_t supOH = utils::readReg("GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   if (ohMask > (0x1<<supOH))

--- a/src/daq_monitor.cpp
+++ b/src/daq_monitor.cpp
@@ -36,7 +36,7 @@ std::map<std::string, uint32_t> daqmon::getmonTTCmain::operator()() const
   return ttcMon;
 }
 
-std::map<std::string, uint32_t> daqmon::getmonTRIGGERmain::operator()(const uint16_t &ohMask) const
+std::map<std::string, uint32_t> daqmon::getmonTRIGGERmain::operator()(const uint16_t& ohMask) const
 {
   const uint32_t supOH = utils::readReg("GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   if (ohMask > (0x1<<supOH))
@@ -59,7 +59,7 @@ std::map<std::string, uint32_t> daqmon::getmonTRIGGERmain::operator()(const uint
   return trigMon;
 }
 
-std::map<std::string, uint32_t> daqmon::getmonTRIGGEROHmain::operator()(const uint16_t &ohMask) const
+std::map<std::string, uint32_t> daqmon::getmonTRIGGEROHmain::operator()(const uint16_t& ohMask) const
 {
   const uint32_t supOH = utils::readReg("GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   if (ohMask > (0x1<<supOH))
@@ -115,7 +115,7 @@ std::map<std::string, uint32_t> daqmon::getmonDAQmain::operator()() const
   return daqMon;
 }
 
-std::map<std::string, uint32_t> daqmon::getmonDAQOHmain::operator()(const uint16_t &ohMask) const
+std::map<std::string, uint32_t> daqmon::getmonDAQOHmain::operator()(const uint16_t& ohMask) const
 {
   const uint32_t supOH = utils::readReg("GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   if (ohMask > (0x1<<supOH))
@@ -148,7 +148,7 @@ std::map<std::string, uint32_t> daqmon::getmonDAQOHmain::operator()(const uint16
   return daqMon;
 }
 
-std::map<std::string, uint32_t> daqmon::getmonGBTLink::operator()(const bool &doReset) const
+std::map<std::string, uint32_t> daqmon::getmonGBTLink::operator()(const bool& doReset) const
 {
   if (doReset) {
     utils::writeReg("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
@@ -180,7 +180,7 @@ std::map<std::string, uint32_t> daqmon::getmonGBTLink::operator()(const bool &do
   return gbtMon;
 }
 
-std::map<std::string, uint32_t> daqmon::getmonOHmain::operator()(const uint16_t &ohMask) const
+std::map<std::string, uint32_t> daqmon::getmonOHmain::operator()(const uint16_t& ohMask) const
 {
   const uint32_t supOH = utils::readReg("GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   if (ohMask > (0x1<<supOH))
@@ -232,7 +232,7 @@ std::map<std::string, uint32_t> daqmon::getmonOHmain::operator()(const uint16_t 
   return ohMon;
 }
 
-std::map<std::string, uint32_t> daqmon::getmonOHSCAmain::operator()(const uint16_t &ohMask) const
+std::map<std::string, uint32_t> daqmon::getmonOHSCAmain::operator()(const uint16_t& ohMask) const
 {
   uint32_t initSCAMonOffMask = 0xffffffff;
   if (!utils::regExists("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF").empty()) {
@@ -296,7 +296,7 @@ std::map<std::string, uint32_t> daqmon::getmonOHSCAmain::operator()(const uint16
   return scaMon;
 }
 
-std::map<std::string, uint32_t> daqmon::getmonOHSysmon::operator()(const uint16_t &ohMask, const bool &doReset) const
+std::map<std::string, uint32_t> daqmon::getmonOHSysmon::operator()(const uint16_t& ohMask, const bool& doReset) const
 {
   const uint32_t supOH = utils::readReg("GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   if (ohMask > (0x1<<supOH))
@@ -391,7 +391,7 @@ std::map<std::string, uint32_t> daqmon::getmonSCA::operator()() const
   return scaMon;
 }
 
-std::map<std::string, uint32_t> daqmon::getmonVFATLink::operator()(const bool &doReset) const
+std::map<std::string, uint32_t> daqmon::getmonVFATLink::operator()(const bool& doReset) const
 {
   if (doReset) {
     utils::writeReg("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
@@ -427,7 +427,7 @@ std::map<std::string, uint32_t> daqmon::getmonVFATLink::operator()(const bool &d
   return vfatMon;
 }
 
-std::map<std::string, uint32_t> daqmon::getmonCTP7dump::operator()(const std::string &fname) const
+std::map<std::string, uint32_t> daqmon::getmonCTP7dump::operator()(const std::string& fname) const
 {
   LOG4CPLUS_INFO(logger, "Using registers found in: " << fname);
   std::ifstream ifs(fname);

--- a/src/expert_tools.cpp
+++ b/src/expert_tools.cpp
@@ -9,12 +9,12 @@
 
 #include "xhal/common/rpc/register.h"
 
-std::uint32_t expert::readRawAddress::operator()(const std::uint32_t &address) const
+uint32_t expert::readRawAddress::operator()(const uint32_t& address) const
 {
     return utils::readRawAddress(address);
 }
 
-void expert::writeRawAddress::operator()(const std::uint32_t &address, const std::uint32_t &value) const
+void expert::writeRawAddress::operator()(const uint32_t& address, const uint32_t& value) const
 {
     return utils::writeRawAddress(address, value);
 }

--- a/src/gbt.cpp
+++ b/src/gbt.cpp
@@ -20,12 +20,12 @@ namespace gbt {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 }
 
-std::map<uint32_t, std::vector<uint32_t>> gbt::scanGBTPhases::operator()(const uint32_t &ohN,
-                                                                         const uint32_t &nResets,
-                                                                         const uint8_t &phaseMin,
-                                                                         const uint8_t &phaseMax,
-                                                                         const uint8_t &phaseStep,
-                                                                         const uint32_t &nVerificationReads) const
+std::map<uint32_t, std::vector<uint32_t>> gbt::scanGBTPhases::operator()(const uint32_t& ohN,
+                                                                         const uint32_t& nResets,
+                                                                         const uint8_t& phaseMin,
+                                                                         const uint8_t& phaseMax,
+                                                                         const uint8_t& phaseStep,
+                                                                         const uint32_t& nVerificationReads) const
 {
     LOG4CPLUS_INFO(logger, "Scanning the phases for OH" << ohN);
 
@@ -93,7 +93,7 @@ std::map<uint32_t, std::vector<uint32_t>> gbt::scanGBTPhases::operator()(const u
 
 }
 
-void gbt::writeGBTConfig::operator()(const uint32_t &ohN, const uint32_t &gbtN, const config_t &config) const
+void gbt::writeGBTConfig::operator()(const uint32_t& ohN, const uint32_t& gbtN, const config_t& config) const
 {
     LOG4CPLUS_INFO(logger, "Writing the configuration of OH #" << ohN << " - GBTX #" << gbtN << ".");
 
@@ -115,7 +115,7 @@ void gbt::writeGBTConfig::operator()(const uint32_t &ohN, const uint32_t &gbtN, 
     }
 }
 
-void gbt::writeGBTPhase::operator()(const uint32_t &ohN, const uint32_t &vfatN, const uint8_t &phase) const
+void gbt::writeGBTPhase::operator()(const uint32_t& ohN, const uint32_t& vfatN, const uint8_t& phase) const
 {
     LOG4CPLUS_INFO(logger, "Writing phase " << phase << " to VFAT #" << vfatN << " of OH #" << ohN << ".");
 

--- a/src/optohybrid.cpp
+++ b/src/optohybrid.cpp
@@ -15,7 +15,7 @@ namespace oh {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 }
 
-void oh::broadcastWrite::operator()(const uint32_t &ohN, const std::string &regName, const uint32_t &value, const uint32_t &mask) const
+void oh::broadcastWrite::operator()(const uint32_t& ohN, const std::string& regName, const uint32_t& value, const uint32_t& mask) const
 {
   std::string t_regName;
   for (size_t vfatN = 0; vfatN < oh::VFATS_PER_OH; ++vfatN) {
@@ -27,7 +27,7 @@ void oh::broadcastWrite::operator()(const uint32_t &ohN, const std::string &regN
   }
 }
 
-std::vector<uint32_t> oh::broadcastRead::operator()(const uint32_t &ohN, const std::string &regName, const uint32_t &mask) const
+std::vector<uint32_t> oh::broadcastRead::operator()(const uint32_t& ohN, const std::string& regName, const uint32_t& mask) const
 {
   std::string regBase = "GEM_AMC.OH.OH" + std::to_string(ohN) + ".GEB.VFAT";
 
@@ -50,24 +50,24 @@ std::vector<uint32_t> oh::broadcastRead::operator()(const uint32_t &ohN, const s
   return data;
 }
 
-void oh::biasAllVFATs::operator()(const uint32_t &ohN, const uint32_t &mask) const
+void oh::biasAllVFATs::operator()(const uint32_t& ohN, const uint32_t& mask) const
 {
   for (auto const& it : vfat_parameters) {
     broadcastWrite{}(ohN, it.first, it.second, mask);
   }
 }
 
-void oh::setAllVFATsToRunMode::operator()(const uint32_t &ohN, const uint32_t &mask) const
+void oh::setAllVFATsToRunMode::operator()(const uint32_t& ohN, const uint32_t& mask) const
 {
   broadcastWrite{}(ohN, "CFG_RUN", 0x1, mask);
 }
 
-void oh::setAllVFATsToSleepMode::operator()(const uint32_t &ohN, const uint32_t &mask) const
+void oh::setAllVFATsToSleepMode::operator()(const uint32_t& ohN, const uint32_t& mask) const
 {
   broadcastWrite{}(ohN, "CFG_RUN", 0x0, mask);
 }
 
-void oh::stopCalPulse2AllChannels::operator()(const uint32_t &ohN, const uint32_t &mask, const uint32_t &chMin, const uint32_t &chMax) const
+void oh::stopCalPulse2AllChannels::operator()(const uint32_t& ohN, const uint32_t& mask, const uint32_t& chMin, const uint32_t& chMax) const
 {
   for (size_t vfatN = 0; vfatN < oh::VFATS_PER_OH; ++vfatN) {
     if ((mask >> vfatN) & 0x1)
@@ -79,7 +79,7 @@ void oh::stopCalPulse2AllChannels::operator()(const uint32_t &ohN, const uint32_
   }
 }
 
-std::map<std::string, std::vector<uint32_t>> oh::statusOH::operator()(const uint32_t &ohMask) const
+std::map<std::string, std::vector<uint32_t>> oh::statusOH::operator()(const uint32_t& ohMask) const
 {
   LOG4CPLUS_INFO(logger, "Reeading OH status registers");
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -17,7 +17,7 @@
 
 memsvc_handle_t memsvc;
 
-std::vector<std::string> utils::split(const std::string &s, char delim)
+std::vector<std::string> utils::split(const std::string& s, char delim)
 {
   std::vector<std::string> elems;
   split(s, delim, std::back_inserter(elems));
@@ -65,7 +65,7 @@ void utils::initLogging()
     }
 }
 
-void utils::update_address_table::operator()(const std::string &at_xml) const
+void utils::update_address_table::operator()(const std::string& at_xml) const
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
   LOG4CPLUS_INFO(logger, "START UPDATE ADDRESS TABLE");
@@ -140,7 +140,7 @@ uint32_t utils::getNumNonzeroBits(uint32_t value)
   return numNonzeroBits;
 }
 
-std::vector<std::string> utils::regExists(const std::string &regName)
+std::vector<std::string> utils::regExists(const std::string& regName)
 {
   auto env = lmdb::env::create();
   env.set_mapsize(utils::LMDB_SIZE);
@@ -161,7 +161,7 @@ std::vector<std::string> utils::regExists(const std::string &regName)
   }
 }
 
-uint32_t utils::getAddress(const std::string &regName)
+uint32_t utils::getAddress(const std::string& regName)
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 
@@ -178,7 +178,7 @@ uint32_t utils::getAddress(const std::string &regName)
   return raddr;
 }
 
-uint32_t utils::getMask(const std::string &regName)
+uint32_t utils::getMask(const std::string& regName)
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 
@@ -237,13 +237,13 @@ uint32_t utils::readRawAddress(const uint32_t address)
   return data[0];
 }
 
-void utils::writeRawReg(const std::string &regName, const uint32_t value)
+void utils::writeRawReg(const std::string& regName, const uint32_t value)
 {
   const auto addr = utils::getAddress(regName);
   return utils::writeRawAddress(addr, value);
 }
 
-uint32_t utils::readRawReg(const std::string &regName)
+uint32_t utils::readRawReg(const std::string& regName)
 {
   const auto addr = utils::getAddress(regName);
   return utils::readRawAddress(addr);
@@ -263,7 +263,7 @@ uint32_t utils::applyMask(const uint32_t data, uint32_t mask)
   return result;
 }
 
-uint32_t utils::readReg(const std::string &regName)
+uint32_t utils::readReg(const std::string& regName)
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 
@@ -293,7 +293,7 @@ uint32_t utils::readReg(const std::string &regName)
   }
 }
 
-uint32_t utils::readBlock(const std::string &regName, uint32_t *result, const uint32_t &size, const uint32_t &offset)
+uint32_t utils::readBlock(const std::string& regName, uint32_t *result, const uint32_t& size, const uint32_t& offset)
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 
@@ -351,13 +351,13 @@ uint32_t utils::readBlock(const std::string &regName, uint32_t *result, const ui
   return 0;
 }
 
-uint32_t utils::readBlock(const uint32_t &regAddr, uint32_t *result, const uint32_t &size, const uint32_t &offset)
+uint32_t utils::readBlock(const uint32_t& regAddr, uint32_t *result, const uint32_t& size, const uint32_t& offset)
 {
   // Might not make sense, as it would be impossible to do any validation at this level
   return 0;
 }
 
-utils::SlowCtrlErrCntVFAT utils::repeatedRegRead(const std::string &regName, const bool breakOnFailure, const uint32_t nReads)
+utils::SlowCtrlErrCntVFAT utils::repeatedRegRead(const std::string& regName, const bool breakOnFailure, const uint32_t nReads)
 {
     // Issue a link reset to reset counters under GEM_AMC.SLOW_CONTROL.VFAT3
     writeReg("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1);
@@ -389,7 +389,7 @@ utils::SlowCtrlErrCntVFAT utils::repeatedRegRead(const std::string &regName, con
     return vfatErrs;
 }
 
-void utils::writeReg(const std::string &regName, const uint32_t value)
+void utils::writeReg(const std::string& regName, const uint32_t value)
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 
@@ -423,7 +423,7 @@ void utils::writeReg(const std::string &regName, const uint32_t value)
   }
 }
 
-void utils::writeBlock(const std::string &regName, const uint32_t *values, const uint32_t &size, const uint32_t &offset)
+void utils::writeBlock(const std::string& regName, const uint32_t* values, const uint32_t& size, const uint32_t& offset)
 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 
@@ -477,7 +477,7 @@ void utils::writeBlock(const std::string &regName, const uint32_t *values, const
   }
 }
 
-void utils::writeBlock(const uint32_t &regAddr, const uint32_t *values, const uint32_t &size, const uint32_t &offset)
+void utils::writeBlock(const uint32_t& regAddr, const uint32_t* values, const uint32_t& size, const uint32_t& offset)
 {
   // This function doesn't make sense with an offset, why would we specify an offset when accessing by register address?
   // Maybe just to do validation checks on the size?
@@ -488,7 +488,7 @@ void utils::writeBlock(const uint32_t &regAddr, const uint32_t *values, const ui
  * Common methods implementation. These methods are exported as remote calls.
  */
 
-utils::RegInfo utils::readRegFromDB::operator()(const std::string &regName) const
+utils::RegInfo utils::readRegFromDB::operator()(const std::string& regName) const
 {
   auto env = lmdb::env::create();
   env.set_mapsize(utils::LMDB_SIZE);
@@ -537,12 +537,12 @@ utils::RegInfo utils::readRegFromDB::operator()(const std::string &regName) cons
   }
 }
 
-uint32_t utils::readRemoteReg::operator()(const std::string &regName) const
+uint32_t utils::readRemoteReg::operator()(const std::string& regName) const
 {
   return readReg(regName);
 }
 
-void utils::writeRemoteReg::operator()(const std::string &regName, const uint32_t value) const
+void utils::writeRemoteReg::operator()(const std::string& regName, const uint32_t& value) const
 {
   return writeReg(regName, value);
 }

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -308,7 +308,7 @@ std::map<uint32_t,std::vector<uint32_t>> vfat3::readVFAT3ADCMultiLink::operator(
   return adcData;
 }
 
-void vfat3::setChannelRegistersVFAT3Simple::operator()(const uint16_t& ohN, const std::vector<uint32_t> &chanRegData, const uint32_t& vfatMask) const
+void vfat3::setChannelRegistersVFAT3Simple::operator()(const uint16_t& ohN, const std::vector<uint32_t>& chanRegData, const uint32_t& vfatMask) const
 {
   const uint32_t notmask = ~vfatMask & 0xFFFFFF;
 

--- a/src/vfat3.cpp
+++ b/src/vfat3.cpp
@@ -26,7 +26,7 @@ namespace vfat3 {
   auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 }
 
-uint16_t vfat3::decodeChipID(const uint32_t &encChipID)
+uint16_t vfat3::decodeChipID(const uint32_t& encChipID)
 {
   // can the generator be static to limit creation/destruction of resources?
   static reedmuller rm = 0;
@@ -96,7 +96,7 @@ uint16_t vfat3::decodeChipID(const uint32_t &encChipID)
   }
 }
 
-uint32_t vfat3::vfatSyncCheck::operator()(const uint16_t &ohN, const uint32_t &mask) const
+uint32_t vfat3::vfatSyncCheck::operator()(const uint16_t& ohN, const uint32_t& mask) const
 {
   uint32_t goodVFATs = 0;
   for (size_t vfatN = 0; vfatN < oh::VFATS_PER_OH; ++vfatN) {
@@ -122,7 +122,7 @@ uint32_t vfat3::vfatSyncCheck::operator()(const uint16_t &ohN, const uint32_t &m
   return goodVFATs;
 }
 
-void vfat3::configureVFAT3DACMonitor::operator()(const uint16_t &ohN, const uint32_t &mask, const uint32_t &dacSelect) const
+void vfat3::configureVFAT3DACMonitor::operator()(const uint16_t& ohN, const uint32_t& mask, const uint32_t& dacSelect) const
 {
   LOG4CPLUS_INFO(logger, "Programming VFAT3 ADC Monitoring for DAC " << dacSelect);
 
@@ -159,7 +159,7 @@ void vfat3::configureVFAT3DACMonitor::operator()(const uint16_t &ohN, const uint
   return;
 }
 
-void vfat3::configureVFAT3DACMonitorMultiLink::operator()(const uint16_t &ohMask, const std::array<uint32_t, amc::OH_PER_AMC> & vfatMasks, const uint32_t &dacSelect) const
+void vfat3::configureVFAT3DACMonitorMultiLink::operator()(const uint16_t& ohMask, const std::array<uint32_t, amc::OH_PER_AMC>& vfatMasks, const uint32_t& dacSelect) const
 {
   const uint32_t supOH = utils::readReg("GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   if (ohMask > (0x1<<supOH))
@@ -180,7 +180,7 @@ void vfat3::configureVFAT3DACMonitorMultiLink::operator()(const uint16_t &ohMask
   return;
 }
 
-void vfat3::configureVFAT3s::operator()(const uint16_t &ohN, const uint32_t &vfatMask) const
+void vfat3::configureVFAT3s::operator()(const uint16_t& ohN, const uint32_t& vfatMask) const
 {
   const uint32_t notmask   = ~vfatMask & 0xFFFFFF;
   const uint32_t goodVFATs = vfatSyncCheck{}(ohN);
@@ -227,7 +227,7 @@ void vfat3::configureVFAT3s::operator()(const uint16_t &ohN, const uint32_t &vfa
   }
 }
 
-std::vector<uint32_t> vfat3::getChannelRegistersVFAT3::operator()(const uint16_t &ohN, const uint32_t &vfatMask) const
+std::vector<uint32_t> vfat3::getChannelRegistersVFAT3::operator()(const uint16_t& ohN, const uint32_t& vfatMask) const
 {
   LOG4CPLUS_INFO(logger, "Read channel register settings");
 
@@ -273,7 +273,7 @@ std::vector<uint32_t> vfat3::getChannelRegistersVFAT3::operator()(const uint16_t
   return chanRegData;
 }
 
-std::vector<uint32_t> vfat3::readVFAT3ADC::operator()(const uint16_t &ohN, const bool &useExtRefADC, const uint32_t &vfatMask) const
+std::vector<uint32_t> vfat3::readVFAT3ADC::operator()(const uint16_t& ohN, const bool& useExtRefADC, const uint32_t& vfatMask) const
 {
   LOG4CPLUS_INFO(logger, "Reading VFAT3 ADCs for OH" << ohN << " using VFAT mask 0x" << std::hex << std::setw(8) << std::setfill('0') << vfatMask << std::dec);
   // std::vector<uint32_t> data(oh::VFATS_PER_OH);
@@ -288,7 +288,7 @@ std::vector<uint32_t> vfat3::readVFAT3ADC::operator()(const uint16_t &ohN, const
   }
 }
 
-std::map<uint32_t,std::vector<uint32_t>> vfat3::readVFAT3ADCMultiLink::operator()(const uint16_t &ohMask, const bool &useExtRefADC) const
+std::map<uint32_t,std::vector<uint32_t>> vfat3::readVFAT3ADCMultiLink::operator()(const uint16_t& ohMask, const bool& useExtRefADC) const
 {
   const uint32_t supOH = utils::readReg("GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH");
   if (ohMask > (0x1<<supOH))
@@ -308,7 +308,7 @@ std::map<uint32_t,std::vector<uint32_t>> vfat3::readVFAT3ADCMultiLink::operator(
   return adcData;
 }
 
-void vfat3::setChannelRegistersVFAT3Simple::operator()(const uint16_t &ohN, const std::vector<uint32_t> &chanRegData, const uint32_t &vfatMask) const
+void vfat3::setChannelRegistersVFAT3Simple::operator()(const uint16_t& ohN, const std::vector<uint32_t> &chanRegData, const uint32_t& vfatMask) const
 {
   const uint32_t notmask = ~vfatMask & 0xFFFFFF;
 
@@ -352,14 +352,14 @@ void vfat3::setChannelRegistersVFAT3Simple::operator()(const uint16_t &ohN, cons
   return;
 }
 
-void vfat3::setChannelRegistersVFAT3::operator()(const uint16_t &ohN,
-                                                 const std::vector<uint32_t> &calEnable,
-                                                 const std::vector<uint32_t> &masks,
-                                                 const std::vector<uint32_t> &trimARM,
-                                                 const std::vector<uint32_t> &trimARMPol,
-                                                 const std::vector<uint32_t> &trimZCC,
-                                                 const std::vector<uint32_t> &trimZCCPol,
-                                                 const uint32_t &vfatMask) const
+void vfat3::setChannelRegistersVFAT3::operator()(const uint16_t& ohN,
+                                                 const std::vector<uint32_t>& calEnable,
+                                                 const std::vector<uint32_t>& masks,
+                                                 const std::vector<uint32_t>& trimARM,
+                                                 const std::vector<uint32_t>& trimARMPol,
+                                                 const std::vector<uint32_t>& trimZCC,
+                                                 const std::vector<uint32_t>& trimZCCPol,
+                                                 const uint32_t& vfatMask) const
 {
   const uint32_t notmask = ~vfatMask & 0xFFFFFF;
 
@@ -430,7 +430,7 @@ void vfat3::setChannelRegistersVFAT3::operator()(const uint16_t &ohN,
   return;
 }
 
-std::map<std::string, std::vector<uint32_t>> vfat3::statusVFAT3s::operator()(const uint16_t &ohN) const
+std::map<std::string, std::vector<uint32_t>> vfat3::statusVFAT3s::operator()(const uint16_t& ohN) const
 {
   std::string regs [] = {
     "CFG_PULSE_STRETCH",
@@ -478,7 +478,7 @@ std::map<std::string, std::vector<uint32_t>> vfat3::statusVFAT3s::operator()(con
   return values;
 }
 
-std::vector<uint32_t> vfat3::getVFAT3ChipIDs::operator()(const uint16_t &ohN, const uint32_t &vfatMask, const bool &rawID) const
+std::vector<uint32_t> vfat3::getVFAT3ChipIDs::operator()(const uint16_t& ohN, const uint32_t& vfatMask, const bool& rawID) const
 {
   const uint32_t notmask   = ~vfatMask & 0xFFFFFF;
   const uint32_t goodVFATs = vfatSyncCheck{}(ohN);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- all arguments for exported methods are passed as const T&
- style convention: use const T& t instead of const T &t. Reason: eases the regex parsing
- const T& t are used instead of T const& t in order to avoid confusion

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Adresses #173 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The code compiles, functionality didn't change
### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
