### PR TITLE
[bugfix] broken ge21 legacy build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,4 +193,6 @@ clean: cleanrpm
 cleandoc:
 	@echo "TO DO"
 
+BUILD_VERSION:=$(BUILD_VERSION).$(GEM_VARIANT)
+
 -include $(Dependencies)

--- a/include/hw_constants.h
+++ b/include/hw_constants.h
@@ -27,6 +27,7 @@ namespace amc {
      */
     namespace ge21 {
         constexpr uint32_t OH_PER_AMC = 12;    ///< The number of OptoHybrids per AMC.
+        constexpr uint32_t FULL_OH_MASK = 0xfff; ///< Reading of all OptoHybrids are enabled.
     }
 
     using namespace GEM_VARIANT;


### PR DESCRIPTION
## Description

Fixes #180 
Also adds `.$(GEM_VARIANT)` to the RPM file name (release not name attribute)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
